### PR TITLE
feat: store domContext and AI response in DynamoDB (#177, #178)

### DIFF
--- a/docs/reports/177/implementation-report.md
+++ b/docs/reports/177/implementation-report.md
@@ -1,0 +1,47 @@
+# Implementation Report: Issue #177 & #178 - Data Persistence
+
+**Date:** 2026-01-06
+**Author:** Claude Opus 4.5
+**Issues:** #177 (Store domContext), #178 (Store AI Response)
+
+## Summary
+
+Implemented data persistence features to store `domContext` (surrounding paragraph) and AI etymology response in DynamoDB for analytics and quality monitoring.
+
+## Changes Made
+
+### `src/lambda_function.py`
+
+1. **`save_state()` function (lines 127-172):**
+   - Added `domContext` field with 100KB truncation cap to prevent DynamoDB 400KB limit violations
+   - Added `response` field serialized as JSON (signal, gem, context)
+   - Handles `None` response gracefully for error cases
+
+2. **`lambda_handler()` function (lines 320-407):**
+   - Moved `save_state()` call from BEFORE to AFTER `generate_etymology()`
+   - Wrapped generation in `try/except/finally` pattern
+   - `save_state()` executes in `finally` block ensuring persistence even on failures
+   - Captures error state (`signal: "error"`) for post-mortem debugging
+
+### `tests/test_persistence.py` (NEW)
+
+9 new unit tests covering:
+- `TestDomContextPersistence`: stored, missing defaults empty, large truncated
+- `TestAIResponsePersistence`: stored, failure still saves, signal values correct
+- `TestSaveStateDirectUnit`: domContext field, response field, None response handling
+
+## Architecture Alignment
+
+- **ADR 0201 (Privacy-First):** 30-day TTL applies to new fields automatically
+- **ADR 0203 (Stateful Serverless):** Extends existing DynamoDB schema correctly
+- **LLD 1177:** 100KB cap on domContext per Gemini review
+- **LLD 1178:** try/finally pattern ensures save on failure per Gemini advisory
+
+## Files Modified
+
+| File | Change Type |
+|------|-------------|
+| `src/lambda_function.py` | Modified |
+| `tests/test_persistence.py` | Added |
+| `docs/reports/177/implementation-report.md` | Added |
+| `docs/reports/177/test-report.md` | Added |

--- a/docs/reports/177/test-report.md
+++ b/docs/reports/177/test-report.md
@@ -1,0 +1,48 @@
+# Test Report: Issue #177 & #178 - Data Persistence
+
+**Date:** 2026-01-06
+**Author:** Claude Opus 4.5
+**Issues:** #177, #178
+
+## Test Execution
+
+```
+poetry run pytest tests/ -v --ignore=tests/e2e
+============================= 184 passed in 7.44s =============================
+```
+
+## New Tests Added
+
+| Test | Status | Description |
+|------|--------|-------------|
+| `test_010_domcontext_stored` | PASS | domContext in input is saved to DynamoDB |
+| `test_020_missing_domcontext_defaults_empty` | PASS | Missing domContext defaults to empty string |
+| `test_030_large_domcontext_truncated` | PASS | >100KB domContext truncated to 100KB |
+| `test_010_response_stored` | PASS | AI response (signal, gem, context) saved |
+| `test_020_generation_failure_still_saves` | PASS | save_state runs in finally block on error |
+| `test_030_signal_values_stored_correctly` | PASS | green/yellow/orange/red signals stored |
+| `test_save_state_includes_domcontext` | PASS | Direct unit test for domContext field |
+| `test_save_state_includes_response` | PASS | Direct unit test for response field |
+| `test_save_state_handles_none_response` | PASS | None response serializes as "null" |
+
+## Regression Check
+
+All 184 existing tests continue to pass. No regressions introduced.
+
+## Coverage of LLD Requirements
+
+### LLD 1177 (domContext)
+- [x] Scenario 010: domContext stored - PASS
+- [x] Scenario 020: Missing domContext - PASS
+- [x] Scenario 030: Large domContext truncated - PASS
+
+### LLD 1178 (AI Response)
+- [x] Scenario 010: Response stored - PASS
+- [x] Scenario 020: Generation failure still saves - PASS
+- [x] Scenario 030: Signal values correct - PASS
+
+## Verification Command
+
+```bash
+poetry run pytest tests/test_persistence.py tests/test_lambda_handler.py -v
+```

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -130,6 +130,8 @@ def save_state(thread_id: str, data: dict) -> None:
 
     See: docs/1113-naked-python-architecture.md Section 7.2
     Issue #145: Added TTL for automatic data expiry.
+    Issue #177: Added domContext field for surrounding paragraph storage.
+    Issue #178: Added response field for AI etymology output storage.
     """
     client = get_dynamodb_client()
     now = int(time.time())
@@ -143,6 +145,19 @@ def save_state(thread_id: str, data: dict) -> None:
         "safety_score": {"S": json.dumps(data.get("safety_score", {}))},
         "ttl": {"N": str(now + TTL_SECONDS)},  # Issue #145: Auto-expire after 30 days
     }
+
+    # Issue #177: Store surrounding paragraph (domContext)
+    # Default to empty string if missing; truncate to 100KB for DynamoDB safety
+    dom_context = data.get("domContext", "") or ""
+    item["domContext"] = {"S": dom_context[:100000]}
+
+    # Issue #178: Store AI response (signal, gem, context)
+    # May be None if generation failed - serialize as JSON for flexibility
+    response_data = data.get("response")
+    if response_data is not None:
+        item["response"] = {"S": json.dumps(response_data)}
+    else:
+        item["response"] = {"S": "null"}
 
     # TODO: Issue #116 - Add user_id when LinkedIn Auth is implemented
     if data.get("userId"):
@@ -308,25 +323,59 @@ def lambda_handler(
         thread_id = generate_thread_id(body)
         timings["thread_id_ms"] = int((time.time() - t0) * 1000)
 
-        # 4. Persist to DynamoDB
-        t0 = time.time()
-        save_state(
-            thread_id,
-            {
-                "text": text,
-                "url": body.get("url", ""),
-                "userId": body.get("userId"),  # May be None pre-#116
-                "safety_score": metadata.get("scores", {}),
-            },
-        )
-        timings["dynamodb_write_ms"] = int((time.time() - t0) * 1000)
+        # Issue #177: Extract domContext (truncate to 100KB for DynamoDB safety)
+        dom_context = (body.get("domContext", "") or "")[:100000]
 
-        # 5. Generate etymology analysis (buffered, not streaming)
+        # 4. Generate etymology analysis (buffered, not streaming)
         # Issue #124: Digital Etymologist returns structured JSON
-        t0 = time.time()
-        context_text = body.get("domContext", "")
-        result = generate_etymology(text, context_text)
-        timings["etymology_generation_ms"] = int((time.time() - t0) * 1000)
+        # Issue #178: Wrapped in try/finally to ensure save_state always runs
+        response_data = None
+        result = None
+        generation_error = None
+
+        try:
+            t0 = time.time()
+            result = generate_etymology(text, dom_context)
+            timings["etymology_generation_ms"] = int((time.time() - t0) * 1000)
+
+            # Extract response data for persistence
+            response_data = {
+                "signal": result["response"]["signal"],
+                "gem": result["response"]["gem"],
+                "context": result["response"]["context"],
+            }
+        except Exception as e:
+            # Issue #178: Capture error state for debugging
+            generation_error = e
+            response_data = {
+                "signal": "error",
+                "gem": str(e),
+                "context": "Generation failed",
+            }
+            logger.error(f"Etymology generation failed: {e}")
+        finally:
+            # Issue #177 & #178: ALWAYS save - even on failure
+            # This ensures we know what input caused issues for post-mortem analysis
+            t0 = time.time()
+            save_state(
+                thread_id,
+                {
+                    "text": text,
+                    "domContext": dom_context,  # Issue #177
+                    "url": body.get("url", ""),
+                    "userId": body.get("userId"),  # May be None pre-#116
+                    "safety_score": metadata.get("scores", {}),
+                    "response": response_data,  # Issue #178
+                },
+            )
+            timings["dynamodb_write_ms"] = int((time.time() - t0) * 1000)
+
+        # If generation failed, return 500 after saving state
+        if generation_error is not None:
+            raise generation_error
+
+        # Type narrowing: if we reach here, generation succeeded and result is set
+        assert result is not None, "result should be set if no generation_error"
 
         # Calculate total handler time
         timings["handler_total_ms"] = int((time.time() - handler_start) * 1000)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,413 @@
+"""
+Unit tests for Data Persistence (Issues #177 & #178).
+
+Tests verify:
+- domContext is stored in DynamoDB (#177)
+- AI response (signal, gem, context) is stored (#178)
+- save_state is called even on generation failure (#178 resilience)
+
+See: docs/1177-store-domcontext.md, docs/1178-store-ai-response.md
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+from src.lambda_function import lambda_handler, save_state
+
+# Safe mock denylist - NO real slurs (Willison Protocol)
+MOCK_DENYLIST = {"test_block_term", "forbidden_fruit", "blocked_word"}
+
+
+class TestDomContextPersistence:
+    """
+    Tests for Issue #177: Store domContext in DynamoDB.
+
+    See: docs/1177-store-domcontext.md Section 11.1
+    """
+
+    def test_010_domcontext_stored(self):
+        """Scenario 010: domContext in input event is saved to DynamoDB."""
+        event = {
+            "text": "apple",
+            "domContext": "The apple fell from the tree in Newton's garden.",
+            "url": "https://example.com/article",
+        }
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, \
+             patch("src.lambda_function.get_dynamodb_client") as mock_dynamo, \
+             patch("src.lambda_function.get_bedrock_client") as mock_bedrock:
+
+            # Mock semantic to pass
+            mock_guard = MagicMock()
+            mock_guard.check_safety.return_value = {
+                "is_safe": True,
+                "reason": "None",
+                "scores": {},
+            }
+            mock_semantic.return_value = mock_guard
+
+            # Mock DynamoDB
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            # Mock Bedrock response
+            mock_response = {
+                "body": MagicMock(
+                    read=MagicMock(
+                        return_value=json.dumps({
+                            "content": [{
+                                "type": "text",
+                                "text": '{"signal": "green", "gem": "A fruit.", "context": "Newton apple."}',
+                            }]
+                        }).encode()
+                    )
+                )
+            }
+            mock_bedrock.return_value.invoke_model.return_value = mock_response
+
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+            assert result["statusCode"] == 200
+
+            # Verify DynamoDB put_item was called with domContext
+            mock_client.put_item.assert_called_once()
+            call_args = mock_client.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            assert "domContext" in item, "Item should have domContext field"
+            assert item["domContext"]["S"] == "The apple fell from the tree in Newton's garden."
+
+    def test_020_missing_domcontext_defaults_empty(self):
+        """Scenario 020: Missing domContext defaults to empty string (no error)."""
+        event = {
+            "text": "apple",
+            "url": "https://example.com/article",
+            # Note: no domContext field
+        }
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, \
+             patch("src.lambda_function.get_dynamodb_client") as mock_dynamo, \
+             patch("src.lambda_function.get_bedrock_client") as mock_bedrock:
+
+            mock_guard = MagicMock()
+            mock_guard.check_safety.return_value = {
+                "is_safe": True,
+                "reason": "None",
+                "scores": {},
+            }
+            mock_semantic.return_value = mock_guard
+
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            mock_response = {
+                "body": MagicMock(
+                    read=MagicMock(
+                        return_value=json.dumps({
+                            "content": [{
+                                "type": "text",
+                                "text": '{"signal": "green", "gem": "A fruit.", "context": "Common noun."}',
+                            }]
+                        }).encode()
+                    )
+                )
+            }
+            mock_bedrock.return_value.invoke_model.return_value = mock_response
+
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+            assert result["statusCode"] == 200
+
+            # Verify domContext is empty string, not missing or None
+            call_args = mock_dynamo.return_value.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            assert "domContext" in item, "Item should have domContext field even when missing from input"
+            assert item["domContext"]["S"] == ""
+
+    def test_030_large_domcontext_truncated(self):
+        """Scenario 030: Large domContext (>100KB) is truncated for DynamoDB safety."""
+        large_context = "x" * 150000  # 150KB - exceeds 100KB cap
+        event = {
+            "text": "apple",
+            "domContext": large_context,
+        }
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, \
+             patch("src.lambda_function.get_dynamodb_client") as mock_dynamo, \
+             patch("src.lambda_function.get_bedrock_client") as mock_bedrock:
+
+            mock_guard = MagicMock()
+            mock_guard.check_safety.return_value = {
+                "is_safe": True,
+                "reason": "None",
+                "scores": {},
+            }
+            mock_semantic.return_value = mock_guard
+
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            mock_response = {
+                "body": MagicMock(
+                    read=MagicMock(
+                        return_value=json.dumps({
+                            "content": [{
+                                "type": "text",
+                                "text": '{"signal": "green", "gem": "A fruit.", "context": "Test."}',
+                            }]
+                        }).encode()
+                    )
+                )
+            }
+            mock_bedrock.return_value.invoke_model.return_value = mock_response
+
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+            assert result["statusCode"] == 200
+
+            # Verify domContext is truncated to 100KB
+            call_args = mock_dynamo.return_value.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            stored_context = item["domContext"]["S"]
+            assert len(stored_context) == 100000, f"Expected 100KB, got {len(stored_context)}"
+
+
+class TestAIResponsePersistence:
+    """
+    Tests for Issue #178: Store AI response in DynamoDB.
+
+    See: docs/1178-store-ai-response.md Section 11.1
+    """
+
+    def test_010_response_stored(self):
+        """Scenario 010: AI response (signal, gem, context) is saved to DynamoDB."""
+        event = {"text": "apple"}
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, \
+             patch("src.lambda_function.get_dynamodb_client") as mock_dynamo, \
+             patch("src.lambda_function.get_bedrock_client") as mock_bedrock:
+
+            mock_guard = MagicMock()
+            mock_guard.check_safety.return_value = {
+                "is_safe": True,
+                "reason": "None",
+                "scores": {},
+            }
+            mock_semantic.return_value = mock_guard
+
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            # Mock specific response to verify it's stored
+            mock_response = {
+                "body": MagicMock(
+                    read=MagicMock(
+                        return_value=json.dumps({
+                            "content": [{
+                                "type": "text",
+                                "text": '{"signal": "green", "gem": "From Old English æppel.", "context": "Common fruit name."}',
+                            }]
+                        }).encode()
+                    )
+                )
+            }
+            mock_bedrock.return_value.invoke_model.return_value = mock_response
+
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+            assert result["statusCode"] == 200
+
+            # Verify response fields are stored
+            call_args = mock_dynamo.return_value.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            assert "response" in item, "Item should have response field"
+            # Response is stored as JSON string in DynamoDB
+            response_data = json.loads(item["response"]["S"])
+            assert response_data["signal"] == "green"
+            assert response_data["gem"] == "From Old English æppel."
+            assert response_data["context"] == "Common fruit name."
+
+    def test_020_generation_failure_still_saves(self):
+        """Scenario 020: Generation failure still saves input to DynamoDB (resilience)."""
+        event = {
+            "text": "problematic_term",
+            "domContext": "Some context here.",
+            "url": "https://example.com",
+        }
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, \
+             patch("src.lambda_function.get_dynamodb_client") as mock_dynamo, \
+             patch("src.lambda_function.generate_etymology") as mock_etymology:
+
+            mock_guard = MagicMock()
+            mock_guard.check_safety.return_value = {
+                "is_safe": True,
+                "reason": "None",
+                "scores": {},
+            }
+            mock_semantic.return_value = mock_guard
+
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            # Mock etymology to RAISE an exception
+            mock_etymology.side_effect = Exception("Bedrock timeout")
+
+            # Call handler - should return 500 but still save
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+            assert result["statusCode"] == 500
+
+            # CRITICAL: save_state MUST still be called even on failure
+            mock_client.put_item.assert_called_once()
+
+            call_args = mock_client.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            # Verify input data was saved
+            assert item["input"]["S"] == "problematic_term"
+            assert item["domContext"]["S"] == "Some context here."
+            assert item["url"]["S"] == "https://example.com"
+
+            # Verify error response was captured
+            assert "response" in item
+            response_data = json.loads(item["response"]["S"])
+            assert response_data["signal"] == "error"
+            assert "Bedrock timeout" in response_data["gem"]
+
+    def test_030_signal_values_stored_correctly(self):
+        """Scenario 030: Signal color values are stored correctly."""
+        test_cases = [
+            ("green", "Common Noun"),
+            ("yellow", "Archaic Term"),
+            ("orange", "Potential Issue"),
+            ("red", "Warning"),
+        ]
+
+        for expected_signal, signal_label in test_cases:
+            event = {"text": f"test_{expected_signal}"}
+
+            with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, \
+                 patch("src.lambda_function.get_dynamodb_client") as mock_dynamo, \
+                 patch("src.lambda_function.get_bedrock_client") as mock_bedrock:
+
+                mock_guard = MagicMock()
+                mock_guard.check_safety.return_value = {
+                    "is_safe": True,
+                    "reason": "None",
+                    "scores": {},
+                }
+                mock_semantic.return_value = mock_guard
+
+                mock_client = MagicMock()
+                mock_dynamo.return_value = mock_client
+
+                mock_response = {
+                    "body": MagicMock(
+                        read=MagicMock(
+                            return_value=json.dumps({
+                                "content": [{
+                                    "type": "text",
+                                    "text": f'{{"signal": "{expected_signal}", "gem": "{signal_label}", "context": "Test."}}',
+                                }]
+                            }).encode()
+                        )
+                    )
+                }
+                mock_bedrock.return_value.invoke_model.return_value = mock_response
+
+                result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+                assert result["statusCode"] == 200
+
+                call_args = mock_dynamo.return_value.put_item.call_args
+                item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+                response_data = json.loads(item["response"]["S"])
+                assert response_data["signal"] == expected_signal, \
+                    f"Expected signal '{expected_signal}', got '{response_data['signal']}'"
+
+
+class TestSaveStateDirectUnit:
+    """
+    Direct unit tests for save_state function with new fields.
+
+    Tests the function signature update for domContext and response.
+    """
+
+    def test_save_state_includes_domcontext(self):
+        """save_state correctly persists domContext field."""
+        with patch("src.lambda_function.get_dynamodb_client") as mock_dynamo:
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            save_state(
+                "test_thread_id",
+                {
+                    "text": "apple",
+                    "domContext": "The apple tree context.",
+                    "url": "https://example.com",
+                    "safety_score": {},
+                },
+            )
+
+            call_args = mock_client.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            assert "domContext" in item
+            assert item["domContext"]["S"] == "The apple tree context."
+
+    def test_save_state_includes_response(self):
+        """save_state correctly persists response field."""
+        with patch("src.lambda_function.get_dynamodb_client") as mock_dynamo:
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            save_state(
+                "test_thread_id",
+                {
+                    "text": "apple",
+                    "domContext": "",
+                    "url": "https://example.com",
+                    "safety_score": {},
+                    "response": {
+                        "signal": "green",
+                        "gem": "Etymology here.",
+                        "context": "Analysis context.",
+                    },
+                },
+            )
+
+            call_args = mock_client.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            assert "response" in item
+            response_data = json.loads(item["response"]["S"])
+            assert response_data["signal"] == "green"
+            assert response_data["gem"] == "Etymology here."
+
+    def test_save_state_handles_none_response(self):
+        """save_state handles None response gracefully (pre-generation save)."""
+        with patch("src.lambda_function.get_dynamodb_client") as mock_dynamo:
+            mock_client = MagicMock()
+            mock_dynamo.return_value = mock_client
+
+            save_state(
+                "test_thread_id",
+                {
+                    "text": "apple",
+                    "domContext": "",
+                    "url": "https://example.com",
+                    "safety_score": {},
+                    "response": None,
+                },
+            )
+
+            call_args = mock_client.put_item.call_args
+            item = call_args.kwargs.get("Item") or call_args[1].get("Item")
+
+            # response field should still exist with null/empty marker
+            assert "response" in item
+            assert item["response"]["S"] == "null" or item["response"]["S"] == "{}"


### PR DESCRIPTION
## Summary
- Store surrounding paragraph (`domContext`) in DynamoDB for analytics (#177)
- Store AI etymology response (signal, gem, context) for quality monitoring (#178)
- Refactored `lambda_handler` with try/except/finally to ensure save on failure

## Changes
- `save_state()` now includes `domContext` (100KB cap) and `response` fields
- `generate_etymology()` wrapped in try/finally - save_state always executes
- Error states captured with `signal="error"` for post-mortem debugging

## Test plan
- [x] 9 new unit tests in `tests/test_persistence.py`
- [x] All 184 tests pass
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)