### PR TITLE
fix(test): repair legacy popup.test.js failures (close #217)

### DIFF
--- a/extensions/chrome/popup.js
+++ b/extensions/chrome/popup.js
@@ -1,8 +1,11 @@
 // extensions/chrome/popup.js
-// State management
-let currentDomain = null;
+// State management - use window.currentDomain as source of truth (Issue #217)
+window.currentDomain = null;
 const selectedDomains = new Set();
 let currentTabId = null;
+
+// Expose selectedDomains for testing (Issue #217)
+window.selectedDomains = selectedDomains;
 
 // Tab State constants (must match service-worker.js)
 const TabState = {
@@ -145,7 +148,7 @@ function showView(viewName) {
 
 async function renderMainView() {
   const domain = await getCurrentDomain();
-  currentDomain = domain;
+  window.currentDomain = domain;
 
   if (!domain) {
     currentDomainEl.textContent = 'Unknown';
@@ -215,7 +218,7 @@ function createAllowlistItem(domain) {
   label.appendChild(domainSpan);
 
   // Add "current" badge if this is the current domain
-  if (domain === currentDomain) {
+  if (domain === window.currentDomain) {
     const badge = document.createElement('span');
     badge.className = 'current-badge';
     badge.textContent = 'current';
@@ -240,17 +243,17 @@ function updateRemoveButton() {
 // ============================================================================
 
 async function handlePowerToggle() {
-  if (!currentDomain) return;
+  if (!window.currentDomain) return;
 
-  const isActive = await isAllowlisted(currentDomain);
+  const isActive = await isAllowlisted(window.currentDomain);
 
   if (isActive) {
     // Deactivating - stay open so user sees the change
-    await removeFromAllowlist(currentDomain);
+    await removeFromAllowlist(window.currentDomain);
     await renderMainView();
   } else {
     // Activating - add to allowlist and close popup
-    await addToAllowlist(currentDomain);
+    await addToAllowlist(window.currentDomain);
     window.close();
   }
 }
@@ -283,7 +286,7 @@ async function handleRemoveSelected() {
   await renderManagementView();
 
   // If current domain was removed, update main view
-  if (domainsToRemove.includes(currentDomain)) {
+  if (domainsToRemove.includes(window.currentDomain)) {
     await renderMainView();
   }
 }

--- a/tests/unit/chrome/popup.test.js
+++ b/tests/unit/chrome/popup.test.js
@@ -403,7 +403,8 @@ describe('View Rendering', () => {
       expect(statusLabel.textContent).toBe('INACTIVE');
     });
 
-    // TODO: Fix legacy scope issue (See Issue #215)
+    // TODO: Fix test harness - mockResolvedValueOnce is consumed by DOMContentLoaded init
+    // before the test's renderMainView() call. Needs mock reset or different setup pattern.
     it.skip('should handle null domain gracefully', async () => {
       const { window } = env;
       const { document } = window;
@@ -519,8 +520,8 @@ describe('View Rendering', () => {
       expect(domainSpan.textContent).toBe('example.com');
     });
 
-    // TODO: Fix legacy scope issue (See Issue #215)
-    it.skip('should add current badge when domain matches currentDomain', async () => {
+    // Fixed: Issue #217 - exposed selectedDomains/currentDomain to window
+    it('should add current badge when domain matches currentDomain', async () => {
       const { window } = env;
 
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -553,8 +554,8 @@ describe('Event Handlers', () => {
   });
 
   describe('handleCheckboxChange', () => {
-    // TODO: Fix legacy scope issue (See Issue #215)
-    it.skip('should add domain to selectedDomains when checked', async () => {
+    // Fixed: Issue #217 - exposed selectedDomains/currentDomain to window
+    it('should add domain to selectedDomains when checked', async () => {
       const { window } = env;
 
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -578,8 +579,8 @@ describe('Event Handlers', () => {
       expect(window.selectedDomains.has('test.com')).toBe(true);
     });
 
-    // TODO: Fix legacy scope issue (See Issue #215)
-    it.skip('should remove domain from selectedDomains when unchecked', async () => {
+    // Fixed: Issue #217 - exposed selectedDomains/currentDomain to window
+    it('should remove domain from selectedDomains when unchecked', async () => {
       const { window } = env;
 
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -607,8 +608,8 @@ describe('Event Handlers', () => {
   });
 
   describe('updateRemoveButton', () => {
-    // TODO: Fix legacy scope issue (See Issue #215)
-    it.skip('should disable button when no domains selected', async () => {
+    // Fixed: Issue #217 - exposed selectedDomains/currentDomain to window
+    it('should disable button when no domains selected', async () => {
       const { window } = env;
       const { document } = window;
 
@@ -622,8 +623,8 @@ describe('Event Handlers', () => {
       expect(removeButton.textContent).toBe('Remove Selected');
     });
 
-    // TODO: Fix legacy scope issue (See Issue #215)
-    it.skip('should enable button and show count when domains selected', async () => {
+    // Fixed: Issue #217 - exposed selectedDomains/currentDomain to window
+    it('should enable button and show count when domains selected', async () => {
       const { window } = env;
       const { document } = window;
 


### PR DESCRIPTION
## Summary
Fix window scope issues in popup.test.js by using `window.currentDomain` as source of truth.

## Changes
- **popup.js**: Use `window.currentDomain` directly instead of local variable
- **popup.js**: Expose `window.selectedDomains` (Set reference for tests)
- **popup.test.js**: Unskip 5 tests that now pass
- **popup.test.js**: Keep 1 test skipped (different issue - test harness timing)

## Results
| Metric | Before | After |
|--------|--------|-------|
| Passed | 158 | 163 |
| Skipped | 6 | 1 |

## Test plan
- [x] `npm run test:unit` passes (163 passed, 1 skipped)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)