### PR TITLE
feat: O1 latency optimization - share boto3 client (close #137)

### DIFF
--- a/src/guardrails/semantic.py
+++ b/src/guardrails/semantic.py
@@ -1,15 +1,28 @@
 import json
+import logging
+import time
 import boto3
 from pathlib import Path
 from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
 
 class SemanticGuardrail:
     """
     LLM-based guardrail to filter unsafe semantic content.
     Loads definitions and few-shot examples from resources/taxonomy.json.
+
+    Issue #137: Accepts optional bedrock_client to share client with main handler,
+    eliminating ~774ms duplicate client initialization on cold starts.
     """
-    def __init__(self, region_name: str = "us-east-1", model_id: str = "anthropic.claude-3-haiku-20240307-v1:0"):
-        self.client = boto3.client("bedrock-runtime", region_name=region_name)
+    def __init__(
+        self,
+        region_name: str = "us-east-1",
+        model_id: str = "anthropic.claude-3-haiku-20240307-v1:0",
+        bedrock_client=None,
+    ):
+        # Use injected client if provided, otherwise create new (backward compat)
+        self.client = bedrock_client or boto3.client("bedrock-runtime", region_name=region_name)
         self.model_id = model_id
         self.resources = self._load_resources()
 
@@ -56,8 +69,13 @@ class SemanticGuardrail:
         Security: User text is wrapped in XML tags to prevent prompt injection.
         See: docs/0809-audit-security.md Finding F1
         """
+        # Issue #137: Timing instrumentation
+        timings = {}
+        start = time.time()
+
         # Wrap user text in XML tags to clearly delineate from prompt
         # This mitigates prompt injection by making the boundary explicit
+        t0 = time.time()
         wrapped_text = f"<user_text>{text}</user_text>"
 
         payload = {
@@ -68,12 +86,17 @@ class SemanticGuardrail:
                 {"role": "user", "content": [{"type": "text", "text": wrapped_text}]}
             ]
         }
+        timings["prompt_build_ms"] = int((time.time() - t0) * 1000)
 
         try:
+            t0 = time.time()
             response = self.client.invoke_model(
                 modelId=self.model_id,
                 body=json.dumps(payload)
             )
+            timings["bedrock_invoke_ms"] = int((time.time() - t0) * 1000)
+
+            t0 = time.time()
             result = json.loads(response['body'].read())
             content_text = result['content'][0]['text']
 
@@ -81,6 +104,12 @@ class SemanticGuardrail:
             data = json.loads(content_text)
             category = data.get("category", "Unknown")
             scores = data.get("scores", {})
+            timings["response_parse_ms"] = int((time.time() - t0) * 1000)
+
+            timings["total_ms"] = int((time.time() - start) * 1000)
+
+            # Issue #137: Log semantic guardrail timing breakdown
+            logger.info(f"SEMANTIC_GUARDRAIL_TIMING: {json.dumps(timings)}")
 
             # Deterministic Policy Enforcement (Code > LLM)
             # "None" and "Neologism" are Safe. Others are Unsafe.
@@ -94,5 +123,7 @@ class SemanticGuardrail:
             }
 
         except Exception as e:
+            timings["total_ms"] = int((time.time() - start) * 1000)
+            logger.info(f"SEMANTIC_GUARDRAIL_TIMING (error): {json.dumps(timings)}")
             # Fail closed on infrastructure error
             return {"is_safe": False, "reason": f"Guardrail Error: {str(e)}", "scores": {}}

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -64,10 +64,18 @@ def get_bedrock_client():
 
 
 def get_semantic_guardrail():
-    """Lazy-initialize SemanticGuardrail."""
+    """
+    Lazy-initialize SemanticGuardrail with shared Bedrock client.
+
+    Issue #137: Pass shared client to eliminate duplicate client initialization
+    (~774ms savings on cold start).
+    """
     global _semantic_guardrail
     if _semantic_guardrail is None:
-        _semantic_guardrail = SemanticGuardrail(region_name=AWS_REGION)
+        _semantic_guardrail = SemanticGuardrail(
+            region_name=AWS_REGION,
+            bedrock_client=get_bedrock_client(),
+        )
     return _semantic_guardrail
 
 
@@ -212,23 +220,37 @@ def run_guardrails(
     Returns:
         (is_safe, block_reason, metadata)
     """
+    # Issue #137: Track individual guardrail timings
+    guardrail_timings = {}
+
     # Step 1: Denylist check (fast, deterministic)
+    t0 = time.time()
     denylist_result = check_denylist(text, denylist)
+    guardrail_timings["denylist_ms"] = int((time.time() - t0) * 1000)
     if denylist_result["blocked"]:
-        return False, "Content blocked by safety filter", {"layer": "denylist"}
+        return False, "Content blocked by safety filter", {"layer": "denylist", "timings": guardrail_timings}
 
     # Step 2: Semantic check (LLM-based, slower)
     # MUST run after denylist, MUST block before generation
+    t0 = time.time()
     semantic = get_semantic_guardrail()
+    guardrail_timings["semantic_init_ms"] = int((time.time() - t0) * 1000)
+
+    t0 = time.time()
     semantic_result = semantic.check_safety(text)
+    guardrail_timings["semantic_llm_ms"] = int((time.time() - t0) * 1000)
+
+    # Issue #137: Log guardrail breakdown
+    logger.info(f"GUARDRAIL_BREAKDOWN: {json.dumps(guardrail_timings)}")
+
     if not semantic_result["is_safe"]:
         return (
             False,
             f"Content blocked: {semantic_result['reason']}",
-            {"layer": "semantic", "scores": semantic_result.get("scores", {})},
+            {"layer": "semantic", "scores": semantic_result.get("scores", {}), "timings": guardrail_timings},
         )
 
-    return True, None, {"layer": "passed", "scores": semantic_result.get("scores", {})}
+    return True, None, {"layer": "passed", "scores": semantic_result.get("scores", {}), "timings": guardrail_timings}
 
 
 def lambda_handler(
@@ -248,7 +270,12 @@ def lambda_handler(
         API Gateway response dict.
     """
     try:
+        # Issue #137: Timing instrumentation for latency investigation
+        timings = {}
+        handler_start = time.time()
+
         # Parse body if coming from API Gateway
+        t0 = time.time()
         if "body" in event:
             body = (
                 json.loads(event["body"])
@@ -257,24 +284,32 @@ def lambda_handler(
             )
         else:
             body = event
+        timings["parse_body_ms"] = int((time.time() - t0) * 1000)
 
         # 1. Validation
+        t0 = time.time()
         valid, error = validate_input(body)
+        timings["validation_ms"] = int((time.time() - t0) * 1000)
         if not valid:
             return {"statusCode": 400, "body": json.dumps({"error": error})}
 
         text = body["text"]
 
         # 2. Guardrails (MUST be sequential: Denylist → Semantic)
+        t0 = time.time()
         is_safe, block_reason, metadata = run_guardrails(text, denylist)
+        timings["guardrails_total_ms"] = int((time.time() - t0) * 1000)
         if not is_safe:
             return {"statusCode": 403, "body": json.dumps({"blocked": block_reason})}
 
         # 3. Generate thread ID for persistence
         # TODO: Issue #116 - Use authenticated user ID
+        t0 = time.time()
         thread_id = generate_thread_id(body)
+        timings["thread_id_ms"] = int((time.time() - t0) * 1000)
 
         # 4. Persist to DynamoDB
+        t0 = time.time()
         save_state(
             thread_id,
             {
@@ -284,14 +319,23 @@ def lambda_handler(
                 "safety_score": metadata.get("scores", {}),
             },
         )
+        timings["dynamodb_write_ms"] = int((time.time() - t0) * 1000)
 
         # 5. Generate etymology analysis (buffered, not streaming)
         # Issue #124: Digital Etymologist returns structured JSON
+        t0 = time.time()
         context_text = body.get("domContext", "")
         result = generate_etymology(text, context_text)
+        timings["etymology_generation_ms"] = int((time.time() - t0) * 1000)
+
+        # Calculate total handler time
+        timings["handler_total_ms"] = int((time.time() - handler_start) * 1000)
+
+        # Issue #137: Log all timings for analysis
+        logger.info(f"LATENCY_BREAKDOWN: {json.dumps(timings)}")
 
         # Build response with structured output
-        response_body = {
+        response_body: dict[str, Any] = {
             "thread_id": thread_id,
             "status": result["status"],
             "signal": result["response"]["signal"],
@@ -302,6 +346,13 @@ def lambda_handler(
         # Include latency for monitoring
         if result.get("metadata", {}).get("latency_ms"):
             response_body["latency_ms"] = result["metadata"]["latency_ms"]
+
+        # Issue #137: Include timing breakdown in response only in dev mode
+        # CloudWatch logging (above) remains active for production observability
+        if os.environ.get("ALETHEIA_ENV") == "dev":
+            response_body["_debug_timings"] = timings
+            if metadata.get("timings"):
+                response_body["_debug_timings"]["guardrails"] = metadata["timings"]
 
         return {
             "statusCode": 200,


### PR DESCRIPTION
## Summary

Implements O1 optimization from the latency investigation:
- SemanticGuardrail now accepts optional `bedrock_client` parameter for dependency injection
- `get_semantic_guardrail()` passes shared client from `get_bedrock_client()`
- Eliminates ~774ms duplicate boto3 client initialization on cold starts
- Added timing instrumentation (`LATENCY_BREAKDOWN`, `GUARDRAIL_BREAKDOWN`, `SEMANTIC_GUARDRAIL_TIMING`) for monitoring

## Test plan

- [x] All 28 existing tests pass
- [x] Deployed to Lambda and verified timing instrumentation works
- [x] Cold start shows `semantic_init_ms` now includes shared client creation
- [x] Warm start shows `semantic_init_ms: 0` (client cached)

## References

- See `docs/0211-latency-optimization.md` for full investigation and ADR
- O2 (async DynamoDB) deferred for future consideration

🤖 Generated with [Claude Code](https://claude.com/claude-code)