### PR TITLE
fix: rename smoke test functions to exclude from pytest (close #153)

### DIFF
--- a/docs/reports/153/implementation-report.md
+++ b/docs/reports/153/implementation-report.md
@@ -1,0 +1,48 @@
+# Implementation Report: Issue #153 - Fix Smoke Test Fixture Errors
+
+**Issue:** #153
+**Date:** 2026-01-05
+**Implementer:** Claude Opus 4.5
+
+## Summary
+
+Fixed pytest fixture errors in `tools/smoke_test.py` by renaming `test_*` functions to `verify_*`, preventing pytest from collecting them as unit tests.
+
+## Problem
+
+`tools/smoke_test.py` contained 5 functions starting with `test_` that pytest collected as unit tests. These functions expected a `url` parameter which pytest interpreted as a missing fixture, causing 5 errors per test run.
+
+## Solution
+
+Renamed all 5 functions from `test_*` to `verify_*`:
+
+| Before | After |
+|--------|-------|
+| `test_valid_input()` | `verify_valid_input()` |
+| `test_blocked_input()` | `verify_blocked_input()` |
+| `test_empty_input()` | `verify_empty_input()` |
+| `test_prompt_injection()` | `verify_prompt_injection()` |
+| `test_tone_neutrality()` | `verify_tone_neutrality()` |
+
+Also updated:
+- Function docstrings (Test → Verify)
+- Function calls in `main()` to use new names
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `tools/smoke_test.py` | Renamed 5 function definitions, updated 5 calls in main() |
+
+## Rationale
+
+Per LLD `docs/1153-smoke-test-fixture-fix.md`:
+- These are **smoke tests** for manual/post-deployment verification, NOT unit tests
+- They test live deployed endpoints, not mocked fixtures
+- Renaming to `verify_*` clearly communicates intent and excludes from pytest
+
+## Alternatives Rejected
+
+1. **Create URL fixture** - Defeats purpose of smoke tests (they hit live endpoints)
+2. **pytest.mark.skip** - Confusing intent, still collected
+3. **Delete file** - Loses smoke test capability

--- a/docs/reports/153/test-report.md
+++ b/docs/reports/153/test-report.md
@@ -1,0 +1,55 @@
+# Test Report: Issue #153 - Fix Smoke Test Fixture Errors
+
+**Issue:** #153
+**Date:** 2026-01-05
+**Tester:** Claude Opus 4.5
+
+## Test Results
+
+| ID | Scenario | Expected | Actual | Status |
+|----|----------|----------|--------|--------|
+| 010 | pytest does not collect smoke_test.py | No `test_*` functions found | No output from grep | PASS |
+| 020 | smoke_test.py imports without error | Module loads | `Import OK` | PASS |
+| 030 | smoke_test.py --help works | Help text displayed | Help text displayed | PASS |
+
+## Verification Commands
+
+### Test 010: pytest Collection
+```bash
+$ poetry run pytest --collect-only 2>&1 | grep -E "(smoke_test|fixture 'url' not found)"
+# (no output - not collected)
+```
+**Result:** PASS - smoke_test.py no longer collected by pytest
+
+### Test 020: Module Import
+```bash
+$ poetry run python -c "import tools.smoke_test; print('Import OK')"
+Import OK
+```
+**Result:** PASS - No syntax errors, module loads correctly
+
+### Test 030: Manual Invocation
+```bash
+$ poetry run python tools/smoke_test.py --help
+usage: smoke_test.py [-h] [--url URL] [--quick]
+
+Smoke test for Aletheia Lambda
+
+options:
+  -h, --help  show this help message and exit
+  --url URL   Override function URL
+  --quick     Run only basic tests (skip LLM-dependent tests)
+```
+**Result:** PASS - Script still works as CLI tool
+
+## Coverage Impact
+
+No impact on unit test coverage - smoke tests were never part of the unit test suite (they test live endpoints).
+
+## Definition of Done Checklist
+
+- [x] All `test_*` functions renamed to `verify_*` in `tools/smoke_test.py`
+- [x] CLI entry point (`__main__`) updated to call `verify_*` functions
+- [x] No more "fixture 'url' not found" errors
+- [x] `pytest --collect-only` does NOT collect `smoke_test.py`
+- [x] Manual invocation `python tools/smoke_test.py --help` works

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -99,8 +99,8 @@ def send_request(url: str, payload: dict, timeout: int = 30) -> tuple[int, dict,
         sys.exit(1)
 
 
-def test_valid_input(url: str) -> bool:
-    """Test 1: Valid input should return 200 with structured response (Issue #124)."""
+def verify_valid_input(url: str) -> bool:
+    """Verify 1: Valid input should return 200 with structured response (Issue #124)."""
     print("\n[TEST 1] Valid Input - Structured Response (expect 200 OK)")
     print(f"  Payload: {json.dumps(VALID_PAYLOAD)}")
 
@@ -138,8 +138,8 @@ def test_valid_input(url: str) -> bool:
         return False
 
 
-def test_blocked_input(url: str) -> bool:
-    """Test 2: Blocked input should return 403."""
+def verify_blocked_input(url: str) -> bool:
+    """Verify 2: Blocked input should return 403."""
     print("\n[TEST 2] Blocked Input (expect 403 Forbidden)")
     blocked_payload = get_blocked_payload()
     # Redact the actual term in output for security
@@ -159,8 +159,8 @@ def test_blocked_input(url: str) -> bool:
         return False
 
 
-def test_empty_input(url: str) -> bool:
-    """Test 3: Empty input should return 400."""
+def verify_empty_input(url: str) -> bool:
+    """Verify 3: Empty input should return 400."""
     print("\n[TEST 3] Empty Input (expect 400 Bad Request)")
     payload = {"text": ""}
     print(f"  Payload: {json.dumps(payload)}")
@@ -179,8 +179,8 @@ def test_empty_input(url: str) -> bool:
         return False
 
 
-def test_prompt_injection(url: str) -> bool:
-    """Test 4: Prompt injection attempt should be handled safely (Issue #124).
+def verify_prompt_injection(url: str) -> bool:
+    """Verify 4: Prompt injection attempt should be handled safely (Issue #124).
 
     Safe handling can be:
     - 200 with structured response (processed but injection not executed)
@@ -221,8 +221,8 @@ def test_prompt_injection(url: str) -> bool:
         return False
 
 
-def test_tone_neutrality(url: str) -> bool:
-    """Test 5: Response should have neutral academic tone (Issue #124)."""
+def verify_tone_neutrality(url: str) -> bool:
+    """Verify 5: Response should have neutral academic tone (Issue #124)."""
     print("\n[TEST 5] Tone Neutrality Check")
     # Use a term that might trigger moralizing in a non-neutral model
     payload = {"text": "lunatic", "url": "https://test.example.com"}
@@ -287,14 +287,14 @@ def main():
     results = []
 
     # Core tests (always run)
-    results.append(("Valid Input + Structure", test_valid_input(url)))
-    results.append(("Blocked Input", test_blocked_input(url)))
-    results.append(("Empty Input", test_empty_input(url)))
+    results.append(("Valid Input + Structure", verify_valid_input(url)))
+    results.append(("Blocked Input", verify_blocked_input(url)))
+    results.append(("Empty Input", verify_empty_input(url)))
 
     # Issue #124 specific tests
     if not args.quick:
-        results.append(("Prompt Injection", test_prompt_injection(url)))
-        results.append(("Tone Neutrality", test_tone_neutrality(url)))
+        results.append(("Prompt Injection", verify_prompt_injection(url)))
+        results.append(("Tone Neutrality", verify_tone_neutrality(url)))
     else:
         print("\n[SKIPPED] Prompt Injection (--quick mode)")
         print("[SKIPPED] Tone Neutrality (--quick mode)")


### PR DESCRIPTION
## Summary
- Renamed 5 `test_*` functions to `verify_*` in `tools/smoke_test.py`
- Prevents pytest from collecting them as unit tests (they're manual smoke tests)
- Eliminates 5 "fixture 'url' not found" errors per test run

## Test plan
- [x] pytest no longer collects smoke_test.py
- [x] Module imports without syntax errors
- [x] Manual invocation (`--help`) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)