### PR TITLE
feat: implement hard vs soft blocking logic (close #126)

### DIFF
--- a/src/guardrails/semantic.py
+++ b/src/guardrails/semantic.py
@@ -1,3 +1,14 @@
+"""
+Semantic Guardrail - LLM-based content classification.
+
+Issue #126: Implements Hard vs. Soft Blocking Logic.
+See: docs/1126-hard-soft-blocking.md
+
+Block Types:
+- "hard": Safety violations (Hate) - 403 Forbidden
+- "soft": Educational warnings (Archaic, Provocative) - 200 with warning
+- "none": Safe content (None, Neologism, Formal) - 200 OK
+"""
 import json
 import logging
 import time
@@ -6,6 +17,16 @@ from pathlib import Path
 from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
+
+# Issue #126: Block type constants
+BLOCK_TYPE_HARD = "hard"
+BLOCK_TYPE_SOFT = "soft"
+BLOCK_TYPE_NONE = "none"
+
+# Issue #126: Category to block type mapping (from LLD 1126 Section 2.1)
+HARD_BLOCK_CATEGORIES = {"Hate"}  # Safety violations - immediate 403
+SOFT_BLOCK_CATEGORIES = {"Archaic", "Provocative"}  # Educational warnings - 200 with warning
+# All other categories (None, Neologism, Formal Academic Term, etc.) = BLOCK_TYPE_NONE
 
 class SemanticGuardrail:
     """
@@ -64,7 +85,15 @@ class SemanticGuardrail:
     def check_safety(self, text: str) -> Dict[str, Any]:
         """
         Analyzes text for safety violations using AWS Bedrock.
-        Returns: {'is_safe': bool, 'reason': str, 'scores': dict}
+
+        Issue #126: Returns block_type instead of is_safe boolean.
+
+        Returns: {
+            'block_type': 'hard' | 'soft' | 'none',
+            'category': str,
+            'scores': dict,
+            'is_safe': bool  # Backwards compatibility
+        }
 
         Security: User text is wrapped in XML tags to prevent prompt injection.
         See: docs/0809-audit-security.md Finding F1
@@ -111,19 +140,45 @@ class SemanticGuardrail:
             # Issue #137: Log semantic guardrail timing breakdown
             logger.info(f"SEMANTIC_GUARDRAIL_TIMING: {json.dumps(timings)}")
 
-            # Deterministic Policy Enforcement (Code > LLM)
-            # "None" and "Neologism" are Safe. Others are Unsafe.
-            unsafe_categories = ["Archaic", "Provocative", "Hate"]
-            is_safe = category not in unsafe_categories
+            # Issue #126: Deterministic Policy Enforcement (Code > LLM)
+            # Map category to block type per LLD 1126 Section 2.1
+            block_type = self._get_block_type(category)
 
             return {
-                "is_safe": is_safe,
-                "reason": category,
-                "scores": scores
+                "block_type": block_type,
+                "category": category,
+                "scores": scores,
+                # Backwards compatibility: is_safe is True only for BLOCK_TYPE_NONE
+                "is_safe": block_type == BLOCK_TYPE_NONE,
+                "reason": category,  # Legacy field
             }
 
         except Exception as e:
             timings["total_ms"] = int((time.time() - start) * 1000)
             logger.info(f"SEMANTIC_GUARDRAIL_TIMING (error): {json.dumps(timings)}")
-            # Fail closed on infrastructure error
-            return {"is_safe": False, "reason": f"Guardrail Error: {str(e)}", "scores": {}}
+            # Fail closed on infrastructure error - treat as soft block with fallback
+            # (Per LLD 1126: semantic errors → soft block, not hard block)
+            return {
+                "block_type": BLOCK_TYPE_SOFT,
+                "category": "error",
+                "scores": {},
+                "is_safe": False,
+                "reason": f"Guardrail Error: {str(e)}",
+                "is_fallback": True,
+            }
+
+    def _get_block_type(self, category: str) -> str:
+        """
+        Map semantic category to block type.
+
+        Issue #126: Per LLD 1126 Category Mapping Matrix.
+
+        Returns:
+            BLOCK_TYPE_HARD, BLOCK_TYPE_SOFT, or BLOCK_TYPE_NONE
+        """
+        if category in HARD_BLOCK_CATEGORIES:
+            return BLOCK_TYPE_HARD
+        elif category in SOFT_BLOCK_CATEGORIES:
+            return BLOCK_TYPE_SOFT
+        else:
+            return BLOCK_TYPE_NONE

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -24,7 +24,12 @@ from botocore.exceptions import ClientError
 
 from .etymologist import HAIKU_MODEL_ID, AnalysisResult, analyze_term
 from .guardrails.denylist import check_denylist, load_denylist
-from .guardrails.semantic import SemanticGuardrail
+from .guardrails.semantic import (
+    SemanticGuardrail,
+    BLOCK_TYPE_HARD,
+    BLOCK_TYPE_SOFT,
+    BLOCK_TYPE_NONE,
+)
 
 # Issue #7: Observability tracing (imported after boto3 so patch_all works)
 from .observability import create_subsegment, log_bedrock_metrics, trace_bedrock_call
@@ -222,10 +227,11 @@ def generate_etymology(word: str, context: str = "") -> AnalysisResult:
 
 def run_guardrails(
     text: str, denylist: set[str] | None = None
-) -> tuple[bool, str | None, dict]:
+) -> tuple[str, str | None, dict]:
     """
     Run guardrail pipeline: Denylist → Semantic.
 
+    Issue #126: Returns block_type instead of is_safe boolean.
     CRITICAL: Sequential execution is mandatory. See LLD Section 6.
 
     Args:
@@ -233,20 +239,27 @@ def run_guardrails(
         denylist: Optional denylist for testing (dependency injection).
 
     Returns:
-        (is_safe, block_reason, metadata)
+        (block_type, category, metadata)
+        - block_type: "hard", "soft", or "none"
+        - category: The semantic category (e.g., "Archaic", "None")
+        - metadata: Timing and scoring information
     """
     # Issue #137: Track individual guardrail timings
     guardrail_timings = {}
 
-    # Step 1: Denylist check (fast, deterministic)
+    # Step 1: Denylist check (fast, deterministic) → ALWAYS hard block
     t0 = time.time()
     denylist_result = check_denylist(text, denylist)
     guardrail_timings["denylist_ms"] = int((time.time() - t0) * 1000)
     if denylist_result["blocked"]:
-        return False, "Content blocked by safety filter", {"layer": "denylist", "timings": guardrail_timings}
+        return (
+            BLOCK_TYPE_HARD,
+            "denylist",
+            {"layer": "denylist", "timings": guardrail_timings},
+        )
 
     # Step 2: Semantic check (LLM-based, slower)
-    # MUST run after denylist, MUST block before generation
+    # MUST run after denylist, returns block_type for nuanced handling
     t0 = time.time()
     semantic = get_semantic_guardrail()
     guardrail_timings["semantic_init_ms"] = int((time.time() - t0) * 1000)
@@ -258,14 +271,20 @@ def run_guardrails(
     # Issue #137: Log guardrail breakdown
     logger.info(f"GUARDRAIL_BREAKDOWN: {json.dumps(guardrail_timings)}")
 
-    if not semantic_result["is_safe"]:
-        return (
-            False,
-            f"Content blocked: {semantic_result['reason']}",
-            {"layer": "semantic", "scores": semantic_result.get("scores", {}), "timings": guardrail_timings},
-        )
+    # Issue #126: Return block_type from semantic guardrail
+    block_type = semantic_result.get("block_type", BLOCK_TYPE_NONE)
+    category = semantic_result.get("category", "Unknown")
 
-    return True, None, {"layer": "passed", "scores": semantic_result.get("scores", {}), "timings": guardrail_timings}
+    return (
+        block_type,
+        category,
+        {
+            "layer": "semantic",
+            "scores": semantic_result.get("scores", {}),
+            "timings": guardrail_timings,
+            "is_fallback": semantic_result.get("is_fallback", False),
+        },
+    )
 
 
 def lambda_handler(
@@ -311,11 +330,22 @@ def lambda_handler(
         text = body["text"]
 
         # 2. Guardrails (MUST be sequential: Denylist → Semantic)
+        # Issue #126: Returns block_type for nuanced handling
         t0 = time.time()
-        is_safe, block_reason, metadata = run_guardrails(text, denylist)
+        block_type, category, metadata = run_guardrails(text, denylist)
         timings["guardrails_total_ms"] = int((time.time() - t0) * 1000)
-        if not is_safe:
-            return {"statusCode": 403, "body": json.dumps({"blocked": block_reason})}
+
+        # Issue #126: Hard block → 403 Forbidden (no etymology)
+        if block_type == BLOCK_TYPE_HARD:
+            return {
+                "statusCode": 403,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({
+                    "blocked": True,
+                    "reason": category,
+                    "message": "Blocked: Content not permitted",
+                }),
+            }
 
         # 3. Generate thread ID for persistence
         # TODO: Issue #116 - Use authenticated user ID
@@ -401,6 +431,15 @@ def lambda_handler(
             "gem": result["response"]["gem"],
             "context": result["response"]["context"],
         }
+
+        # Issue #126: Add warning flag for soft blocks
+        # Soft block = 200 OK but with warning for frontend to display
+        if block_type == BLOCK_TYPE_SOFT:
+            response_body["warning"] = True
+            response_body["warning_category"] = category
+            # Include fallback flag if semantic check had an error
+            if metadata.get("is_fallback"):
+                response_body["fallback"] = True
 
         # Include latency for monitoring
         if result.get("metadata", {}).get("latency_ms"):

--- a/tests/unit/test_lambda_handler.py
+++ b/tests/unit/test_lambda_handler.py
@@ -70,50 +70,85 @@ class TestValidateInput:
 
 
 class TestRunGuardrails:
-    """Tests for run_guardrails function - guardrail pipeline."""
+    """Tests for run_guardrails function - guardrail pipeline.
+
+    Issue #126: Updated to expect block_type instead of is_safe.
+    """
 
     def test_020_blocked_text_denylist(self):
-        """Scenario 020: Blocked text returns 403 via denylist."""
-        is_safe, reason, metadata = run_guardrails(
+        """Scenario 020: Denylist term returns hard block."""
+        from src.guardrails.semantic import BLOCK_TYPE_HARD
+
+        block_type, category, metadata = run_guardrails(
             "test_block_term", denylist=MOCK_DENYLIST
         )
-        assert is_safe is False
-        assert "blocked" in reason.lower()
+        assert block_type == BLOCK_TYPE_HARD
+        assert category == "denylist"
         assert metadata["layer"] == "denylist"
 
     def test_safe_text_passes_denylist(self):
-        """Safe text passes denylist check."""
+        """Safe text passes denylist and semantic checks."""
+        from src.guardrails.semantic import BLOCK_TYPE_NONE
+
         # Mock semantic to also pass
         with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic:
             mock_guard = MagicMock()
             mock_guard.check_safety.return_value = {
+                "block_type": BLOCK_TYPE_NONE,
+                "category": "None",
                 "is_safe": True,
                 "reason": "None",
                 "scores": {},
             }
             mock_semantic.return_value = mock_guard
 
-            is_safe, reason, metadata = run_guardrails("apple", denylist=MOCK_DENYLIST)
-            assert is_safe is True
-            assert reason is None
-            assert metadata["layer"] == "passed"
+            block_type, category, metadata = run_guardrails("apple", denylist=MOCK_DENYLIST)
+            assert block_type == BLOCK_TYPE_NONE
+            assert category == "None"
+            assert metadata["layer"] == "semantic"
 
-    def test_blocked_by_semantic(self):
-        """Text blocked by semantic guardrail returns correct metadata."""
+    def test_blocked_by_semantic_hard(self):
+        """Hate speech returns hard block from semantic guardrail."""
+        from src.guardrails.semantic import BLOCK_TYPE_HARD
+
         with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic:
             mock_guard = MagicMock()
             mock_guard.check_safety.return_value = {
+                "block_type": BLOCK_TYPE_HARD,
+                "category": "Hate",
                 "is_safe": False,
                 "reason": "Hate",
                 "scores": {"Hate": 0.9},
             }
             mock_semantic.return_value = mock_guard
 
-            is_safe, reason, metadata = run_guardrails(
+            block_type, category, metadata = run_guardrails(
                 "safe_word", denylist=MOCK_DENYLIST
             )
-            assert is_safe is False
-            assert "Hate" in reason
+            assert block_type == BLOCK_TYPE_HARD
+            assert category == "Hate"
+            assert metadata["layer"] == "semantic"
+
+    def test_archaic_returns_soft_block(self):
+        """Archaic words return soft block (Issue #126)."""
+        from src.guardrails.semantic import BLOCK_TYPE_SOFT
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic:
+            mock_guard = MagicMock()
+            mock_guard.check_safety.return_value = {
+                "block_type": BLOCK_TYPE_SOFT,
+                "category": "Archaic",
+                "is_safe": False,
+                "reason": "Archaic",
+                "scores": {"Archaic": 0.9},
+            }
+            mock_semantic.return_value = mock_guard
+
+            block_type, category, metadata = run_guardrails(
+                "forsooth", denylist=MOCK_DENYLIST
+            )
+            assert block_type == BLOCK_TYPE_SOFT
+            assert category == "Archaic"
             assert metadata["layer"] == "semantic"
 
 
@@ -147,14 +182,18 @@ class TestLambdaHandler:
 
     def test_010_valid_input_safe_text(self):
         """Scenario 010: Valid input with safe text returns 200 with structured output."""
+        from src.guardrails.semantic import BLOCK_TYPE_NONE
+
         event = {"text": "apple"}
 
         with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, patch(
             "src.lambda_function.get_dynamodb_client"
         ) as mock_dynamo, patch("src.lambda_function.get_bedrock_client") as mock_bedrock:
-            # Mock semantic to pass
+            # Mock semantic to pass (Issue #126: include block_type)
             mock_guard = MagicMock()
             mock_guard.check_safety.return_value = {
+                "block_type": BLOCK_TYPE_NONE,
+                "category": "None",
                 "is_safe": True,
                 "reason": "None",
                 "scores": {},
@@ -238,15 +277,18 @@ class TestLambdaHandler:
     def test_070_boto3_exception(self):
         """Scenario 070: boto3 exception returns 500, no LLM output."""
         from botocore.exceptions import ClientError
+        from src.guardrails.semantic import BLOCK_TYPE_NONE
 
         event = {"text": "apple"}
 
         with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, patch(
             "src.lambda_function.get_dynamodb_client"
         ) as mock_dynamo:
-            # Mock semantic to pass
+            # Mock semantic to pass (Issue #126: include block_type)
             mock_guard = MagicMock()
             mock_guard.check_safety.return_value = {
+                "block_type": BLOCK_TYPE_NONE,
+                "category": "None",
                 "is_safe": True,
                 "reason": "None",
                 "scores": {},

--- a/tests/unit/test_semantic.py
+++ b/tests/unit/test_semantic.py
@@ -1,7 +1,12 @@
 import json
 from pathlib import Path
 from unittest.mock import Mock, patch
-from src.guardrails.semantic import SemanticGuardrail
+from src.guardrails.semantic import (
+    SemanticGuardrail,
+    BLOCK_TYPE_HARD,
+    BLOCK_TYPE_SOFT,
+    BLOCK_TYPE_NONE,
+)
 
 TAXONOMY_PATH = Path(__file__).parent.parent.parent / "src" / "guardrails" / "resources" / "taxonomy.json"
 
@@ -138,3 +143,132 @@ def test_semantic_failure(mock_boto_client):
 
     assert result["is_safe"] is False
     assert "Guardrail Error" in result["reason"]
+
+
+class TestHardSoftBlockingLogic:
+    """Tests for Issue #126: Hard vs. Soft Blocking Logic."""
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_hate_category_returns_hard_block(self, mock_boto_client):
+        """Hate speech should return BLOCK_TYPE_HARD."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        llm_output = json.dumps({"scores": {"Hate": 0.95}, "category": "Hate"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("offensive content")
+
+        assert result["block_type"] == BLOCK_TYPE_HARD
+        assert result["category"] == "Hate"
+        assert result["is_safe"] is False
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_archaic_category_returns_soft_block(self, mock_boto_client):
+        """Archaic words should return BLOCK_TYPE_SOFT (educational warning)."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        llm_output = json.dumps({"scores": {"Archaic": 0.9}, "category": "Archaic"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("forsooth")
+
+        assert result["block_type"] == BLOCK_TYPE_SOFT
+        assert result["category"] == "Archaic"
+        assert result["is_safe"] is False  # Backwards compat: soft block is still "not safe"
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_provocative_category_returns_soft_block(self, mock_boto_client):
+        """Provocative content should return BLOCK_TYPE_SOFT."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        llm_output = json.dumps({"scores": {"Provocative": 0.85}, "category": "Provocative"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("provocative term")
+
+        assert result["block_type"] == BLOCK_TYPE_SOFT
+        assert result["category"] == "Provocative"
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_none_category_returns_no_block(self, mock_boto_client):
+        """Safe content should return BLOCK_TYPE_NONE."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        llm_output = json.dumps({"scores": {"None": 1.0}, "category": "None"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("hello world")
+
+        assert result["block_type"] == BLOCK_TYPE_NONE
+        assert result["category"] == "None"
+        assert result["is_safe"] is True
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_neologism_category_returns_no_block(self, mock_boto_client):
+        """Neologisms should return BLOCK_TYPE_NONE (informational only)."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        llm_output = json.dumps({"scores": {"Neologism": 0.9}, "category": "Neologism"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("skibidi")
+
+        assert result["block_type"] == BLOCK_TYPE_NONE
+        assert result["category"] == "Neologism"
+        assert result["is_safe"] is True
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_error_returns_soft_block_with_fallback(self, mock_boto_client):
+        """Errors should return BLOCK_TYPE_SOFT with fallback flag (fail safe)."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        # Simulate AWS Exception
+        mock_client_instance.invoke_model.side_effect = Exception("Network Error")
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("test input")
+
+        assert result["block_type"] == BLOCK_TYPE_SOFT
+        assert result["is_fallback"] is True
+        assert result["is_safe"] is False


### PR DESCRIPTION
## Summary

Implements hard vs. soft blocking logic per LLD 1126:

- **Hard Block (403):** Safety violations - Hate speech, Denylist matches
- **Soft Block (200 with warning):** Educational warnings - Archaic, Provocative
- **Clean (200):** Safe content - None, Neologism, Formal Academic

### Changes

- Update `semantic.py` to return `block_type` instead of `is_safe` boolean
- Update `lambda_function.py` to handle block types:
  - Hard block → 403 with `{blocked: true, reason, message}`
  - Soft block → 200 with `{warning: true, warning_category, ...etymology...}`
  - Clean → 200 with etymology response
- Errors fail safe to soft block with `fallback: true` flag

## Test plan

- [x] All 218 unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy)
- [x] New tests verify:
  - Hate → BLOCK_TYPE_HARD
  - Archaic → BLOCK_TYPE_SOFT
  - Provocative → BLOCK_TYPE_SOFT
  - None → BLOCK_TYPE_NONE
  - Neologism → BLOCK_TYPE_NONE
  - Error → BLOCK_TYPE_SOFT with fallback

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)