### PR TITLE
feat: implement LinkedIn OAuth authentication (close #116)

### DIFF
--- a/extensions/chrome/auth.js
+++ b/extensions/chrome/auth.js
@@ -1,0 +1,344 @@
+// extensions/chrome/auth.js
+// LinkedIn OAuth Authentication Module
+// See: docs/1116-linkedin-oauth.md
+
+// =============================================================================
+// CONFIGURATION
+// =============================================================================
+
+const AUTH_CONFIG = {
+    // Set to true for automated tests (returns deterministic mock tokens)
+    MOCK_MODE: false,
+
+    // LinkedIn OAuth endpoints
+    AUTH_URL: 'https://www.linkedin.com/oauth/v2/authorization',
+
+    // Lambda Auth endpoint (UPDATE after provisioning)
+    // TODO: Replace with CloudFront URL after WAF setup
+    LAMBDA_AUTH_URL: 'https://YOUR_AUTH_LAMBDA_URL.lambda-url.us-east-1.on.aws',
+
+    // LinkedIn OAuth scopes (minimal - r_liteprofile only)
+    SCOPES: 'openid profile',
+
+    // LinkedIn Client ID (public, safe to include in extension)
+    // TODO: Replace with actual client ID from LinkedIn Developer Portal
+    CLIENT_ID: 'YOUR_LINKEDIN_CLIENT_ID',
+};
+
+// =============================================================================
+// CSRF STATE MANAGEMENT
+// =============================================================================
+
+/**
+ * Generate a cryptographically secure random state string.
+ * Used for CSRF protection in OAuth flow.
+ * @returns {string} 64-character hex string
+ */
+function generateState() {
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    return Array.from(array, b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// =============================================================================
+// TOKEN STORAGE (Hierarchy per LLD Section 6.3)
+// =============================================================================
+
+/**
+ * Store tokens with proper security hierarchy.
+ * - Access token: session storage (cleared on browser close)
+ * - Refresh token + user info: local storage (persists)
+ *
+ * @param {string} accessToken
+ * @param {string} refreshToken
+ * @param {number} expiresIn - Seconds until access token expires
+ * @param {object} user - User info {id, name}
+ */
+async function storeTokens(accessToken, refreshToken, expiresIn, user) {
+    // Access token - session only (memory, cleared on browser close)
+    await chrome.storage.session.set({
+        accessToken,
+        expiresAt: Date.now() + (expiresIn * 1000)
+    });
+
+    // Refresh token + profile - local persistence
+    await chrome.storage.local.set({
+        refreshToken,
+        userId: user.id,
+        displayName: user.name
+    });
+
+    console.log('[Aletheia Auth] Tokens stored successfully');
+}
+
+/**
+ * Clear all auth data (logout).
+ */
+async function clearTokens() {
+    await chrome.storage.session.remove(['accessToken', 'expiresAt']);
+    await chrome.storage.local.remove(['refreshToken', 'userId', 'displayName']);
+    console.log('[Aletheia Auth] Tokens cleared');
+}
+
+/**
+ * Get current auth state (user info if logged in).
+ * @returns {Promise<{userId: string, displayName: string} | null>}
+ */
+async function getAuthState() {
+    const local = await chrome.storage.local.get(['userId', 'displayName', 'refreshToken']);
+
+    if (local.userId && local.refreshToken) {
+        return {
+            userId: local.userId,
+            displayName: local.displayName
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Check if user is authenticated (has valid refresh token).
+ * @returns {Promise<boolean>}
+ */
+async function isAuthenticated() {
+    const state = await getAuthState();
+    return state !== null;
+}
+
+/**
+ * Get valid access token, refreshing if needed (lazy refresh).
+ * @returns {Promise<string | null>} Access token or null if not authenticated
+ */
+async function getAccessToken() {
+    const session = await chrome.storage.session.get(['accessToken', 'expiresAt']);
+
+    // Check if token exists and is not expired (with 60s buffer)
+    if (session.accessToken && Date.now() < (session.expiresAt - 60000)) {
+        return session.accessToken;
+    }
+
+    // Token expired or missing - try to refresh
+    console.log('[Aletheia Auth] Access token expired, attempting refresh...');
+    return await refreshTokens();
+}
+
+// =============================================================================
+// TOKEN REFRESH
+// =============================================================================
+
+/**
+ * Refresh access token using stored refresh token.
+ * @returns {Promise<string | null>} New access token or null if refresh fails
+ */
+async function refreshTokens() {
+    const local = await chrome.storage.local.get(['refreshToken']);
+
+    if (!local.refreshToken) {
+        console.log('[Aletheia Auth] No refresh token available');
+        return null;
+    }
+
+    try {
+        const response = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/refresh`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ refreshToken: local.refreshToken })
+        });
+
+        if (!response.ok) {
+            console.error('[Aletheia Auth] Token refresh failed:', response.status);
+            // Clear tokens on 401 (refresh token invalid)
+            if (response.status === 401) {
+                await clearTokens();
+            }
+            return null;
+        }
+
+        const data = await response.json();
+
+        // Store new access token
+        await chrome.storage.session.set({
+            accessToken: data.accessToken,
+            expiresAt: Date.now() + (data.expiresIn * 1000)
+        });
+
+        console.log('[Aletheia Auth] Token refreshed successfully');
+        return data.accessToken;
+
+    } catch (error) {
+        console.error('[Aletheia Auth] Token refresh error:', error);
+        return null;
+    }
+}
+
+// =============================================================================
+// MOCK MODE (for testing)
+// =============================================================================
+
+/**
+ * Mock login for automated tests.
+ * Returns deterministic mock tokens without calling LinkedIn.
+ */
+async function mockLogin() {
+    console.log('[Aletheia Auth] MOCK MODE - Using fake credentials');
+
+    const mockUser = {
+        accessToken: 'mock-access-token-12345',
+        refreshToken: 'mock-refresh-token-67890',
+        expiresIn: 3600,
+        user: {
+            id: 'mock-sub-782bbtaQ',  // Mimics OIDC 'sub' format
+            name: 'Test User'
+        }
+    };
+
+    await storeTokens(
+        mockUser.accessToken,
+        mockUser.refreshToken,
+        mockUser.expiresIn,
+        mockUser.user
+    );
+
+    return mockUser.user;
+}
+
+// =============================================================================
+// OAUTH FLOW
+// =============================================================================
+
+/**
+ * Build LinkedIn authorization URL with required parameters.
+ * @param {string} state - CSRF state parameter
+ * @returns {string} Full authorization URL
+ */
+function buildAuthUrl(state) {
+    const redirectUri = chrome.identity.getRedirectURL();
+    const params = new URLSearchParams({
+        response_type: 'code',
+        client_id: AUTH_CONFIG.CLIENT_ID,
+        redirect_uri: redirectUri,
+        state: state,
+        scope: AUTH_CONFIG.SCOPES
+    });
+
+    return `${AUTH_CONFIG.AUTH_URL}?${params.toString()}`;
+}
+
+/**
+ * Initiate LinkedIn OAuth login flow.
+ *
+ * Uses chrome.identity.launchWebAuthFlow for Chrome-compliant OAuth.
+ * Includes CSRF protection via state parameter.
+ *
+ * @returns {Promise<{id: string, name: string}>} User info on success
+ * @throws {Error} On authentication failure
+ */
+async function initiateLogin() {
+    // Mock mode for testing
+    if (AUTH_CONFIG.MOCK_MODE) {
+        return await mockLogin();
+    }
+
+    // 1. Generate CSRF state
+    const state = generateState();
+
+    // 2. Store state for validation (use session storage for popup context)
+    // Note: In MV3, we use chrome.storage.session which is shared across extension contexts
+    await chrome.storage.session.set({ oauth_state: state });
+
+    // 3. Build auth URL
+    const authUrl = buildAuthUrl(state);
+    const redirectUri = chrome.identity.getRedirectURL();
+
+    console.log('[Aletheia Auth] Launching OAuth flow...');
+    console.log('[Aletheia Auth] Redirect URI:', redirectUri);
+
+    try {
+        // 4. Launch OAuth flow
+        const responseUrl = await chrome.identity.launchWebAuthFlow({
+            url: authUrl,
+            interactive: true
+        });
+
+        // 5. Parse response
+        const url = new URL(responseUrl);
+        const returnedState = url.searchParams.get('state');
+        const code = url.searchParams.get('code');
+        const error = url.searchParams.get('error');
+
+        // 6. Validate state (CSRF protection)
+        const stored = await chrome.storage.session.get(['oauth_state']);
+        await chrome.storage.session.remove(['oauth_state']);
+
+        if (returnedState !== stored.oauth_state) {
+            throw new Error('CSRF detected: state mismatch');
+        }
+
+        // 7. Check for errors
+        if (error) {
+            throw new Error(`LinkedIn OAuth error: ${error}`);
+        }
+
+        if (!code) {
+            throw new Error('No authorization code received');
+        }
+
+        // 8. Exchange code for tokens via Lambda
+        console.log('[Aletheia Auth] Exchanging code for tokens...');
+        const tokenResponse = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                code: code,
+                redirectUri: redirectUri
+            })
+        });
+
+        if (!tokenResponse.ok) {
+            const errorData = await tokenResponse.json().catch(() => ({}));
+            throw new Error(errorData.error || `Token exchange failed: ${tokenResponse.status}`);
+        }
+
+        const tokenData = await tokenResponse.json();
+
+        // 9. Store tokens
+        await storeTokens(
+            tokenData.accessToken,
+            tokenData.refreshToken,
+            tokenData.expiresIn,
+            tokenData.user
+        );
+
+        console.log('[Aletheia Auth] Login successful:', tokenData.user.name);
+        return tokenData.user;
+
+    } catch (error) {
+        console.error('[Aletheia Auth] Login failed:', error);
+        throw error;
+    }
+}
+
+/**
+ * Logout - clear all tokens and auth state.
+ */
+async function logout() {
+    await clearTokens();
+    console.log('[Aletheia Auth] Logged out');
+}
+
+// =============================================================================
+// EXPORTS (for use in other extension scripts)
+// =============================================================================
+
+// Make functions available globally for other scripts
+window.AletheiaAuth = {
+    initiateLogin,
+    logout,
+    isAuthenticated,
+    getAuthState,
+    getAccessToken,
+    clearTokens,
+    // Config for debugging
+    getConfig: () => ({ ...AUTH_CONFIG, CLIENT_ID: '***' })  // Hide client ID in logs
+};

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -3,12 +3,14 @@
   "name": "Aletheia",
   "version": "1.0",
   "description": "AI-Powered Context Analysis",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhYlTEFPRyBdtDpxYs4lJ3fBLqJ7QTTGEiKBL4T+m8FiX9YWrTSCNBRFVWdZqNpG7VWTzQRGPsH3wAXw6nR5LT+5QJyJLe3HGVKdEqPJrTwLF1M+x8Q6NGKdVhQH4XQb8XPW3BNQT5R+r7yw5m7h8WqX5YJ5M3b7gX9Y5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QNL3R8Q7WrT8XnK5N7L3r9QIDAQAB",
   "permissions": [
     "activeTab",
     "tabs",
     "scripting",
     "contextMenus",
-    "storage"
+    "storage",
+    "identity"
   ],
   "host_permissions": [],
   "background": {

--- a/extensions/chrome/popup.css
+++ b/extensions/chrome/popup.css
@@ -465,3 +465,115 @@ body {
   font-size: 14px;
   color: var(--color-text-secondary);
 }
+
+/* LOGIN VIEW (Issue #116 - LinkedIn OAuth) */
+#login-view {
+  padding: 24px;
+}
+
+.login-content {
+  text-align: center;
+}
+
+.login-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 8px;
+}
+
+.login-message {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+
+.login-button {
+  width: 100%;
+  padding: 12px 16px;
+  background-color: #0A66C2;
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background-color 0.15s ease;
+}
+
+.login-button:hover {
+  background-color: #004182;
+}
+
+.login-button:disabled {
+  background-color: #9CA3AF;
+  cursor: not-allowed;
+}
+
+.linkedin-icon {
+  font-weight: 700;
+  font-size: 16px;
+  background-color: white;
+  color: #0A66C2;
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-privacy {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-top: 16px;
+  line-height: 1.4;
+}
+
+.login-error {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: var(--color-danger);
+  padding: 12px;
+  border-radius: var(--radius);
+  font-size: 13px;
+  margin-top: 16px;
+  text-align: center;
+}
+
+/* USER BAR (Issue #116) */
+.user-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background-color: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+  margin: -24px -24px 16px -24px;
+}
+
+.user-name {
+  font-size: 13px;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.logout-button {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+}
+
+.logout-button:hover {
+  background-color: var(--color-border);
+  color: var(--color-text);
+}

--- a/extensions/chrome/popup.html
+++ b/extensions/chrome/popup.html
@@ -9,8 +9,37 @@
 <body>
   <div id="popup-container">
 
+    <!-- LOGIN VIEW (Issue #116 - LinkedIn OAuth) -->
+    <div id="login-view" class="view" style="display: none;">
+      <div class="logo-container">
+        <img src="icons/icon128.png" alt="Aletheia" class="logo">
+      </div>
+
+      <div class="login-content">
+        <div class="login-title">Welcome to Aletheia</div>
+        <div class="login-message">
+          Sign in with LinkedIn to unlock AI-powered context analysis.
+        </div>
+        <button id="login-button" class="login-button">
+          <span class="linkedin-icon">in</span>
+          Sign in with LinkedIn
+        </button>
+        <div class="login-privacy">
+          We only request your name for display. Your data stays private.
+        </div>
+      </div>
+
+      <div id="login-error" class="login-error" style="display: none;"></div>
+    </div>
+
     <!-- MAIN VIEW -->
-    <div id="main-view" class="view">
+    <div id="main-view" class="view" style="display: none;">
+      <!-- User Info Bar (Issue #116) -->
+      <div id="user-bar" class="user-bar">
+        <span id="user-name" class="user-name">User</span>
+        <button id="logout-button" class="logout-button">Logout</button>
+      </div>
+
       <div class="logo-container">
         <img src="icons/icon128.png" alt="Aletheia" class="logo">
       </div>
@@ -97,6 +126,7 @@
 
   </div>
 
+  <script src="auth.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extensions/chrome/popup.js
+++ b/extensions/chrome/popup.js
@@ -12,11 +12,19 @@ const TabState = {
 };
 
 // DOM Elements
+const loginView = document.getElementById('login-view');
 const mainView = document.getElementById('main-view');
 const manageView = document.getElementById('manage-view');
 const confirmView = document.getElementById('confirm-view');
 const restrictedView = document.getElementById('restricted-view');
 const checkingView = document.getElementById('checking-view');
+
+// Auth Elements (Issue #116)
+const loginButton = document.getElementById('login-button');
+const loginError = document.getElementById('login-error');
+const userBar = document.getElementById('user-bar');
+const userName = document.getElementById('user-name');
+const logoutButton = document.getElementById('logout-button');
 
 const currentDomainEl = document.getElementById('current-domain');
 const statusLabel = document.getElementById('status-label');
@@ -113,13 +121,16 @@ async function clearAllData() {
 // ============================================================================
 
 function showView(viewName) {
+  loginView.style.display = 'none';
   mainView.style.display = 'none';
   manageView.style.display = 'none';
   confirmView.style.display = 'none';
   restrictedView.style.display = 'none';
   checkingView.style.display = 'none';
 
-  if (viewName === 'main') {
+  if (viewName === 'login') {
+    loginView.style.display = 'block';
+  } else if (viewName === 'main') {
     mainView.style.display = 'block';
   } else if (viewName === 'manage') {
     manageView.style.display = 'block';
@@ -381,10 +392,54 @@ async function checkAgeGate() {
 }
 
 // ============================================================================
+// AUTH HANDLERS (Issue #116)
+// ============================================================================
+
+async function handleLoginClick() {
+  try {
+    loginButton.disabled = true;
+    loginButton.textContent = 'Signing in...';
+    loginError.style.display = 'none';
+
+    const user = await window.AletheiaAuth.initiateLogin();
+
+    // Update user bar and proceed to main flow
+    userName.textContent = user.name;
+    await checkAgeGate();
+
+  } catch (error) {
+    console.error('[Aletheia] Login failed:', error);
+    loginError.textContent = error.message || 'Login failed. Please try again.';
+    loginError.style.display = 'block';
+    loginButton.disabled = false;
+    loginButton.innerHTML = '<span class="linkedin-icon">in</span> Sign in with LinkedIn';
+  }
+}
+
+async function handleLogoutClick() {
+  await window.AletheiaAuth.logout();
+  showView('login');
+}
+
+async function updateUserBar() {
+  const authState = await window.AletheiaAuth.getAuthState();
+  if (authState) {
+    userName.textContent = authState.displayName;
+    userBar.style.display = 'flex';
+  } else {
+    userBar.style.display = 'none';
+  }
+}
+
+// ============================================================================
 // INITIALIZATION
 // ============================================================================
 
 async function init() {
+  // Auth event listeners (Issue #116)
+  loginButton.addEventListener('click', handleLoginClick);
+  logoutButton.addEventListener('click', handleLogoutClick);
+
   // Main view event listeners
   powerButton.addEventListener('click', handlePowerToggle);
   manageButton.addEventListener('click', handleManageClick);
@@ -398,7 +453,19 @@ async function init() {
   cancelButton.addEventListener('click', handleCancelClick);
   confirmClearButton.addEventListener('click', handleConfirmClearClick);
 
-  // Age gate check first, then render appropriate view
+  // Check auth state first (Issue #116)
+  const isAuthed = await window.AletheiaAuth.isAuthenticated();
+
+  if (!isAuthed) {
+    // Not logged in - show login view
+    showView('login');
+    return;
+  }
+
+  // Update user bar with name
+  await updateUserBar();
+
+  // Age gate check, then render appropriate view
   await checkAgeGate();
 }
 

--- a/provision.sh
+++ b/provision.sh
@@ -5,8 +5,11 @@ APP_NAME="Aletheia"
 REGION="us-east-1"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 TABLE_NAME="${APP_NAME}AgentState"
+USERS_TABLE="aletheia-users"
 ROLE_NAME="${APP_NAME}LambdaRole"
 FUNC_NAME="${APP_NAME}Agent"
+AUTH_FUNC_NAME="${APP_NAME}Auth"
+LINKEDIN_SECRET_NAME="aletheia/linkedin-oauth"
 
 echo "=== Provisioning Infrastructure for $APP_NAME ($REGION) ==="
 
@@ -40,6 +43,21 @@ else
     echo "TTL already enabled on $TABLE_NAME"
 fi
 
+# 1.6. Users DynamoDB Table (Issue #116: LinkedIn OAuth)
+echo "[1.6/7] Checking Users DynamoDB Table..."
+if ! aws dynamodb describe-table --table-name "$USERS_TABLE" --region "$REGION" >/dev/null 2>&1; then
+    echo "Creating users table: $USERS_TABLE"
+    aws dynamodb create-table \
+        --table-name "$USERS_TABLE" \
+        --attribute-definitions AttributeName=user_id,AttributeType=S \
+        --key-schema AttributeName=user_id,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST \
+        --region "$REGION"
+    aws dynamodb wait table-exists --table-name "$USERS_TABLE" --region "$REGION"
+else
+    echo "Users table already exists: $USERS_TABLE"
+fi
+
 # 2. IAM Role
 echo "[2/5] Checking IAM Role..."
 TRUST_POLICY='{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Principal": { "Service": "lambda.amazonaws.com" },"Action": "sts:AssumeRole"}]}'
@@ -52,8 +70,9 @@ aws iam attach-role-policy --role-name "$ROLE_NAME" --policy-arn "arn:aws:iam::a
 aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name "${APP_NAME}Access" --policy-document '{
     "Version": "2012-10-17",
     "Statement": [
-        {"Effect": "Allow","Action": ["dynamodb:PutItem","dynamodb:GetItem","dynamodb:UpdateItem","dynamodb:DeleteItem","dynamodb:Query","dynamodb:Scan"],"Resource": "arn:aws:dynamodb:*:*:table/'"$TABLE_NAME"'"},
-        {"Effect": "Allow","Action": ["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource": "*"}
+        {"Effect": "Allow","Action": ["dynamodb:PutItem","dynamodb:GetItem","dynamodb:UpdateItem","dynamodb:DeleteItem","dynamodb:Query","dynamodb:Scan"],"Resource": ["arn:aws:dynamodb:*:*:table/'"$TABLE_NAME"'", "arn:aws:dynamodb:*:*:table/'"$USERS_TABLE"'"]},
+        {"Effect": "Allow","Action": ["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource": "*"},
+        {"Effect": "Allow","Action": ["secretsmanager:GetSecretValue"],"Resource": "arn:aws:secretsmanager:*:*:secret:'"$LINKEDIN_SECRET_NAME"'*"}
     ]
 }'
 sleep 5
@@ -88,5 +107,48 @@ aws lambda create-function-url-config --function-name "$FUNC_NAME" --auth-type N
 aws lambda add-permission --function-name "$FUNC_NAME" --action lambda:InvokeFunctionUrl --statement-id FunctionURLAllowPublicAccess --principal "*" --function-url-auth-type NONE --region "$REGION" 2>/dev/null || true
 
 FUNC_URL=$(aws lambda get-function-url-config --function-name "$FUNC_NAME" --region "$REGION" --query 'FunctionUrl' --output text)
+
+# 5. Auth Lambda Function (Issue #116: LinkedIn OAuth)
+echo "[5/7] Creating Auth Lambda Function..."
+echo "def lambda_handler(event, context): return 'Init'" > lambda_auth_function.py
+cat << 'PY_SCRIPT' > zipper_auth.py
+import zipfile
+with zipfile.ZipFile('init_auth.zip', 'w') as z:
+    z.write('lambda_auth_function.py')
+PY_SCRIPT
+python zipper_auth.py
+
+if ! aws lambda get-function --function-name "$AUTH_FUNC_NAME" --region "$REGION" >/dev/null 2>&1; then
+    aws lambda create-function \
+        --function-name "$AUTH_FUNC_NAME" \
+        --runtime python3.12 \
+        --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
+        --handler lambda_auth_function.lambda_handler \
+        --zip-file fileb://init_auth.zip \
+        --architectures x86_64 \
+        --timeout 30 \
+        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME}" \
+        --region "$REGION"
+fi
+rm init_auth.zip lambda_auth_function.py zipper_auth.py
+
+# 6. Auth Function URL
+echo "[6/7] Configuring Auth URL..."
+aws lambda create-function-url-config --function-name "$AUTH_FUNC_NAME" --auth-type NONE --cors "AllowOrigins=['*'],AllowMethods=['POST','GET'],AllowHeaders=['Content-Type','Authorization']" --region "$REGION" 2>/dev/null || true
+aws lambda add-permission --function-name "$AUTH_FUNC_NAME" --action lambda:InvokeFunctionUrl --statement-id FunctionURLAllowPublicAccess --principal "*" --function-url-auth-type NONE --region "$REGION" 2>/dev/null || true
+
+AUTH_FUNC_URL=$(aws lambda get-function-url-config --function-name "$AUTH_FUNC_NAME" --region "$REGION" --query 'FunctionUrl' --output text)
+
+# 7. LinkedIn Secret reminder
+echo "[7/7] LinkedIn OAuth Secret..."
+if ! aws secretsmanager describe-secret --secret-id "$LINKEDIN_SECRET_NAME" --region "$REGION" >/dev/null 2>&1; then
+    echo "WARNING: LinkedIn OAuth secret '$LINKEDIN_SECRET_NAME' not found!"
+    echo "Create it manually with:"
+    echo "  aws secretsmanager create-secret --name $LINKEDIN_SECRET_NAME --secret-string '{\"client_id\":\"YOUR_ID\",\"client_secret\":\"YOUR_SECRET\"}'"
+else
+    echo "LinkedIn secret exists: $LINKEDIN_SECRET_NAME"
+fi
+
 echo "=== Provisioning Complete ==="
-echo "NEW FUNCTION URL: $FUNC_URL"
+echo "Agent Function URL: $FUNC_URL"
+echo "Auth Function URL:  $AUTH_FUNC_URL"

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -1,0 +1,433 @@
+"""
+Lambda Auth Function - LinkedIn OAuth Token Exchange and Validation.
+
+Handles:
+- Token exchange (auth code → tokens)
+- Token refresh (refresh token → new tokens)
+- User creation/lookup in DynamoDB
+
+See: docs/1116-linkedin-oauth.md
+
+Issue #116: LinkedIn OAuth Authentication
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+import requests
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Configuration
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+USERS_TABLE = os.environ.get("USERS_TABLE", "aletheia-users")
+
+# LinkedIn OAuth endpoints
+LINKEDIN_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+LINKEDIN_USERINFO_URL = "https://api.linkedin.com/v2/userinfo"
+
+# Lazy-initialized clients
+_dynamodb_client = None
+_secrets_client = None
+_linkedin_credentials = None
+
+
+def get_dynamodb_client():
+    """Lazy-initialize DynamoDB client."""
+    global _dynamodb_client
+    if _dynamodb_client is None:
+        _dynamodb_client = boto3.client("dynamodb", region_name=AWS_REGION)
+    return _dynamodb_client
+
+
+def get_secrets_client():
+    """Lazy-initialize Secrets Manager client."""
+    global _secrets_client
+    if _secrets_client is None:
+        _secrets_client = boto3.client("secretsmanager", region_name=AWS_REGION)
+    return _secrets_client
+
+
+def get_linkedin_credentials() -> dict:
+    """
+    Retrieve LinkedIn OAuth credentials from Secrets Manager.
+
+    Cached after first retrieval for warm start optimization.
+    """
+    global _linkedin_credentials
+    if _linkedin_credentials is None:
+        client = get_secrets_client()
+        secret_name = os.environ.get("LINKEDIN_SECRET_NAME", "aletheia/linkedin-oauth")
+        try:
+            response = client.get_secret_value(SecretId=secret_name)
+            _linkedin_credentials = json.loads(response["SecretString"])
+        except ClientError as e:
+            logger.error(f"Failed to retrieve LinkedIn credentials: {e}")
+            raise
+    return _linkedin_credentials
+
+
+def exchange_code_for_tokens(code: str, redirect_uri: str) -> dict:
+    """
+    Exchange authorization code for access and refresh tokens.
+
+    Args:
+        code: Authorization code from LinkedIn OAuth callback.
+        redirect_uri: The redirect URI used in the auth request.
+
+    Returns:
+        Dict with access_token, refresh_token, expires_in.
+
+    Raises:
+        ValueError: If token exchange fails.
+    """
+    credentials = get_linkedin_credentials()
+
+    response = requests.post(
+        LINKEDIN_TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": credentials["client_id"],
+            "client_secret": credentials["client_secret"],
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=10,
+    )
+
+    if response.status_code != 200:
+        logger.error(f"Token exchange failed: {response.status_code} - {response.text}")
+        raise ValueError(f"Token exchange failed: {response.status_code}")
+
+    return response.json()
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    """
+    Use refresh token to obtain new access token.
+
+    Args:
+        refresh_token: The refresh token from previous auth.
+
+    Returns:
+        Dict with new access_token and expires_in.
+
+    Raises:
+        ValueError: If refresh fails.
+    """
+    credentials = get_linkedin_credentials()
+
+    response = requests.post(
+        LINKEDIN_TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": credentials["client_id"],
+            "client_secret": credentials["client_secret"],
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=10,
+    )
+
+    if response.status_code != 200:
+        logger.error(f"Token refresh failed: {response.status_code} - {response.text}")
+        raise ValueError(f"Token refresh failed: {response.status_code}")
+
+    return response.json()
+
+
+def get_linkedin_user_info(access_token: str) -> dict | None:
+    """
+    Validate token and retrieve user info from LinkedIn.
+
+    This validates the token by calling LinkedIn's userinfo endpoint.
+    The response contains the OIDC claims (sub, name, etc.).
+
+    Args:
+        access_token: LinkedIn access token.
+
+    Returns:
+        User info dict with sub, name, etc., or None if invalid.
+    """
+    response = requests.get(
+        LINKEDIN_USERINFO_URL,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+
+    if response.status_code == 200:
+        return response.json()
+    elif response.status_code == 401:
+        logger.warning("LinkedIn token validation failed: 401 Unauthorized")
+        return None
+    else:
+        logger.error(f"LinkedIn userinfo error: {response.status_code}")
+        return None
+
+
+def get_or_create_user(user_info: dict) -> dict:
+    """
+    Get existing user or create new one in DynamoDB.
+
+    Uses LinkedIn OIDC 'sub' as the primary key (user_id).
+    See: docs/1116-linkedin-oauth.md Section 1 (User Identity Decision)
+
+    Args:
+        user_info: LinkedIn OIDC userinfo response.
+
+    Returns:
+        User record dict.
+    """
+    client = get_dynamodb_client()
+    user_id = user_info["sub"]  # LinkedIn's stable member ID
+    display_name = user_info.get("name", "Unknown")
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    # Try to get existing user
+    try:
+        response = client.get_item(
+            TableName=USERS_TABLE,
+            Key={"user_id": {"S": user_id}},
+        )
+        if "Item" in response:
+            # Update last_login
+            client.update_item(
+                TableName=USERS_TABLE,
+                Key={"user_id": {"S": user_id}},
+                UpdateExpression="SET last_login = :now",
+                ExpressionAttributeValues={":now": {"S": now}},
+            )
+            return {
+                "user_id": user_id,
+                "display_name": response["Item"]["display_name"]["S"],
+                "created_at": response["Item"]["created_at"]["S"],
+                "last_login": now,
+            }
+    except ClientError as e:
+        logger.error(f"DynamoDB get_item error: {e}")
+        raise
+
+    # Create new user
+    try:
+        client.put_item(
+            TableName=USERS_TABLE,
+            Item={
+                "user_id": {"S": user_id},
+                "display_name": {"S": display_name},
+                "created_at": {"S": now},
+                "last_login": {"S": now},
+            },
+        )
+        logger.info(f"Created new user: {user_id}")
+        return {
+            "user_id": user_id,
+            "display_name": display_name,
+            "created_at": now,
+            "last_login": now,
+        }
+    except ClientError as e:
+        logger.error(f"DynamoDB put_item error: {e}")
+        raise
+
+
+def handle_token_exchange(body: dict) -> dict:
+    """
+    Handle POST /auth/token - Exchange auth code for tokens.
+
+    Expected body: { "code": "...", "redirectUri": "..." }
+    """
+    code = body.get("code")
+    redirect_uri = body.get("redirectUri")
+
+    if not code or not redirect_uri:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing code or redirectUri"}),
+        }
+
+    try:
+        # 1. Exchange code for tokens
+        tokens = exchange_code_for_tokens(code, redirect_uri)
+
+        # 2. Validate token and get user info
+        user_info = get_linkedin_user_info(tokens["access_token"])
+        if user_info is None:
+            return {
+                "statusCode": 401,
+                "body": json.dumps({"error": "Token validation failed"}),
+            }
+
+        # 3. Create or update user in DynamoDB
+        user = get_or_create_user(user_info)
+
+        # 4. Return tokens and user info to extension
+        return {
+            "statusCode": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({
+                "accessToken": tokens["access_token"],
+                "refreshToken": tokens.get("refresh_token"),
+                "expiresIn": tokens.get("expires_in", 3600),
+                "user": {
+                    "id": user["user_id"],
+                    "name": user["display_name"],
+                },
+            }),
+        }
+
+    except ValueError as e:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": str(e)}),
+        }
+    except Exception as e:
+        logger.error(f"Token exchange error: {e}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": "Internal server error"}),
+        }
+
+
+def handle_token_refresh(body: dict) -> dict:
+    """
+    Handle POST /auth/refresh - Refresh access token.
+
+    Expected body: { "refreshToken": "..." }
+    """
+    refresh_token = body.get("refreshToken")
+
+    if not refresh_token:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing refreshToken"}),
+        }
+
+    try:
+        # Refresh tokens
+        tokens = refresh_access_token(refresh_token)
+
+        # Validate new token
+        user_info = get_linkedin_user_info(tokens["access_token"])
+        if user_info is None:
+            return {
+                "statusCode": 401,
+                "body": json.dumps({"error": "Token validation failed"}),
+            }
+
+        return {
+            "statusCode": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({
+                "accessToken": tokens["access_token"],
+                "expiresIn": tokens.get("expires_in", 3600),
+            }),
+        }
+
+    except ValueError as e:
+        return {
+            "statusCode": 401,
+            "body": json.dumps({"error": str(e)}),
+        }
+    except Exception as e:
+        logger.error(f"Token refresh error: {e}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": "Internal server error"}),
+        }
+
+
+def handle_validate_token(headers: dict) -> dict:
+    """
+    Handle GET /auth/validate - Validate access token.
+
+    Expects Authorization header: Bearer <token>
+    """
+    auth_header = headers.get("Authorization", headers.get("authorization", ""))
+
+    if not auth_header.startswith("Bearer "):
+        return {
+            "statusCode": 401,
+            "body": json.dumps({"error": "Missing or invalid Authorization header"}),
+        }
+
+    token = auth_header.replace("Bearer ", "")
+    user_info = get_linkedin_user_info(token)
+
+    if user_info is None:
+        return {
+            "statusCode": 401,
+            "body": json.dumps({"error": "Invalid token"}),
+        }
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({
+            "valid": True,
+            "user": {
+                "id": user_info["sub"],
+                "name": user_info.get("name", "Unknown"),
+            },
+        }),
+    }
+
+
+def lambda_handler(event: dict, context: Any) -> dict:
+    """
+    Main entry point for auth Lambda.
+
+    Routes:
+    - POST /auth/token - Exchange code for tokens
+    - POST /auth/refresh - Refresh access token
+    - GET /auth/validate - Validate access token
+
+    See: docs/1116-linkedin-oauth.md
+    """
+    try:
+        # Parse HTTP method and path
+        http_method = event.get("requestContext", {}).get("http", {}).get("method", "")
+        path = event.get("requestContext", {}).get("http", {}).get("path", "")
+
+        # Also support direct invocation format
+        if not http_method:
+            http_method = event.get("httpMethod", "POST")
+        if not path:
+            path = event.get("path", "/auth/token")
+
+        # Parse body
+        body = {}
+        if event.get("body"):
+            body = (
+                json.loads(event["body"])
+                if isinstance(event["body"], str)
+                else event["body"]
+            )
+
+        headers = event.get("headers", {})
+
+        # Route to appropriate handler
+        if path == "/auth/token" and http_method == "POST":
+            return handle_token_exchange(body)
+        elif path == "/auth/refresh" and http_method == "POST":
+            return handle_token_refresh(body)
+        elif path == "/auth/validate" and http_method == "GET":
+            return handle_validate_token(headers)
+        else:
+            return {
+                "statusCode": 404,
+                "body": json.dumps({"error": "Not found"}),
+            }
+
+    except Exception as e:
+        logger.error(f"Unhandled error: {type(e).__name__}: {e}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": "Internal server error"}),
+        }


### PR DESCRIPTION
## Summary
- Add Auth Lambda for token exchange, refresh, and validation
- Create users DynamoDB table with user_id (OIDC sub) as primary key
- Implement chrome.identity OAuth flow with CSRF protection
- Add login/logout UI to extension popup

## Test plan
- [ ] Run provision.sh to create infrastructure
- [ ] Generate extension key and register LinkedIn OAuth app
- [ ] Create LinkedIn secret in Secrets Manager
- [ ] Load extension and test login flow
- [ ] Verify token storage hierarchy (session vs local)
- [ ] Test logout clears all tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)