### PR TITLE
fix(firefox): update min version to 115 for storage.session API

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -17,11 +17,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "extension@aletheia.study",
-      "strict_min_version": "109.0",
-      "data_collection_permissions": {
-        "required": ["websiteContent", "personallyIdentifyingInfo"],
-        "optional": []
-      }
+      "strict_min_version": "115.0"
     },
     "gecko_android": {
       "strict_min_version": "120.0"


### PR DESCRIPTION
## Summary
- Updated Firefox `strict_min_version` from 109.0 to 115.0
- Removed `data_collection_permissions` (requires Firefox 140+, too new)

## Why
The `storage.session` API used in `auth.js` requires Firefox 115+. The old min version (109) caused web-ext lint warnings and potential runtime errors.

## Test Plan
- [x] `web-ext lint` passes with only 1 optional warning
- [x] `web-ext build` succeeds
- [x] Package created: `web-ext-artifacts/aletheia-1.0.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)