### PR TITLE
feat(privacy): implement NoArchive transform layer (close #162)

### DIFF
--- a/docs/reports/162/implementation-report.md
+++ b/docs/reports/162/implementation-report.md
@@ -1,0 +1,91 @@
+# Implementation Report: Issue #162 - NoArchive Transform Layer
+
+**Issue:** #162
+**Date:** 2026-01-07
+**Author:** Claude Opus 4.5
+**Status:** Complete
+
+---
+
+## Summary
+
+Implemented the NoArchive Transform Layer to respect publisher `<meta name="robots" content="noarchive">` signals. When this signal is present, Aletheia generates the etymology response for the user but does NOT persist the query or response to DynamoDB.
+
+**Key Principle:** Generate but don't persist. The user still receives their analysis - we just don't store it.
+
+---
+
+## Changes Made
+
+### 1. Extension: content-check.js
+
+Added `checkNoArchive()` function that:
+- Queries both `<meta name="robots">` and `<meta name="googlebot">` tags
+- Returns `true` if either contains "noarchive" directive
+- Handles comma-separated directive lists (e.g., "noindex, noarchive")
+
+Updated `checkPageSignals()` to return combined result including `noarchive` boolean.
+
+**Lines changed:** 67-112
+
+### 2. Extension: service-worker.js
+
+- Added `tabNoArchive` Map to store noarchive signals per tab (line 27)
+- Updated `checkTabForAgeRestriction()` to extract and store noarchive signal (lines 61-65)
+- Added cleanup on tab close (line 133)
+- Updated payload to include `signals: { noarchive: boolean }` (lines 317-328)
+
+### 3. Lambda: lambda_function.py
+
+- Added signal extraction: `signals = body.get("signals", {})` (line 330)
+- Added skip flag: `skip_persistence = signals.get("noarchive", False)` (line 331)
+- Modified `finally` block to conditionally call `save_state()` (lines 360-381)
+- Added logging when skipping: `NOARCHIVE: Skipping persistence for thread_id=...`
+
+---
+
+## Files Changed
+
+| File | Lines | Change |
+|------|-------|--------|
+| `extensions/chrome/content-check.js` | +47 | Added `checkNoArchive()` and `checkPageSignals()` |
+| `extensions/chrome/service-worker.js` | +15 | Store/send noarchive signal |
+| `src/lambda_function.py` | +12 | Conditional persistence skip |
+| `tests/test_noarchive.py` | +230 | New test file (5 tests) |
+| `tests/fixtures/html/test-noarchive.html` | +57 | Test fixture |
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│     Page        │     │   Extension     │     │     Lambda      │
+│                 │     │                 │     │                 │
+│ <meta robots    │────▶│ checkNoArchive()│────▶│ if noarchive:   │
+│  noarchive>     │     │ signals.noarchive│     │   skip save_state│
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                                                         │
+                                                         ▼
+                                                ┌─────────────────┐
+                                                │  User sees      │
+                                                │  etymology      │
+                                                │  (no DynamoDB)  │
+                                                └─────────────────┘
+```
+
+---
+
+## Security Notes
+
+- **Client can lie:** A malicious client could always send `noarchive=true`. This is acceptable - it's a "fail-safe" state (less persistence, not more).
+- **No PII in logs:** The skip event is logged but NOT the content that was skipped.
+- **Rollback risk:** Rolling back this feature means ignoring publisher signals, which has compliance implications.
+
+---
+
+## Verification
+
+1. All 5 new unit tests pass
+2. All 189 existing tests pass (no regressions)
+3. CloudWatch logs will show `NOARCHIVE: Skipping persistence` when triggered

--- a/docs/reports/162/test-report.md
+++ b/docs/reports/162/test-report.md
@@ -1,0 +1,104 @@
+# Test Report: Issue #162 - NoArchive Transform Layer
+
+**Issue:** #162
+**Date:** 2026-01-07
+**Author:** Claude Opus 4.5
+**Status:** All Tests Passing
+
+---
+
+## Test Summary
+
+| Category | Tests | Status |
+|----------|-------|--------|
+| New NoArchive Tests | 5 | PASS |
+| Existing Tests | 184 | PASS |
+| **Total** | **189** | **PASS** |
+
+---
+
+## New Tests (tests/test_noarchive.py)
+
+### TestNoArchiveSkipsPersistence
+
+| Test | Description | Result |
+|------|-------------|--------|
+| `test_noarchive_true_skips_save_state` | When `signals.noarchive=True`, DynamoDB `put_item` is NOT called | PASS |
+| `test_no_signals_persists_to_dynamodb` | When no signals provided, DynamoDB IS called | PASS |
+| `test_noarchive_false_persists_to_dynamodb` | When `signals.noarchive=False`, DynamoDB IS called | PASS |
+| `test_noarchive_empty_signals_persists` | When `signals={}`, DynamoDB IS called | PASS |
+| `test_response_structure_same_regardless_of_noarchive` | Response structure identical whether noarchive is True/False | PASS |
+
+---
+
+## Test Evidence
+
+```
+============================= test session starts =============================
+platform win32 -- Python 3.12.10, pytest-9.0.1, pluggy-1.6.0
+plugins: anyio-4.11.0, langsmith-0.4.46, cov-7.0.0
+
+tests/test_noarchive.py::TestNoArchiveSkipsPersistence::test_noarchive_true_skips_save_state PASSED
+tests/test_noarchive.py::TestNoArchiveSkipsPersistence::test_no_signals_persists_to_dynamodb PASSED
+tests/test_noarchive.py::TestNoArchiveSkipsPersistence::test_noarchive_false_persists_to_dynamodb PASSED
+tests/test_noarchive.py::TestNoArchiveSkipsPersistence::test_noarchive_empty_signals_persists PASSED
+tests/test_noarchive.py::TestNoArchiveSkipsPersistence::test_response_structure_same_regardless_of_noarchive PASSED
+
+============================= 5 passed in 0.41s ===============================
+```
+
+---
+
+## Full Regression Suite
+
+```
+============================= 189 passed in 7.92s =============================
+```
+
+No regressions in existing tests.
+
+---
+
+## Test Fixtures
+
+Created `tests/fixtures/html/test-noarchive.html` for manual/E2E testing:
+- Contains `<meta name="robots" content="noarchive">`
+- Includes test words and expected behavior documentation
+- Can be loaded locally to verify extension behavior
+
+---
+
+## Manual Verification Steps
+
+1. Load `tests/fixtures/html/test-noarchive.html` in Chrome
+2. Enable Aletheia on localhost (add to allowlist)
+3. Select a word, trigger "Explain with AI"
+4. Verify overlay shows etymology result
+5. Check CloudWatch logs for `NOARCHIVE: Skipping persistence`
+6. Verify no record in DynamoDB for that request
+
+---
+
+## Coverage Areas
+
+| Area | Covered |
+|------|---------|
+| Lambda signal extraction | YES |
+| Conditional save_state skip | YES |
+| Response structure unchanged | YES |
+| Default behavior (no signals) | YES |
+| Explicit false behavior | YES |
+| Empty signals object | YES |
+| Extension meta tag detection | FIXTURE (manual) |
+| E2E browser test | FIXTURE (manual) |
+
+---
+
+## Recommendations
+
+For full E2E coverage, consider adding a Playwright test that:
+1. Loads the HTML fixture
+2. Injects content-check.js
+3. Verifies `noarchive: true` in returned signals
+
+This would automate the manual verification steps above.

--- a/extensions/chrome/content-check.js
+++ b/extensions/chrome/content-check.js
@@ -1,9 +1,11 @@
 /**
- * content-check.js - DOM wrapper for age-restricted content detection
+ * content-check.js - DOM wrapper for page signal detection
  * Issue #104 - Age-Restricted Blocking
+ * Issue #162 - NoArchive Transform Layer
  *
- * This script is injected into web pages to check for age-restriction meta tags.
- * It queries the DOM and uses the pure logic from content-safety.js.
+ * This script is injected into web pages to check for meta tags:
+ * - Age restriction (rating meta tag)
+ * - NoArchive signal (robots/googlebot meta tags)
  *
  * Execution context: Content script (runs in page context)
  * Returns: Result object sent back to service worker via scripting.executeScript
@@ -62,5 +64,49 @@ function isAgeRestrictedInline(ratingContent) {
     return false;
 }
 
+/**
+ * Check if the page has a noarchive signal in robots or googlebot meta tags.
+ * Issue #162 - NoArchive Transform Layer
+ *
+ * Checks both:
+ * - <meta name="robots" content="noarchive">
+ * - <meta name="googlebot" content="noarchive">
+ *
+ * The noarchive directive can appear alone or with other directives (comma-separated).
+ *
+ * @returns {boolean} True if noarchive signal is present
+ */
+function checkNoArchive() {
+    // Query for both robots and googlebot meta tags
+    const metas = document.querySelectorAll('meta[name="robots"], meta[name="googlebot"]');
+
+    for (const meta of metas) {
+        const content = meta.getAttribute('content') || '';
+        // noarchive can appear alone or comma-separated with other directives
+        if (content.toLowerCase().includes('noarchive')) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Check all page signals and return combined result.
+ * This is the main entry point when the script is injected.
+ *
+ * @returns {Object} Result object with all signal checks
+ */
+function checkPageSignals() {
+    const ratingResult = checkPageRating();
+
+    return {
+        type: 'PAGE_SIGNALS',
+        isRestricted: ratingResult.isRestricted,
+        ratingValue: ratingResult.ratingValue,
+        noarchive: checkNoArchive()
+    };
+}
+
 // Execute and return result when script is injected
-checkPageRating();
+checkPageSignals();

--- a/extensions/chrome/service-worker.js
+++ b/extensions/chrome/service-worker.js
@@ -23,6 +23,9 @@ const TabState = {
 // In-memory tab states (no persistence - privacy by design)
 const tabStates = new Map();
 
+// Issue #162: Store noarchive signals per tab
+const tabNoArchive = new Map();
+
 /**
  * Check if a URL should be checked for age-restricted content.
  * Only check navigable web pages (http/https).
@@ -33,12 +36,15 @@ function shouldCheckTab(url) {
 }
 
 /**
- * Check a tab for age-restricted content by injecting content-check.js
+ * Check a tab for age-restricted content and noarchive signal by injecting content-check.js
+ * Issue #104: Age-Restricted Blocking
+ * Issue #162: NoArchive Transform Layer
  */
 async function checkTabForAgeRestriction(tabId, url) {
     if (!shouldCheckTab(url)) {
         // Non-web pages are allowed (chrome://, file://, etc.)
         tabStates.set(tabId, TabState.ALLOWED);
+        tabNoArchive.set(tabId, false);
         return;
     }
 
@@ -49,8 +55,14 @@ async function checkTabForAgeRestriction(tabId, url) {
             files: ['content-check.js']
         });
 
-        // The script returns the result from checkPageRating()
+        // The script returns the result from checkPageSignals()
         const result = results?.[0]?.result;
+
+        // Issue #162: Store noarchive signal
+        tabNoArchive.set(tabId, result?.noarchive || false);
+        if (result?.noarchive) {
+            console.log(`[Aletheia] NoArchive signal detected on tab ${tabId}`);
+        }
 
         if (result?.isRestricted) {
             tabStates.set(tabId, TabState.RESTRICTED);
@@ -63,6 +75,7 @@ async function checkTabForAgeRestriction(tabId, url) {
     } catch (error) {
         // FAIL OPEN: If we can't inject (CSP, etc.), allow the tab
         tabStates.set(tabId, TabState.ALLOWED);
+        tabNoArchive.set(tabId, false);
         console.log(`[Aletheia] Tab ${tabId} check failed (fail open):`, error.message);
     }
 }
@@ -117,6 +130,7 @@ function isTabRestricted(tabId) {
 // Clean up state when tabs close (memory hygiene)
 chrome.tabs.onRemoved.addListener((tabId) => {
     tabStates.delete(tabId);
+    tabNoArchive.delete(tabId);  // Issue #162
 });
 
 // =============================================================================
@@ -300,11 +314,17 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
         const fullPageText = injectionResults[0].result;
 
+        // Issue #162: Include noarchive signal in payload
+        const hasNoArchive = tabNoArchive.get(tab.id) || false;
+
         const payload = {
             text: info.selectionText,
             url: info.pageUrl,
             title: tab.title,
-            domContext: fullPageText
+            domContext: fullPageText,
+            signals: {
+                noarchive: hasNoArchive
+            }
         };
 
         console.log("[Aletheia] Sending payload to AWS:", payload.text);

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -326,6 +326,10 @@ def lambda_handler(
         # Issue #177: Extract domContext (truncate to 100KB for DynamoDB safety)
         dom_context = (body.get("domContext", "") or "")[:100000]
 
+        # Issue #162: Extract noarchive signal - skip persistence if publisher requests
+        signals = body.get("signals", {})
+        skip_persistence = signals.get("noarchive", False)
+
         # 4. Generate etymology analysis (buffered, not streaming)
         # Issue #124: Digital Etymologist returns structured JSON
         # Issue #178: Wrapped in try/finally to ensure save_state always runs
@@ -354,21 +358,27 @@ def lambda_handler(
             }
             logger.error(f"Etymology generation failed: {e}")
         finally:
-            # Issue #177 & #178: ALWAYS save - even on failure
-            # This ensures we know what input caused issues for post-mortem analysis
-            t0 = time.time()
-            save_state(
-                thread_id,
-                {
-                    "text": text,
-                    "domContext": dom_context,  # Issue #177
-                    "url": body.get("url", ""),
-                    "userId": body.get("userId"),  # May be None pre-#116
-                    "safety_score": metadata.get("scores", {}),
-                    "response": response_data,  # Issue #178
-                },
-            )
-            timings["dynamodb_write_ms"] = int((time.time() - t0) * 1000)
+            # Issue #162: Skip persistence if noarchive signal is present
+            if skip_persistence:
+                logger.info(
+                    f"NOARCHIVE: Skipping persistence for thread_id={thread_id}"
+                )
+                timings["dynamodb_write_ms"] = 0  # No write performed
+            else:
+                # Issue #177 & #178: Save state for analysis
+                t0 = time.time()
+                save_state(
+                    thread_id,
+                    {
+                        "text": text,
+                        "domContext": dom_context,  # Issue #177
+                        "url": body.get("url", ""),
+                        "userId": body.get("userId"),  # May be None pre-#116
+                        "safety_score": metadata.get("scores", {}),
+                        "response": response_data,  # Issue #178
+                    },
+                )
+                timings["dynamodb_write_ms"] = int((time.time() - t0) * 1000)
 
         # If generation failed, return 500 after saving state
         if generation_error is not None:

--- a/tests/fixtures/html/test-noarchive.html
+++ b/tests/fixtures/html/test-noarchive.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NoArchive Test Page - Issue #162</title>
+
+    <!--
+        Issue #162: NoArchive Transform Layer Test Fixture
+
+        This page includes the noarchive directive in the robots meta tag.
+        When Aletheia processes text from this page, it should NOT persist
+        the query or response to DynamoDB.
+
+        Test scenarios:
+        1. robots with noarchive alone
+        2. robots with noarchive + other directives
+        3. googlebot variant (comment out robots to test)
+    -->
+
+    <!-- Standard robots noarchive directive -->
+    <meta name="robots" content="noarchive">
+
+    <!-- Alternative: noarchive with other directives (comma-separated) -->
+    <!-- <meta name="robots" content="noindex, noarchive, nofollow"> -->
+
+    <!-- Alternative: Google-specific variant -->
+    <!-- <meta name="googlebot" content="noarchive"> -->
+
+</head>
+<body>
+    <h1>NoArchive Test Page</h1>
+
+    <p>This page has a <code>&lt;meta name="robots" content="noarchive"&gt;</code> tag.</p>
+
+    <p>
+        When you select text on this page and use "Explain with AI", the extension
+        should detect the noarchive signal and include <code>signals.noarchive: true</code>
+        in the payload sent to Lambda.
+    </p>
+
+    <h2>Test Words</h2>
+    <p>Select one of these words to test:</p>
+    <ul>
+        <li><strong>Etymology</strong> - The study of word origins</li>
+        <li><strong>Serendipity</strong> - Finding something good without looking for it</li>
+        <li><strong>Ephemeral</strong> - Lasting for a very short time</li>
+    </ul>
+
+    <h2>Expected Behavior</h2>
+    <ol>
+        <li>Extension detects <code>noarchive</code> meta tag</li>
+        <li>Payload includes <code>signals: { noarchive: true }</code></li>
+        <li>Lambda generates etymology (user sees result)</li>
+        <li>Lambda does NOT call <code>save_state()</code></li>
+        <li>No record in DynamoDB</li>
+    </ol>
+
+    <h2>Verification</h2>
+    <p>Check CloudWatch logs for: <code>NOARCHIVE: Skipping persistence for thread_id=...</code></p>
+</body>
+</html>

--- a/tests/test_noarchive.py
+++ b/tests/test_noarchive.py
@@ -1,0 +1,266 @@
+"""
+Unit tests for NoArchive Transform Layer (Issue #162).
+
+See: docs/1162-noarchive-transform.md
+
+Tests verify that the noarchive signal correctly skips DynamoDB persistence
+while still returning the etymology analysis to the user.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+
+from src.lambda_function import lambda_handler
+
+
+# Safe mock denylist - NO real slurs
+MOCK_DENYLIST = {"test_block_term"}
+
+
+def make_mock_context():
+    """Create a mock Lambda context object."""
+    ctx = MagicMock()
+    ctx.function_name = "test-lambda"
+    ctx.memory_limit_in_mb = 128
+    ctx.invoked_function_arn = "arn:aws:lambda:us-east-1:123456789:function:test"
+    ctx.aws_request_id = "test-request-id"
+    return ctx
+
+
+def make_event(text: str, signals: dict | None = None) -> dict:
+    """Create a Lambda event with optional signals."""
+    body: dict[str, str | dict] = {
+        "text": text,
+        "url": "https://example.com/test",
+        "title": "Test Page",
+        "domContext": "Some context text",
+    }
+    if signals is not None:
+        body["signals"] = signals
+
+    return {"body": json.dumps(body)}
+
+
+class TestNoArchiveSkipsPersistence:
+    """Tests for Issue #162: NoArchive signal skips DynamoDB persistence."""
+
+    @patch("src.lambda_function.get_dynamodb_client")
+    @patch("src.lambda_function.get_semantic_guardrail")
+    @patch("src.lambda_function.analyze_term")
+    def test_noarchive_true_skips_save_state(
+        self, mock_analyze, mock_semantic, mock_dynamodb
+    ):
+        """When signals.noarchive=True, save_state is NOT called."""
+        # Setup mocks
+        mock_semantic_guard = MagicMock()
+        mock_semantic_guard.check_safety.return_value = {
+            "is_safe": True,
+            "reason": "None",
+            "scores": {},
+        }
+        mock_semantic.return_value = mock_semantic_guard
+
+        mock_analyze.return_value = {
+            "status": "success",
+            "response": {
+                "signal": "Test Signal",
+                "gem": "Test etymology",
+                "context": "Test context",
+            },
+            "metadata": {"latency_ms": 100},
+        }
+
+        mock_db_client = MagicMock()
+        mock_dynamodb.return_value = mock_db_client
+
+        # Call with noarchive=True
+        event = make_event("apple", signals={"noarchive": True})
+        response = lambda_handler(event, make_mock_context(), denylist=MOCK_DENYLIST)
+
+        # Verify response is still returned
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["signal"] == "Test Signal"
+        assert body["gem"] == "Test etymology"
+
+        # Verify DynamoDB put_item was NOT called
+        mock_db_client.put_item.assert_not_called()
+
+    @patch("src.lambda_function.get_dynamodb_client")
+    @patch("src.lambda_function.get_semantic_guardrail")
+    @patch("src.lambda_function.analyze_term")
+    def test_no_signals_persists_to_dynamodb(
+        self, mock_analyze, mock_semantic, mock_dynamodb
+    ):
+        """When no signals provided, save_state IS called."""
+        # Setup mocks
+        mock_semantic_guard = MagicMock()
+        mock_semantic_guard.check_safety.return_value = {
+            "is_safe": True,
+            "reason": "None",
+            "scores": {},
+        }
+        mock_semantic.return_value = mock_semantic_guard
+
+        mock_analyze.return_value = {
+            "status": "success",
+            "response": {
+                "signal": "Test Signal",
+                "gem": "Test etymology",
+                "context": "Test context",
+            },
+            "metadata": {"latency_ms": 100},
+        }
+
+        mock_db_client = MagicMock()
+        mock_dynamodb.return_value = mock_db_client
+
+        # Call without signals
+        event = make_event("apple")
+        response = lambda_handler(event, make_mock_context(), denylist=MOCK_DENYLIST)
+
+        # Verify response is returned
+        assert response["statusCode"] == 200
+
+        # Verify DynamoDB put_item WAS called
+        mock_db_client.put_item.assert_called_once()
+
+    @patch("src.lambda_function.get_dynamodb_client")
+    @patch("src.lambda_function.get_semantic_guardrail")
+    @patch("src.lambda_function.analyze_term")
+    def test_noarchive_false_persists_to_dynamodb(
+        self, mock_analyze, mock_semantic, mock_dynamodb
+    ):
+        """When signals.noarchive=False, save_state IS called."""
+        # Setup mocks
+        mock_semantic_guard = MagicMock()
+        mock_semantic_guard.check_safety.return_value = {
+            "is_safe": True,
+            "reason": "None",
+            "scores": {},
+        }
+        mock_semantic.return_value = mock_semantic_guard
+
+        mock_analyze.return_value = {
+            "status": "success",
+            "response": {
+                "signal": "Test Signal",
+                "gem": "Test etymology",
+                "context": "Test context",
+            },
+            "metadata": {"latency_ms": 100},
+        }
+
+        mock_db_client = MagicMock()
+        mock_dynamodb.return_value = mock_db_client
+
+        # Call with noarchive=False (explicit)
+        event = make_event("apple", signals={"noarchive": False})
+        response = lambda_handler(event, make_mock_context(), denylist=MOCK_DENYLIST)
+
+        # Verify response is returned
+        assert response["statusCode"] == 200
+
+        # Verify DynamoDB put_item WAS called
+        mock_db_client.put_item.assert_called_once()
+
+    @patch("src.lambda_function.get_dynamodb_client")
+    @patch("src.lambda_function.get_semantic_guardrail")
+    @patch("src.lambda_function.analyze_term")
+    def test_noarchive_empty_signals_persists(
+        self, mock_analyze, mock_semantic, mock_dynamodb
+    ):
+        """When signals={} (empty), save_state IS called."""
+        # Setup mocks
+        mock_semantic_guard = MagicMock()
+        mock_semantic_guard.check_safety.return_value = {
+            "is_safe": True,
+            "reason": "None",
+            "scores": {},
+        }
+        mock_semantic.return_value = mock_semantic_guard
+
+        mock_analyze.return_value = {
+            "status": "success",
+            "response": {
+                "signal": "Test Signal",
+                "gem": "Test etymology",
+                "context": "Test context",
+            },
+            "metadata": {"latency_ms": 100},
+        }
+
+        mock_db_client = MagicMock()
+        mock_dynamodb.return_value = mock_db_client
+
+        # Call with empty signals
+        event = make_event("apple", signals={})
+        response = lambda_handler(event, make_mock_context(), denylist=MOCK_DENYLIST)
+
+        # Verify response is returned
+        assert response["statusCode"] == 200
+
+        # Verify DynamoDB put_item WAS called
+        mock_db_client.put_item.assert_called_once()
+
+    @patch("src.lambda_function.get_dynamodb_client")
+    @patch("src.lambda_function.get_semantic_guardrail")
+    @patch("src.lambda_function.analyze_term")
+    def test_response_structure_same_regardless_of_noarchive(
+        self, mock_analyze, mock_semantic, mock_dynamodb
+    ):
+        """Response structure is identical whether noarchive is True or False."""
+        # Setup mocks
+        mock_semantic_guard = MagicMock()
+        mock_semantic_guard.check_safety.return_value = {
+            "is_safe": True,
+            "reason": "None",
+            "scores": {},
+        }
+        mock_semantic.return_value = mock_semantic_guard
+
+        mock_analyze.return_value = {
+            "status": "success",
+            "response": {
+                "signal": "Test Signal",
+                "gem": "Test etymology",
+                "context": "Test context",
+            },
+            "metadata": {"latency_ms": 100},
+        }
+
+        mock_db_client = MagicMock()
+        mock_dynamodb.return_value = mock_db_client
+
+        # Call with noarchive=True
+        event_noarchive = make_event("apple", signals={"noarchive": True})
+        response_noarchive = lambda_handler(
+            event_noarchive, make_mock_context(), denylist=MOCK_DENYLIST
+        )
+
+        # Reset mock for second call
+        mock_db_client.reset_mock()
+
+        # Call without noarchive
+        event_normal = make_event("apple")
+        response_normal = lambda_handler(
+            event_normal, make_mock_context(), denylist=MOCK_DENYLIST
+        )
+
+        # Both should return 200
+        assert response_noarchive["statusCode"] == 200
+        assert response_normal["statusCode"] == 200
+
+        # Both should have same response structure
+        body_noarchive = json.loads(response_noarchive["body"])
+        body_normal = json.loads(response_normal["body"])
+
+        assert "signal" in body_noarchive
+        assert "gem" in body_noarchive
+        assert "context" in body_noarchive
+        assert "thread_id" in body_noarchive
+
+        assert "signal" in body_normal
+        assert "gem" in body_normal
+        assert "context" in body_normal
+        assert "thread_id" in body_normal


### PR DESCRIPTION
## Summary

- Implements "Good Citizen" compliance by respecting publisher `noarchive` signals
- Extension detects `<meta name="robots" content="noarchive">` and `<meta name="googlebot" content="noarchive">`
- Lambda skips `save_state()` when signal is present (user still gets etymology)

## Test plan

- [x] 5 new unit tests in `tests/test_noarchive.py`
- [x] All 189 tests pass
- [x] HTML fixture for manual testing
- [ ] CloudWatch verification: look for `NOARCHIVE: Skipping persistence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)