### PR TITLE
test: Add Python backend test coverage (#189, #213)

### DIFF
--- a/docs/reports/189-213/implementation-report.md
+++ b/docs/reports/189-213/implementation-report.md
@@ -1,0 +1,68 @@
+# Implementation Report: Python Backend Test Coverage
+
+**Issues:** #189, #213
+**Branch:** `189-213-python-backend-tests`
+**Date:** 2026-01-09
+
+## Summary
+
+Added comprehensive unit test coverage for two previously untested Python modules:
+
+1. **`tools/build_release.py`** - Build script for Chrome/Firefox extension artifacts
+2. **`src/lambda_auth_function.py`** - Specifically the `delete_user_data()` GDPR erasure function
+
+## Files Created
+
+| File | Purpose | Test Count |
+|------|---------|------------|
+| `tests/tools/test_build_release.py` | Build tool tests | 23 |
+| `tests/unit/test_lambda_auth.py` | GDPR erasure tests | 16 |
+
+**Total new tests:** 39
+
+## Test Coverage Details
+
+### test_build_release.py (Issue #189)
+
+Tests for the release build tool covering:
+
+| Class | Coverage |
+|-------|----------|
+| `TestVerifyIcons` | Icon existence, size validation, empty placeholder detection |
+| `TestLoadManifest` | JSON parsing, invalid JSON handling |
+| `TestValidateParity` | Chrome/Firefox manifest synchronization, drift detection |
+| `TestShouldInclude` | File filtering (.git, __pycache__, .DS_Store, node_modules) |
+| `TestBuildZip` | Zip creation, exclusion filtering, directory structure preservation |
+| `TestMainCLI` | CLI exit codes, error handling |
+
+### test_lambda_auth.py (Issue #213)
+
+Tests for GDPR Article 17 erasure implementation:
+
+| Class | Coverage |
+|-------|----------|
+| `TestDeleteUserData` | Single page deletion, pagination, GSI queries, error handling |
+| `TestHandleDeleteMyData` | HTTP endpoint, auth validation, error responses |
+| `TestGDPRCompliance` | Identity verification requirement, data completeness, transparency |
+
+## Design Decisions
+
+1. **Mocking Strategy:** Used `unittest.mock` for all AWS service calls (DynamoDB) to avoid external dependencies
+2. **Temp Directories:** Used `pytest`'s `tmp_path` fixture for file system tests
+3. **Module Constants Patching:** Patched `CHROME_DIR`/`FIREFOX_DIR` for isolated directory structure tests
+4. **GDPR Compliance Class:** Added explicit tests verifying Article 17 requirements
+
+## Not Included (By Design)
+
+- No changes to production code
+- No JavaScript files modified
+- No integration tests requiring live AWS services
+
+## Verification
+
+```
+$ poetry run pytest tests/ -v
+============================= 257 passed in 11.81s =============================
+```
+
+All existing tests continue to pass. New tests add 39 to the suite.

--- a/docs/reports/189-213/test-report.md
+++ b/docs/reports/189-213/test-report.md
@@ -1,0 +1,103 @@
+# Test Report: Python Backend Test Coverage
+
+**Issues:** #189, #213
+**Branch:** `189-213-python-backend-tests`
+**Date:** 2026-01-09
+
+## Test Execution Summary
+
+| Metric | Value |
+|--------|-------|
+| New tests added | 39 |
+| Total tests in suite | 257 |
+| All tests passing | Yes |
+| Execution time | 11.81s |
+
+## New Test Results
+
+### test_build_release.py (23 tests)
+
+```
+tests/tools/test_build_release.py::TestVerifyIcons::test_all_icons_present_passes PASSED
+tests/tools/test_build_release.py::TestVerifyIcons::test_missing_icon_raises_file_not_found PASSED
+tests/tools/test_build_release.py::TestVerifyIcons::test_empty_icon_raises_value_error PASSED
+tests/tools/test_build_release.py::TestVerifyIcons::test_icon_sizes_constant PASSED
+tests/tools/test_build_release.py::TestLoadManifest::test_valid_manifest_loads PASSED
+tests/tools/test_build_release.py::TestLoadManifest::test_invalid_json_raises_error PASSED
+tests/tools/test_build_release.py::TestValidateParity::test_matching_manifests_pass PASSED
+tests/tools/test_build_release.py::TestValidateParity::test_version_drift_raises_error PASSED
+tests/tools/test_build_release.py::TestValidateParity::test_name_drift_raises_error PASSED
+tests/tools/test_build_release.py::TestValidateParity::test_missing_chrome_manifest_raises PASSED
+tests/tools/test_build_release.py::TestValidateParity::test_parity_keys_constant PASSED
+tests/tools/test_build_release.py::TestShouldInclude::test_normal_file_included PASSED
+tests/tools/test_build_release.py::TestShouldInclude::test_git_excluded PASSED
+tests/tools/test_build_release.py::TestShouldInclude::test_pycache_excluded PASSED
+tests/tools/test_build_release.py::TestShouldInclude::test_ds_store_excluded PASSED
+tests/tools/test_build_release.py::TestShouldInclude::test_node_modules_excluded PASSED
+tests/tools/test_build_release.py::TestShouldInclude::test_exclude_patterns_constant PASSED
+tests/tools/test_build_release.py::TestBuildZip::test_creates_valid_zip PASSED
+tests/tools/test_build_release.py::TestBuildZip::test_excludes_filtered_patterns PASSED
+tests/tools/test_build_release.py::TestBuildZip::test_preserves_directory_structure PASSED
+tests/tools/test_build_release.py::TestMainCLI::test_returns_zero_on_success PASSED
+tests/tools/test_build_release.py::TestMainCLI::test_returns_one_on_missing_icons PASSED
+tests/tools/test_build_release.py::TestMainCLI::test_returns_one_on_parity_drift PASSED
+```
+
+### test_lambda_auth.py (16 tests)
+
+```
+tests/unit/test_lambda_auth.py::TestDeleteUserData::test_deletes_single_page_items PASSED
+tests/unit/test_lambda_auth.py::TestDeleteUserData::test_handles_pagination PASSED
+tests/unit/test_lambda_auth.py::TestDeleteUserData::test_no_items_returns_zero PASSED
+tests/unit/test_lambda_auth.py::TestDeleteUserData::test_uses_correct_gsi_index PASSED
+tests/unit/test_lambda_auth.py::TestDeleteUserData::test_raises_on_dynamodb_error PASSED
+tests/unit/test_lambda_auth.py::TestDeleteUserData::test_raises_on_delete_error PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_successful_deletion_returns_200 PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_missing_auth_header_returns_401 PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_invalid_auth_format_returns_401 PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_invalid_token_returns_401 PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_dynamodb_error_returns_500 PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_lowercase_authorization_header_works PASSED
+tests/unit/test_lambda_auth.py::TestHandleDeleteMyData::test_extracts_user_id_from_token PASSED
+tests/unit/test_lambda_auth.py::TestGDPRCompliance::test_deletion_requires_identity_verification PASSED
+tests/unit/test_lambda_auth.py::TestGDPRCompliance::test_all_user_data_queried_for_deletion PASSED
+tests/unit/test_lambda_auth.py::TestGDPRCompliance::test_deletion_returns_count_for_transparency PASSED
+```
+
+## Regression Check
+
+Full test suite executed with no failures:
+
+```
+============================= 257 passed in 11.81s =============================
+```
+
+## Coverage Analysis
+
+### Issue #189 Coverage Goals
+
+| Goal | Status |
+|------|--------|
+| Verify zip generation | Covered in `TestBuildZip` |
+| Verify manifest parity | Covered in `TestValidateParity` |
+| Verify icon existence | Covered in `TestVerifyIcons` |
+
+### Issue #213 Coverage Goals
+
+| Goal | Status |
+|------|--------|
+| Mock DynamoDB | All tests use mocked `get_dynamodb_client` |
+| Verify GDPR erasure logic | Covered in `TestDeleteUserData`, `TestGDPRCompliance` |
+| Pagination handling | `test_handles_pagination` verifies multi-page queries |
+
+## Edge Cases Tested
+
+1. **Empty placeholder icons** - Detected via file size check (<100 bytes)
+2. **Pagination in GDPR deletion** - Handles `LastEvaluatedKey` continuation
+3. **HTTP header case sensitivity** - Both `Authorization` and `authorization` work
+4. **No items to delete** - Returns 0, no errors
+5. **DynamoDB failures** - Propagate as 500 responses
+
+## Manual Testing Required
+
+None - all tests are automated unit tests with mocked dependencies.

--- a/tests/tools/test_build_release.py
+++ b/tests/tools/test_build_release.py
@@ -1,0 +1,367 @@
+"""
+Unit tests for build_release.py tool.
+
+Issue #189: Test zip generation, manifest parity, and icon existence.
+
+Target: tools/build_release.py
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+from zipfile import ZipFile
+
+import pytest
+
+from tools.build_release import (
+    ICON_SIZES,
+    PARITY_KEYS,
+    EXCLUDE_PATTERNS,
+    verify_icons,
+    load_manifest,
+    validate_parity,
+    should_include,
+    build_zip,
+    main,
+)
+
+
+class TestVerifyIcons:
+    """Tests for verify_icons function - icon existence validation."""
+
+    def test_all_icons_present_passes(self, tmp_path):
+        """All required icons present and valid passes verification."""
+        icons_dir = tmp_path / "icons"
+        icons_dir.mkdir()
+
+        # Create valid icon files (>100 bytes)
+        for size in ICON_SIZES:
+            icon_file = icons_dir / f"icon{size}.png"
+            icon_file.write_bytes(b"x" * 200)  # 200 bytes > 100 minimum
+
+        # Should not raise
+        verify_icons(tmp_path, "Test")
+
+    def test_missing_icon_raises_file_not_found(self, tmp_path):
+        """Missing icon raises FileNotFoundError."""
+        icons_dir = tmp_path / "icons"
+        icons_dir.mkdir()
+
+        # Create only some icons (missing icon128.png)
+        for size in [16, 32, 48]:
+            icon_file = icons_dir / f"icon{size}.png"
+            icon_file.write_bytes(b"x" * 200)
+
+        with pytest.raises(FileNotFoundError, match="Missing.*icon"):
+            verify_icons(tmp_path, "Test")
+
+    def test_empty_icon_raises_value_error(self, tmp_path):
+        """Icon smaller than 100 bytes raises ValueError."""
+        icons_dir = tmp_path / "icons"
+        icons_dir.mkdir()
+
+        # Create icons, one suspiciously small
+        for size in ICON_SIZES:
+            icon_file = icons_dir / f"icon{size}.png"
+            if size == 128:
+                icon_file.write_bytes(b"x" * 50)  # Too small
+            else:
+                icon_file.write_bytes(b"x" * 200)
+
+        with pytest.raises(ValueError, match="Suspicious.*icon"):
+            verify_icons(tmp_path, "Test")
+
+    def test_icon_sizes_constant(self):
+        """ICON_SIZES contains expected values."""
+        assert ICON_SIZES == [16, 32, 48, 128]
+
+
+class TestLoadManifest:
+    """Tests for load_manifest function - JSON parsing."""
+
+    def test_valid_manifest_loads(self, tmp_path):
+        """Valid JSON manifest loads correctly."""
+        manifest_path = tmp_path / "manifest.json"
+        manifest_data = {"name": "Test", "version": "1.0.0"}
+        manifest_path.write_text(json.dumps(manifest_data))
+
+        result = load_manifest(manifest_path)
+
+        assert result == manifest_data
+
+    def test_invalid_json_raises_error(self, tmp_path):
+        """Invalid JSON raises JSONDecodeError."""
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text("{ invalid json }")
+
+        with pytest.raises(json.JSONDecodeError):
+            load_manifest(manifest_path)
+
+
+class TestValidateParity:
+    """Tests for validate_parity function - manifest synchronization."""
+
+    def test_matching_manifests_pass(self, tmp_path):
+        """Manifests with matching parity keys pass validation."""
+        chrome_dir = tmp_path / "extensions" / "chrome"
+        firefox_dir = tmp_path / "extensions" / "firefox"
+        chrome_dir.mkdir(parents=True)
+        firefox_dir.mkdir(parents=True)
+
+        shared_values = {
+            "name": "Aletheia",
+            "version": "1.2.3",
+            "description": "Etymology insights",
+            "icons": {"16": "icons/icon16.png"},
+        }
+
+        # Chrome manifest (MV3 extras)
+        chrome_manifest = {**shared_values, "manifest_version": 3}
+        (chrome_dir / "manifest.json").write_text(json.dumps(chrome_manifest))
+
+        # Firefox manifest (MV2 extras)
+        firefox_manifest = {**shared_values, "manifest_version": 2}
+        (firefox_dir / "manifest.json").write_text(json.dumps(firefox_manifest))
+
+        # Patch the module constants to use temp dirs
+        with patch("tools.build_release.CHROME_DIR", chrome_dir), \
+             patch("tools.build_release.FIREFOX_DIR", firefox_dir):
+            # Should not raise
+            validate_parity()
+
+    def test_version_drift_raises_error(self, tmp_path):
+        """Different versions raises ValueError."""
+        chrome_dir = tmp_path / "extensions" / "chrome"
+        firefox_dir = tmp_path / "extensions" / "firefox"
+        chrome_dir.mkdir(parents=True)
+        firefox_dir.mkdir(parents=True)
+
+        # Different versions
+        chrome_manifest = {"name": "Aletheia", "version": "1.2.3", "description": "Test", "icons": {}}
+        firefox_manifest = {"name": "Aletheia", "version": "1.2.4", "description": "Test", "icons": {}}
+
+        (chrome_dir / "manifest.json").write_text(json.dumps(chrome_manifest))
+        (firefox_dir / "manifest.json").write_text(json.dumps(firefox_manifest))
+
+        with patch("tools.build_release.CHROME_DIR", chrome_dir), \
+             patch("tools.build_release.FIREFOX_DIR", firefox_dir):
+            with pytest.raises(ValueError, match="parity drift"):
+                validate_parity()
+
+    def test_name_drift_raises_error(self, tmp_path):
+        """Different names raises ValueError."""
+        chrome_dir = tmp_path / "extensions" / "chrome"
+        firefox_dir = tmp_path / "extensions" / "firefox"
+        chrome_dir.mkdir(parents=True)
+        firefox_dir.mkdir(parents=True)
+
+        chrome_manifest = {"name": "Aletheia", "version": "1.0.0", "description": "Test", "icons": {}}
+        firefox_manifest = {"name": "Aletheia Beta", "version": "1.0.0", "description": "Test", "icons": {}}
+
+        (chrome_dir / "manifest.json").write_text(json.dumps(chrome_manifest))
+        (firefox_dir / "manifest.json").write_text(json.dumps(firefox_manifest))
+
+        with patch("tools.build_release.CHROME_DIR", chrome_dir), \
+             patch("tools.build_release.FIREFOX_DIR", firefox_dir):
+            with pytest.raises(ValueError, match="parity drift"):
+                validate_parity()
+
+    def test_missing_chrome_manifest_raises(self, tmp_path):
+        """Missing Chrome manifest raises FileNotFoundError."""
+        firefox_dir = tmp_path / "extensions" / "firefox"
+        firefox_dir.mkdir(parents=True)
+        (firefox_dir / "manifest.json").write_text("{}")
+
+        with patch("tools.build_release.CHROME_DIR", tmp_path / "extensions" / "chrome"), \
+             patch("tools.build_release.FIREFOX_DIR", firefox_dir):
+            with pytest.raises(FileNotFoundError):
+                validate_parity()
+
+    def test_parity_keys_constant(self):
+        """PARITY_KEYS contains expected identity/branding keys."""
+        assert "name" in PARITY_KEYS
+        assert "version" in PARITY_KEYS
+        assert "description" in PARITY_KEYS
+        assert "icons" in PARITY_KEYS
+
+
+class TestShouldInclude:
+    """Tests for should_include function - file filtering."""
+
+    def test_normal_file_included(self):
+        """Normal files are included."""
+        assert should_include(Path("src/content.js")) is True
+        assert should_include(Path("manifest.json")) is True
+        assert should_include(Path("icons/icon16.png")) is True
+
+    def test_git_excluded(self):
+        """Git directories are excluded."""
+        assert should_include(Path(".git/config")) is False
+        assert should_include(Path("src/.git/HEAD")) is False
+
+    def test_pycache_excluded(self):
+        """Python cache directories are excluded."""
+        assert should_include(Path("__pycache__/module.pyc")) is False
+
+    def test_ds_store_excluded(self):
+        """macOS .DS_Store files are excluded."""
+        assert should_include(Path(".DS_Store")) is False
+        assert should_include(Path("icons/.DS_Store")) is False
+
+    def test_node_modules_excluded(self):
+        """node_modules directories are excluded."""
+        assert should_include(Path("node_modules/package/index.js")) is False
+
+    def test_exclude_patterns_constant(self):
+        """EXCLUDE_PATTERNS contains expected patterns."""
+        assert ".git" in EXCLUDE_PATTERNS
+        assert "__pycache__" in EXCLUDE_PATTERNS
+        assert ".DS_Store" in EXCLUDE_PATTERNS
+        assert "node_modules" in EXCLUDE_PATTERNS
+
+
+class TestBuildZip:
+    """Tests for build_zip function - zip archive creation."""
+
+    def test_creates_valid_zip(self, tmp_path):
+        """Creates a valid zip file with correct contents."""
+        source_dir = tmp_path / "extension"
+        source_dir.mkdir()
+
+        # Create test files
+        (source_dir / "manifest.json").write_text('{"name": "test"}')
+        (source_dir / "content.js").write_text("console.log('test');")
+
+        icons_dir = source_dir / "icons"
+        icons_dir.mkdir()
+        (icons_dir / "icon16.png").write_bytes(b"PNG data")
+
+        output_zip = tmp_path / "output.zip"
+        build_zip(source_dir, output_zip, "Test")
+
+        # Verify zip exists and contains expected files
+        assert output_zip.exists()
+        with ZipFile(output_zip, "r") as z:
+            names = z.namelist()
+            assert "manifest.json" in names
+            assert "content.js" in names
+            assert "icons/icon16.png" in names
+
+    def test_excludes_filtered_patterns(self, tmp_path):
+        """Excluded patterns are not in the zip."""
+        source_dir = tmp_path / "extension"
+        source_dir.mkdir()
+
+        # Create files including ones that should be excluded
+        (source_dir / "manifest.json").write_text('{"name": "test"}')
+
+        git_dir = source_dir / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text("git config")
+
+        cache_dir = source_dir / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "module.pyc").write_bytes(b"bytecode")
+
+        output_zip = tmp_path / "output.zip"
+        build_zip(source_dir, output_zip, "Test")
+
+        with ZipFile(output_zip, "r") as z:
+            names = z.namelist()
+            assert "manifest.json" in names
+            assert ".git/config" not in names
+            assert "__pycache__/module.pyc" not in names
+
+    def test_preserves_directory_structure(self, tmp_path):
+        """Nested directory structure is preserved in zip."""
+        source_dir = tmp_path / "extension"
+        source_dir.mkdir()
+
+        nested = source_dir / "src" / "utils"
+        nested.mkdir(parents=True)
+        (nested / "helper.js").write_text("export const helper = () => {};")
+
+        output_zip = tmp_path / "output.zip"
+        build_zip(source_dir, output_zip, "Test")
+
+        with ZipFile(output_zip, "r") as z:
+            assert "src/utils/helper.js" in z.namelist()
+
+
+class TestMainCLI:
+    """Integration tests for main() CLI entry point."""
+
+    def test_returns_zero_on_success(self, tmp_path):
+        """Successful build returns exit code 0."""
+        # Set up complete extension structure
+        chrome_dir = tmp_path / "extensions" / "chrome"
+        firefox_dir = tmp_path / "extensions" / "firefox"
+        dist_dir = tmp_path / "dist"
+
+        for ext_dir in [chrome_dir, firefox_dir]:
+            ext_dir.mkdir(parents=True)
+
+            # Create manifest
+            manifest = {
+                "name": "Aletheia",
+                "version": "1.0.0",
+                "description": "Test",
+                "icons": {"16": "icons/icon16.png"},
+            }
+            (ext_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            # Create icons
+            icons_dir = ext_dir / "icons"
+            icons_dir.mkdir()
+            for size in ICON_SIZES:
+                (icons_dir / f"icon{size}.png").write_bytes(b"x" * 200)
+
+        with patch("tools.build_release.CHROME_DIR", chrome_dir), \
+             patch("tools.build_release.FIREFOX_DIR", firefox_dir), \
+             patch("tools.build_release.DIST_DIR", dist_dir), \
+             patch("tools.build_release.run_firefox_lint"):  # Skip lint
+            result = main()
+
+        assert result == 0
+        assert (dist_dir / "aletheia-chrome-v1.0.0.zip").exists()
+        assert (dist_dir / "aletheia-firefox-v1.0.0.zip").exists()
+
+    def test_returns_one_on_missing_icons(self, tmp_path):
+        """Missing icons returns exit code 1."""
+        chrome_dir = tmp_path / "extensions" / "chrome"
+        chrome_dir.mkdir(parents=True)
+
+        # Manifest but no icons
+        (chrome_dir / "manifest.json").write_text('{"version": "1.0.0"}')
+
+        with patch("tools.build_release.CHROME_DIR", chrome_dir), \
+             patch("tools.build_release.FIREFOX_DIR", tmp_path / "firefox"):
+            result = main()
+
+        assert result == 1
+
+    def test_returns_one_on_parity_drift(self, tmp_path):
+        """Manifest parity drift returns exit code 1."""
+        chrome_dir = tmp_path / "extensions" / "chrome"
+        firefox_dir = tmp_path / "extensions" / "firefox"
+
+        for ext_dir in [chrome_dir, firefox_dir]:
+            ext_dir.mkdir(parents=True)
+            icons_dir = ext_dir / "icons"
+            icons_dir.mkdir()
+            for size in ICON_SIZES:
+                (icons_dir / f"icon{size}.png").write_bytes(b"x" * 200)
+
+        # Different versions = parity drift
+        (chrome_dir / "manifest.json").write_text(
+            json.dumps({"name": "Aletheia", "version": "1.0.0", "description": "Test", "icons": {}})
+        )
+        (firefox_dir / "manifest.json").write_text(
+            json.dumps({"name": "Aletheia", "version": "2.0.0", "description": "Test", "icons": {}})
+        )
+
+        with patch("tools.build_release.CHROME_DIR", chrome_dir), \
+             patch("tools.build_release.FIREFOX_DIR", firefox_dir):
+            result = main()
+
+        assert result == 1

--- a/tests/unit/test_lambda_auth.py
+++ b/tests/unit/test_lambda_auth.py
@@ -1,0 +1,265 @@
+"""
+Unit tests for Lambda Auth Function - GDPR Data Erasure.
+
+Issue #213: Mock DynamoDB and verify GDPR erasure logic.
+
+Target: src/lambda_auth_function.py (specifically delete_user_data)
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from src.lambda_auth_function import (
+    delete_user_data,
+    handle_delete_my_data,
+    AGENT_STATE_TABLE,
+)
+
+
+class TestDeleteUserData:
+    """Tests for delete_user_data function - GDPR Article 17 erasure.
+
+    Issue #147: Right to Erasure implementation.
+    """
+
+    def test_deletes_single_page_items(self):
+        """Deletes all items for user when results fit in single page."""
+        mock_client = MagicMock()
+
+        # Single page of results (no LastEvaluatedKey)
+        mock_client.query.return_value = {
+            "Items": [
+                {"thread_id": {"S": "thread-001"}, "checkpoint_id": {"S": "cp-001"}},
+                {"thread_id": {"S": "thread-002"}, "checkpoint_id": {"S": "cp-002"}},
+            ]
+        }
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            count = delete_user_data("user-123")
+
+        assert count == 2
+        assert mock_client.delete_item.call_count == 2
+
+        # Verify correct keys used for deletion
+        mock_client.delete_item.assert_any_call(
+            TableName=AGENT_STATE_TABLE,
+            Key={
+                "thread_id": {"S": "thread-001"},
+                "checkpoint_id": {"S": "cp-001"},
+            }
+        )
+        mock_client.delete_item.assert_any_call(
+            TableName=AGENT_STATE_TABLE,
+            Key={
+                "thread_id": {"S": "thread-002"},
+                "checkpoint_id": {"S": "cp-002"},
+            }
+        )
+
+    def test_handles_pagination(self):
+        """Handles paginated results for users with many items."""
+        mock_client = MagicMock()
+
+        # First page with continuation token
+        first_page = {
+            "Items": [
+                {"thread_id": {"S": "thread-001"}, "checkpoint_id": {"S": "cp-001"}},
+            ],
+            "LastEvaluatedKey": {"thread_id": {"S": "thread-001"}},
+        }
+
+        # Second page (final)
+        second_page = {
+            "Items": [
+                {"thread_id": {"S": "thread-002"}, "checkpoint_id": {"S": "cp-002"}},
+            ]
+        }
+
+        mock_client.query.side_effect = [first_page, second_page]
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            count = delete_user_data("user-123")
+
+        assert count == 2
+        assert mock_client.query.call_count == 2
+        assert mock_client.delete_item.call_count == 2
+
+    def test_no_items_returns_zero(self):
+        """Returns 0 when user has no items to delete."""
+        mock_client = MagicMock()
+        mock_client.query.return_value = {"Items": []}
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            count = delete_user_data("user-with-no-data")
+
+        assert count == 0
+        mock_client.delete_item.assert_not_called()
+
+    def test_uses_correct_gsi_index(self):
+        """Queries use the user_id-index GSI."""
+        mock_client = MagicMock()
+        mock_client.query.return_value = {"Items": []}
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            delete_user_data("user-123")
+
+        # Verify GSI query parameters
+        call_kwargs = mock_client.query.call_args.kwargs
+        assert call_kwargs["IndexName"] == "user_id-index"
+        assert call_kwargs["KeyConditionExpression"] == "user_id = :uid"
+        assert call_kwargs["ExpressionAttributeValues"] == {":uid": {"S": "user-123"}}
+
+    def test_raises_on_dynamodb_error(self):
+        """Raises ClientError when DynamoDB fails."""
+        mock_client = MagicMock()
+        mock_client.query.side_effect = ClientError(
+            {"Error": {"Code": "InternalServerError", "Message": "DB error"}},
+            "Query"
+        )
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            with pytest.raises(ClientError):
+                delete_user_data("user-123")
+
+    def test_raises_on_delete_error(self):
+        """Raises ClientError when delete_item fails."""
+        mock_client = MagicMock()
+        mock_client.query.return_value = {
+            "Items": [
+                {"thread_id": {"S": "thread-001"}, "checkpoint_id": {"S": "cp-001"}},
+            ]
+        }
+        mock_client.delete_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": "Failed"}},
+            "DeleteItem"
+        )
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            with pytest.raises(ClientError):
+                delete_user_data("user-123")
+
+
+class TestHandleDeleteMyData:
+    """Tests for handle_delete_my_data endpoint handler.
+
+    Issue #147: GDPR Article 17 data erasure endpoint.
+    """
+
+    def test_successful_deletion_returns_200(self):
+        """Successful deletion returns 200 with item count."""
+        with patch("src.lambda_auth_function.get_linkedin_user_info") as mock_userinfo, \
+             patch("src.lambda_auth_function.delete_user_data") as mock_delete:
+            mock_userinfo.return_value = {"sub": "linkedin-user-123", "name": "Test User"}
+            mock_delete.return_value = 5
+
+            result = handle_delete_my_data({"Authorization": "Bearer valid-token"})
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["success"] is True
+        assert body["itemsDeleted"] == 5
+        assert "deleted" in body["message"].lower()
+
+    def test_missing_auth_header_returns_401(self):
+        """Missing Authorization header returns 401."""
+        result = handle_delete_my_data({})
+
+        assert result["statusCode"] == 401
+        body = json.loads(result["body"])
+        assert "Authorization" in body["error"]
+
+    def test_invalid_auth_format_returns_401(self):
+        """Non-Bearer auth format returns 401."""
+        result = handle_delete_my_data({"Authorization": "Basic credentials"})
+
+        assert result["statusCode"] == 401
+        body = json.loads(result["body"])
+        assert "Authorization" in body["error"]
+
+    def test_invalid_token_returns_401(self):
+        """Invalid token returns 401."""
+        with patch("src.lambda_auth_function.get_linkedin_user_info") as mock_userinfo:
+            mock_userinfo.return_value = None  # Invalid token
+
+            result = handle_delete_my_data({"Authorization": "Bearer invalid-token"})
+
+        assert result["statusCode"] == 401
+        body = json.loads(result["body"])
+        assert "Invalid token" in body["error"]
+
+    def test_dynamodb_error_returns_500(self):
+        """DynamoDB error returns 500."""
+        with patch("src.lambda_auth_function.get_linkedin_user_info") as mock_userinfo, \
+             patch("src.lambda_auth_function.delete_user_data") as mock_delete:
+            mock_userinfo.return_value = {"sub": "linkedin-user-123", "name": "Test User"}
+            mock_delete.side_effect = ClientError(
+                {"Error": {"Code": "InternalServerError", "Message": "DB error"}},
+                "Query"
+            )
+
+            result = handle_delete_my_data({"Authorization": "Bearer valid-token"})
+
+        assert result["statusCode"] == 500
+        body = json.loads(result["body"])
+        assert "failed" in body["error"].lower()
+
+    def test_lowercase_authorization_header_works(self):
+        """Handles lowercase 'authorization' header (HTTP/2 normalization)."""
+        with patch("src.lambda_auth_function.get_linkedin_user_info") as mock_userinfo, \
+             patch("src.lambda_auth_function.delete_user_data") as mock_delete:
+            mock_userinfo.return_value = {"sub": "linkedin-user-123", "name": "Test User"}
+            mock_delete.return_value = 2
+
+            result = handle_delete_my_data({"authorization": "Bearer valid-token"})
+
+        assert result["statusCode"] == 200
+
+    def test_extracts_user_id_from_token(self):
+        """Extracts LinkedIn 'sub' claim for deletion."""
+        with patch("src.lambda_auth_function.get_linkedin_user_info") as mock_userinfo, \
+             patch("src.lambda_auth_function.delete_user_data") as mock_delete:
+            mock_userinfo.return_value = {"sub": "specific-linkedin-id", "name": "Test User"}
+            mock_delete.return_value = 0
+
+            handle_delete_my_data({"Authorization": "Bearer valid-token"})
+
+        # Verify delete_user_data called with correct user_id
+        mock_delete.assert_called_once_with("specific-linkedin-id")
+
+
+class TestGDPRCompliance:
+    """Tests verifying GDPR Article 17 compliance requirements."""
+
+    def test_deletion_requires_identity_verification(self):
+        """User must prove identity before deletion (OAuth token required)."""
+        # No token = no deletion
+        result = handle_delete_my_data({})
+        assert result["statusCode"] == 401
+
+    def test_all_user_data_queried_for_deletion(self):
+        """All user data in agent state table is queried for deletion."""
+        mock_client = MagicMock()
+        mock_client.query.return_value = {"Items": []}
+
+        with patch("src.lambda_auth_function.get_dynamodb_client", return_value=mock_client):
+            delete_user_data("user-123")
+
+        # Verify query targets user's data
+        call_kwargs = mock_client.query.call_args.kwargs
+        assert "user_id = :uid" in call_kwargs["KeyConditionExpression"]
+        assert call_kwargs["ExpressionAttributeValues"][":uid"]["S"] == "user-123"
+
+    def test_deletion_returns_count_for_transparency(self):
+        """Response includes count of deleted items for user transparency."""
+        with patch("src.lambda_auth_function.get_linkedin_user_info") as mock_userinfo, \
+             patch("src.lambda_auth_function.delete_user_data") as mock_delete:
+            mock_userinfo.return_value = {"sub": "user-123", "name": "Test User"}
+            mock_delete.return_value = 42
+
+            result = handle_delete_my_data({"Authorization": "Bearer valid-token"})
+
+        body = json.loads(result["body"])
+        assert body["itemsDeleted"] == 42


### PR DESCRIPTION
## Summary
- Add `tests/tools/test_build_release.py` with 23 tests for build tool (icon validation, manifest parity, zip generation)
- Add `tests/unit/test_lambda_auth.py` with 16 tests for GDPR erasure (mocked DynamoDB, pagination, auth validation)
- 39 new tests, all 257 suite tests passing

## Test plan
- [x] Run `poetry run pytest tests/ -v` - all 257 tests pass
- [x] Pre-commit hooks pass (ruff, mypy)
- [x] Reports created in `docs/reports/189-213/`

Closes #189
Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)