### PR TITLE
feat(firefox): Implement tabs-based OAuth flow

### DIFF
--- a/docs/reports/256/implementation-report.md
+++ b/docs/reports/256/implementation-report.md
@@ -1,0 +1,150 @@
+# Implementation Report: Firefox OAuth Tabs-Based Flow
+
+**Issue:** #256
+**Branch:** `256-firefox-oauth-tabs`
+**Date:** 2026-01-10
+
+## Summary
+
+Fixed Firefox OAuth authentication by replacing the non-existent `browser.identity` API with a tabs-based OAuth flow. Firefox MV3 does not have `browser.identity` (Chrome-only), causing OAuth to completely fail.
+
+## Problem
+
+The Firefox `auth.js` was using `browser.identity.launchWebAuthFlow()` and `browser.identity.getRedirectURL()`, which don't exist in Firefox's WebExtensions API. This was a silent failure that wasn't caught during development because:
+
+1. Chrome and Firefox extensions shared no unit tests for auth
+2. The mock incorrectly provided a fake `browser.identity` API
+3. No runtime testing was performed on Firefox
+
+## Solution
+
+Implemented a tabs-based OAuth flow that works in Firefox MV3:
+
+### 1. Lambda Callback Endpoint (`src/lambda_auth_function.py`)
+
+Added `handle_oauth_callback()` function that:
+- Handles GET requests to `/auth/callback`
+- Receives OAuth redirect from LinkedIn with `?code=...&state=...`
+- Returns minimal HTML page with code/state in URL
+- Extension monitors tab URL to extract code
+
+```python
+def handle_oauth_callback(query_params: dict) -> dict:
+    """Handle OAuth callback redirect from LinkedIn."""
+    code = query_params.get("code", "")
+    state = query_params.get("state", "")
+    error = query_params.get("error", "")
+    # Returns HTML page (extension monitors URL for code extraction)
+```
+
+### 2. Firefox Auth Module (`extensions/firefox/auth.js`)
+
+Replaced identity-based flow with tabs-based flow:
+
+- **`getRedirectURL()`**: Returns Lambda callback URL instead of `browser.identity.getRedirectURL()`
+- **`waitForOAuthCallback(tabId, callbackUrl)`**: New function that:
+  - Monitors tab URL changes via `browser.tabs.onUpdated`
+  - Detects when tab navigates to callback URL
+  - Extracts code and state from URL params
+  - Handles tab close (user cancellation)
+  - 5-minute timeout for login flow
+- **`initiateLogin()`**: Rewritten to:
+  1. Generate CSRF state
+  2. Store state in session storage
+  3. Open auth tab with `browser.tabs.create()`
+  4. Wait for callback via URL monitoring
+  5. Validate state (CSRF protection)
+  6. Exchange code for tokens via Lambda
+
+### 3. Firefox Mock (`tests/mocks/firefox-api.mock.js`)
+
+Added tab lifecycle simulation for testing:
+- `tabs.create()` - Creates mock tabs with auto-incrementing IDs
+- `tabs.remove()` - Removes mock tabs
+- `tabs.onUpdated.addListener/removeListener` - Handler registration
+- `__simulateTabUpdate(tabId, url, status)` - Test utility to simulate navigation
+- `__triggerTabRemoved(tabId, removeInfo)` - Test utility for tab close
+
+### 4. Firefox Auth Tests (`tests/unit/firefox/auth.test.js`)
+
+Updated all tests to work with tabs-based flow:
+- **Namespace Verification**: Now verifies NO `browser.identity` usage
+- **CSRF Tests**: Simulate OAuth callback via `__simulateTabUpdate()`
+- **Token Storage Tests**: Complete OAuth flow simulation
+- **Tab Close Handling**: New test for user cancellation
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `src/lambda_auth_function.py` | Added `/auth/callback` endpoint |
+| `extensions/firefox/auth.js` | Tabs-based OAuth flow |
+| `tests/mocks/firefox-api.mock.js` | Tab lifecycle mocking |
+| `tests/unit/firefox/auth.test.js` | Updated for tabs-based flow |
+
+## Architecture
+
+```
+User clicks Login
+       │
+       ▼
+┌─────────────────┐
+│ generateState() │  Generate CSRF state
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────────────────┐
+│ browser.storage.session.set │  Store state for validation
+└────────────┬────────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│ browser.tabs.create()   │  Open LinkedIn OAuth page
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────────┐
+│ browser.tabs.onUpdated      │  Monitor tab URL changes
+│ + browser.tabs.onRemoved    │
+└────────────┬────────────────┘
+             │ (user authenticates)
+             ▼
+┌──────────────────────────────────────┐
+│ Tab navigates to Lambda /auth/callback│
+│ ?code=...&state=...                   │
+└────────────┬─────────────────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│ Validate state (CSRF)   │  Compare stored vs returned state
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│ POST /auth/token        │  Exchange code for tokens
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│ storeTokens()           │  Store in session/local storage
+└─────────────────────────┘
+```
+
+## Security Considerations
+
+1. **CSRF Protection**: State parameter generated with `crypto.getRandomValues()`, validated on callback
+2. **Token Hierarchy**: Access token in session storage (cleared on browser close), refresh token in local storage
+3. **Lambda Callback**: Only returns HTML page, no token exchange happens at callback URL
+4. **Tab Cleanup**: Auth tab automatically closed after callback detection
+
+## Deployment Notes
+
+After merging, the Lambda callback URL must be registered with LinkedIn OAuth app:
+- URL: `https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws/auth/callback`
+- LinkedIn Developer Portal > App Settings > Auth > Redirect URLs
+
+## Related Documents
+
+- LLD: `docs/lld/active/1206-firefox-oauth.md`
+- Audit: `docs/0826-audit-cross-browser-testing.md`
+- ADR: `docs/0215-test-first-philosophy.md`

--- a/docs/reports/256/test-report.md
+++ b/docs/reports/256/test-report.md
@@ -1,0 +1,150 @@
+# Test Report: Firefox OAuth Tabs-Based Flow
+
+**Issue:** #256
+**Branch:** `256-firefox-oauth-tabs`
+**Date:** 2026-01-10
+
+## Test Results
+
+```
+ Test Files  7 passed (7)
+      Tests  195 passed | 1 skipped (196)
+```
+
+All Firefox auth tests pass, and the full test suite remains green.
+
+## Firefox Auth Tests (18 tests)
+
+### Namespace Verification (4 tests)
+| Test | Status | Purpose |
+|------|--------|---------|
+| auth.js file exists | PASS | Confirms auth module exists |
+| does NOT use browser.identity | PASS | **CRITICAL** - Verifies no browser.identity usage |
+| uses browser.storage not chrome.storage | PASS | Correct namespace |
+| uses browser.runtime not chrome.runtime | PASS | Correct namespace |
+
+### CSRF State Generation (3 tests)
+| Test | Status | Purpose |
+|------|--------|---------|
+| AletheiaAuth is exported to window | PASS | Module export verification |
+| generateState produces 64-character hex string | PASS | State format validation |
+| generates unique state values | PASS | Randomness verification |
+
+### CSRF State Validation (3 tests)
+| Test | Status | Purpose |
+|------|--------|---------|
+| rejects mismatched state parameter | PASS | **SECURITY** - CSRF protection |
+| accepts matching state parameter | PASS | Valid OAuth flow |
+| handles user closing auth tab | PASS | User cancellation handling |
+
+### Token Storage Hierarchy (3 tests)
+| Test | Status | Purpose |
+|------|--------|---------|
+| stores access token in session storage | PASS | Session storage for access token |
+| stores refresh token in local storage | PASS | Local storage for refresh token |
+| clears all tokens on logout | PASS | Proper logout cleanup |
+
+### Mock Mode (1 test)
+| Test | Status | Purpose |
+|------|--------|---------|
+| returns deterministic mock user when MOCK_MODE enabled | PASS | Testing mode functionality |
+
+### Authentication State (4 tests)
+| Test | Status | Purpose |
+|------|--------|---------|
+| isAuthenticated returns true when userId exists | PASS | Auth state detection |
+| isAuthenticated returns false when no userId | PASS | Unauthenticated state |
+| getAuthState returns user info when authenticated | PASS | User info retrieval |
+| getAuthState returns null when not authenticated | PASS | Null return for no auth |
+
+## Test Methodology
+
+### OAuth Flow Simulation
+
+Tests simulate the tabs-based OAuth flow using mock utilities:
+
+```javascript
+// Start login (opens tab)
+const loginPromise = global.window.AletheiaAuth.initiateLogin();
+
+// Wait for tab to be created
+await new Promise(resolve => setTimeout(resolve, 10));
+
+// Get stored state for validation
+const stored = await browserMock.storage.session.get(['oauth_state']);
+
+// Simulate LinkedIn callback redirect
+const callbackUrl = `${authConfig.LAMBDA_AUTH_URL}/auth/callback?code=test-code&state=${stored.oauth_state}`;
+browserMock.__simulateTabUpdate(100, callbackUrl, 'complete');
+
+// Complete login
+const user = await loginPromise;
+expect(user).toEqual({ id: 'test-user-id', name: 'Test User' });
+```
+
+### CSRF Attack Simulation
+
+```javascript
+// Attacker provides different state
+const callbackUrl = `...?code=fake-code&state=attacker-controlled-state`;
+browserMock.__simulateTabUpdate(100, callbackUrl, 'complete');
+
+// Should reject with CSRF error
+await expect(loginPromise).rejects.toThrow(/CSRF|state/i);
+```
+
+### Tab Close Simulation
+
+```javascript
+// User closes the auth tab
+browserMock.__triggerTabRemoved(100, {});
+
+// Should reject with cancelled error
+await expect(loginPromise).rejects.toThrow(/cancelled|closed/i);
+```
+
+## Coverage
+
+The tests cover:
+
+1. **Happy Path**: Complete OAuth flow from login to token storage
+2. **Security**: CSRF state validation, namespace verification
+3. **Error Handling**: User cancellation, mismatched state
+4. **Storage Hierarchy**: Access token in session, refresh token in local
+5. **Logout**: Proper token cleanup
+
+## Mock Utilities Added
+
+| Utility | Purpose |
+|---------|---------|
+| `browserMock.tabs.create()` | Create mock tab for auth flow |
+| `browserMock.tabs.remove()` | Remove mock tab |
+| `browserMock.tabs.onUpdated.addListener()` | Register URL change listener |
+| `browserMock.__simulateTabUpdate(tabId, url, status)` | Simulate tab navigation |
+| `browserMock.__triggerTabRemoved(tabId, removeInfo)` | Simulate tab close |
+
+## Regression Testing
+
+Full test suite passes (195/196 tests, 1 intentionally skipped):
+- Chrome popup tests: PASS
+- Firefox popup tests: PASS
+- Firefox auth tests: PASS
+- Chrome auth tests: PASS
+- Extension parity tests: PASS
+- Content script tests: PASS
+
+## Manual Testing Recommendations
+
+Before release, manually test in Firefox:
+1. Install extension in Firefox Developer Edition
+2. Click "Sign in with LinkedIn" button
+3. Verify tab opens to LinkedIn OAuth page
+4. Complete LinkedIn authentication
+5. Verify tab closes and popup shows authenticated state
+6. Verify logout clears state
+
+## Known Limitations
+
+1. **LinkedIn Redirect URL**: Must be registered in LinkedIn Developer Portal before live testing
+2. **Timeout**: 5-minute timeout on OAuth flow (configurable in production)
+3. **Tab Focus**: User may need to click popup again after auth tab closes

--- a/extensions/firefox/auth.js
+++ b/extensions/firefox/auth.js
@@ -4,6 +4,14 @@
 //
 // CRITICAL: Uses browser.* namespace (NOT chrome.*)
 // Firefox extension APIs use the WebExtensions browser.* standard
+//
+// NOTE: Firefox MV3 does NOT have browser.identity API.
+// This module uses a tabs-based OAuth flow instead:
+// 1. Open auth page in new tab (browser.tabs.create)
+// 2. Monitor tab URL changes (browser.tabs.onUpdated)
+// 3. Detect callback URL and extract auth code
+// 4. Exchange code for tokens via Lambda
+// See: docs/0826-audit-cross-browser-testing.md, Issue #256
 
 // =============================================================================
 // CONFIGURATION
@@ -213,8 +221,17 @@ async function mockLogin() {
 }
 
 // =============================================================================
-// OAUTH FLOW
+// OAUTH FLOW (Firefox tabs-based - Issue #256)
 // =============================================================================
+
+/**
+ * Get the OAuth callback URL.
+ * Firefox doesn't have browser.identity, so we use a Lambda callback endpoint.
+ * @returns {string} Callback URL
+ */
+function getRedirectURL() {
+    return `${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/callback`;
+}
 
 /**
  * Build LinkedIn authorization URL with required parameters.
@@ -222,7 +239,7 @@ async function mockLogin() {
  * @returns {string} Full authorization URL
  */
 function buildAuthUrl(state) {
-    const redirectUri = browser.identity.getRedirectURL();
+    const redirectUri = getRedirectURL();
     const params = new URLSearchParams({
         response_type: 'code',
         client_id: AUTH_CONFIG.CLIENT_ID,
@@ -235,9 +252,75 @@ function buildAuthUrl(state) {
 }
 
 /**
+ * Wait for OAuth callback by monitoring tab URL changes.
+ * @param {number} tabId - The auth tab ID
+ * @param {string} callbackUrl - The callback URL prefix to watch for
+ * @returns {Promise<{code: string, state: string}>} The auth code and state
+ */
+function waitForOAuthCallback(tabId, callbackUrl) {
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            browser.tabs.onUpdated.removeListener(listener);
+            browser.tabs.onRemoved.removeListener(removedListener);
+            reject(new Error('OAuth timeout: user did not complete login within 5 minutes'));
+        }, 5 * 60 * 1000); // 5 minute timeout
+
+        const removedListener = (removedTabId) => {
+            if (removedTabId === tabId) {
+                clearTimeout(timeout);
+                browser.tabs.onUpdated.removeListener(listener);
+                browser.tabs.onRemoved.removeListener(removedListener);
+                reject(new Error('OAuth cancelled: user closed the login tab'));
+            }
+        };
+
+        const listener = (updatedTabId, changeInfo, tab) => {
+            if (updatedTabId !== tabId) return;
+            if (changeInfo.status !== 'complete') return;
+            if (!tab.url || !tab.url.startsWith(callbackUrl)) return;
+
+            // We've reached the callback URL
+            clearTimeout(timeout);
+            browser.tabs.onUpdated.removeListener(listener);
+            browser.tabs.onRemoved.removeListener(removedListener);
+
+            try {
+                const url = new URL(tab.url);
+                const code = url.searchParams.get('code');
+                const state = url.searchParams.get('state');
+                const error = url.searchParams.get('error');
+                const errorDescription = url.searchParams.get('error_description');
+
+                // Close the auth tab
+                browser.tabs.remove(tabId).catch(() => {});
+
+                if (error) {
+                    reject(new Error(`LinkedIn OAuth error: ${errorDescription || error}`));
+                } else if (!code) {
+                    reject(new Error('No authorization code received'));
+                } else {
+                    resolve({ code, state });
+                }
+            } catch (e) {
+                reject(new Error(`Failed to parse callback URL: ${e.message}`));
+            }
+        };
+
+        browser.tabs.onUpdated.addListener(listener);
+        browser.tabs.onRemoved.addListener(removedListener);
+    });
+}
+
+/**
  * Initiate LinkedIn OAuth login flow.
  *
- * Uses browser.identity.launchWebAuthFlow for Firefox-compliant OAuth.
+ * Firefox doesn't have browser.identity API, so we use a tabs-based flow:
+ * 1. Open a new tab with LinkedIn OAuth page
+ * 2. User authenticates with LinkedIn
+ * 3. LinkedIn redirects to our Lambda callback
+ * 4. We detect the callback URL and extract the auth code
+ * 5. Exchange code for tokens via Lambda
+ *
  * Includes CSRF protection via state parameter.
  *
  * @returns {Promise<{id: string, name: string}>} User info on success
@@ -252,29 +335,23 @@ async function initiateLogin() {
     // 1. Generate CSRF state
     const state = generateState();
 
-    // 2. Store state for validation (use session storage for popup context)
-    // Note: In MV3, we use browser.storage.session which is shared across extension contexts
+    // 2. Store state for validation
     await browser.storage.session.set({ oauth_state: state });
 
     // 3. Build auth URL
     const authUrl = buildAuthUrl(state);
-    const redirectUri = browser.identity.getRedirectURL();
+    const redirectUri = getRedirectURL();
 
-    console.log('[Aletheia Auth] Launching OAuth flow...');
+    console.log('[Aletheia Auth] Launching OAuth flow (tabs-based)...');
     console.log('[Aletheia Auth] Redirect URI:', redirectUri);
 
     try {
-        // 4. Launch OAuth flow
-        const responseUrl = await browser.identity.launchWebAuthFlow({
-            url: authUrl,
-            interactive: true
-        });
+        // 4. Open auth tab
+        const tab = await browser.tabs.create({ url: authUrl });
+        console.log('[Aletheia Auth] Opened auth tab:', tab.id);
 
-        // 5. Parse response
-        const url = new URL(responseUrl);
-        const returnedState = url.searchParams.get('state');
-        const code = url.searchParams.get('code');
-        const error = url.searchParams.get('error');
+        // 5. Wait for OAuth callback
+        const { code, state: returnedState } = await waitForOAuthCallback(tab.id, redirectUri);
 
         // 6. Validate state (CSRF protection)
         const stored = await browser.storage.session.get(['oauth_state']);
@@ -284,16 +361,7 @@ async function initiateLogin() {
             throw new Error('CSRF detected: state mismatch');
         }
 
-        // 7. Check for errors
-        if (error) {
-            throw new Error(`LinkedIn OAuth error: ${error}`);
-        }
-
-        if (!code) {
-            throw new Error('No authorization code received');
-        }
-
-        // 8. Exchange code for tokens via Lambda
+        // 7. Exchange code for tokens via Lambda
         console.log('[Aletheia Auth] Exchanging code for tokens...');
         const tokenResponse = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/token`, {
             method: 'POST',
@@ -311,7 +379,7 @@ async function initiateLogin() {
 
         const tokenData = await tokenResponse.json();
 
-        // 9. Store tokens
+        // 8. Store tokens
         await storeTokens(
             tokenData.accessToken,
             tokenData.refreshToken,
@@ -348,6 +416,9 @@ window.AletheiaAuth = {
     getAuthState,
     getAccessToken,
     clearTokens,
+    // Exposed for testing
+    generateState,
+    getRedirectURL,
     // Config for debugging
     getConfig: () => ({ ...AUTH_CONFIG, CLIENT_ID: '***' })  // Hide client ID in logs
 };

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -443,6 +443,67 @@ def delete_user_data(user_id: str) -> int:
         raise
 
 
+def handle_oauth_callback(query_params: dict) -> dict:
+    """
+    Handle GET /auth/callback - OAuth redirect endpoint for Firefox.
+
+    Firefox doesn't have browser.identity API, so we use a Lambda callback.
+    LinkedIn redirects here with ?code=...&state=...
+    We return an HTML page that the extension can detect and extract the code from.
+
+    Issue #256: Firefox OAuth tabs-based flow.
+    """
+    code = query_params.get("code", "")
+    state = query_params.get("state", "")
+    error = query_params.get("error", "")
+    error_description = query_params.get("error_description", "")
+
+    if error:
+        # OAuth error from LinkedIn
+        html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Aletheia - Login Failed</title>
+    <style>
+        body {{ font-family: system-ui, sans-serif; max-width: 400px; margin: 50px auto; text-align: center; }}
+        .error {{ color: #dc3545; }}
+    </style>
+</head>
+<body>
+    <h1 class="error">Login Failed</h1>
+    <p>{error_description or error}</p>
+    <p>You can close this tab.</p>
+    <div id="oauth-result" data-error="{error}" data-error-description="{error_description}"></div>
+</body>
+</html>"""
+    else:
+        # Success - include code and state in a hidden div for extension to extract
+        html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Aletheia - Login Successful</title>
+    <style>
+        body {{ font-family: system-ui, sans-serif; max-width: 400px; margin: 50px auto; text-align: center; }}
+        .success {{ color: #28a745; }}
+        #oauth-result {{ display: none; }}
+    </style>
+</head>
+<body>
+    <h1 class="success">Login Successful!</h1>
+    <p>You can close this tab and return to the extension.</p>
+    <div id="oauth-result" data-code="{code}" data-state="{state}"></div>
+</body>
+</html>"""
+
+    return {
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "text/html; charset=utf-8",
+        },
+        "body": html,
+    }
+
+
 def handle_delete_my_data(headers: dict) -> dict:
     """
     Handle DELETE /my-data - GDPR Article 17 data erasure endpoint.
@@ -501,6 +562,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
     - POST /auth/token - Exchange code for tokens
     - POST /auth/refresh - Refresh access token
     - GET /auth/validate - Validate access token
+    - GET /auth/callback - OAuth callback for Firefox (Issue #256)
     - DELETE /my-data - GDPR erasure (Issue #147)
 
     See: docs/1116-linkedin-oauth.md, docs/1147-gdpr-data-erasure.md
@@ -527,6 +589,9 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
         headers = event.get("headers", {})
 
+        # Parse query string parameters (for callback)
+        query_params = event.get("queryStringParameters", {}) or {}
+
         # Route to appropriate handler
         if path == "/auth/token" and http_method == "POST":
             return handle_token_exchange(body)
@@ -534,6 +599,8 @@ def lambda_handler(event: dict, context: Any) -> dict:
             return handle_token_refresh(body)
         elif path == "/auth/validate" and http_method == "GET":
             return handle_validate_token(headers)
+        elif path == "/auth/callback" and http_method == "GET":
+            return handle_oauth_callback(query_params)
         elif path == "/my-data" and http_method == "DELETE":
             return handle_delete_my_data(headers)
         else:

--- a/tests/mocks/firefox-api.mock.js
+++ b/tests/mocks/firefox-api.mock.js
@@ -62,6 +62,7 @@ export function createFirefoxMock(options = {}) {
 
   // Internal tab state
   let mockTabs = [];
+  let nextTabId = 100; // Start tab IDs at 100 to distinguish from default tab
 
   // Message handler responses
   let messageResponses = {};
@@ -71,6 +72,7 @@ export function createFirefoxMock(options = {}) {
   const installHandlers = [];
   const contextMenuClickHandlers = [];
   const tabRemovedHandlers = [];
+  const tabUpdatedHandlers = [];
 
   // Badge state per tab
   const badgeState = new Map();
@@ -139,9 +141,37 @@ export function createFirefoxMock(options = {}) {
           }
         });
       }),
+      create: vi.fn().mockImplementation((createProperties) => {
+        // Create a mock tab for OAuth flow testing
+        const newTab = {
+          id: nextTabId++,
+          url: createProperties.url || 'about:blank',
+          active: createProperties.active !== false,
+          currentWindow: true
+        };
+        mockTabs.push(newTab);
+        return Promise.resolve(newTab);
+      }),
+      remove: vi.fn().mockImplementation((tabId) => {
+        mockTabs = mockTabs.filter(t => t.id !== tabId);
+        return Promise.resolve();
+      }),
+      onUpdated: {
+        addListener: vi.fn().mockImplementation((handler) => {
+          tabUpdatedHandlers.push(handler);
+        }),
+        removeListener: vi.fn().mockImplementation((handler) => {
+          const index = tabUpdatedHandlers.indexOf(handler);
+          if (index > -1) tabUpdatedHandlers.splice(index, 1);
+        })
+      },
       onRemoved: {
         addListener: vi.fn().mockImplementation((handler) => {
           tabRemovedHandlers.push(handler);
+        }),
+        removeListener: vi.fn().mockImplementation((handler) => {
+          const index = tabRemovedHandlers.indexOf(handler);
+          if (index > -1) tabRemovedHandlers.splice(index, 1);
         })
       }
     },
@@ -385,6 +415,27 @@ export function createFirefoxMock(options = {}) {
       }
     },
 
+    /**
+     * Simulate a tab URL update (for OAuth flow testing).
+     * @param {number} tabId - The tab ID
+     * @param {string} url - The new URL
+     * @param {string} status - Load status ('loading' or 'complete')
+     */
+    __simulateTabUpdate: (tabId, url, status = 'complete') => {
+      // Update the mock tab's URL
+      const tab = mockTabs.find(t => t.id === tabId);
+      if (tab) {
+        tab.url = url;
+      }
+
+      const changeInfo = { status, url };
+      const tabInfo = tab || { id: tabId, url, active: true, currentWindow: true };
+
+      for (const handler of tabUpdatedHandlers) {
+        handler(tabId, changeInfo, tabInfo);
+      }
+    },
+
     /** Get badge state for a tab */
     __getBadgeState: (tabId) => {
       return badgeState.get(tabId) || { text: '', color: '' };
@@ -400,11 +451,13 @@ export function createFirefoxMock(options = {}) {
       localStorageData = { allowlist: [] };
       sessionStorageData = {};
       mockTabs = [];
+      nextTabId = 100;
       messageResponses = {};
       messageListeners.length = 0;
       installHandlers.length = 0;
       contextMenuClickHandlers.length = 0;
       tabRemovedHandlers.length = 0;
+      tabUpdatedHandlers.length = 0;
       badgeState.clear();
       scriptInjectionResults = [{ result: {} }];
       oauthConfig = {

--- a/tests/unit/firefox/auth.test.js
+++ b/tests/unit/firefox/auth.test.js
@@ -80,7 +80,12 @@ function createAuthEnvironment(options = {}) {
     }
   }
 
-  return { browserMock };
+  // Auth config from the source file (for test assertions)
+  const authConfig = {
+    LAMBDA_AUTH_URL: 'https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws'
+  };
+
+  return { browserMock, authConfig };
 }
 
 // ============================================================================
@@ -92,8 +97,12 @@ describe('Namespace Verification', () => {
     expect(authJsSource.length).toBeGreaterThan(0);
   });
 
-  it('uses browser.identity not chrome.identity', () => {
-    expect(authJsSource).toContain('browser.identity');
+  it('does NOT use browser.identity (Firefox MV3 does not have it)', () => {
+    // Firefox MV3 doesn't have browser.identity API
+    // We use a tabs-based OAuth flow instead
+    // See: docs/0826-audit-cross-browser-testing.md, Issue #256
+    expect(authJsSource).not.toContain('browser.identity.launchWebAuthFlow');
+    expect(authJsSource).not.toContain('browser.identity.getRedirectURL');
     expect(authJsSource).not.toContain('chrome.identity');
   });
 
@@ -133,66 +142,35 @@ describe('CSRF State Generation', () => {
     expect(global.window.AletheiaAuth).toBeDefined();
   });
 
-  it('generateState produces 64-character hex string', async () => {
-    // Access internal function if exposed, or test via initiateLogin
-    // For now, we'll test the outcome: state stored in session storage
-    const { browserMock } = env;
-
-    // Trigger login to generate state
-    if (global.window.AletheiaAuth) {
-      // Set mock mode to avoid actual OAuth flow
-      // The state should be stored before launchWebAuthFlow is called
-      try {
-        await global.window.AletheiaAuth.initiateLogin();
-      } catch (_e) {
-        // May fail if fetch mock isn't perfect, but state should be set
-      }
-
-      // Check that oauth_state was stored in session
-      const sessionData = browserMock.__getSessionStorageData();
-      if (sessionData.oauth_state) {
-        expect(sessionData.oauth_state).toMatch(/^[0-9a-f]{64}$/);
-      }
+  it('generateState produces 64-character hex string', () => {
+    // Use the exposed generateState function directly
+    if (global.window.AletheiaAuth && global.window.AletheiaAuth.generateState) {
+      const state = global.window.AletheiaAuth.generateState();
+      expect(state).toMatch(/^[0-9a-f]{64}$/);
     }
   });
 
-  it('generates unique state values', async () => {
+  it('generates unique state values', () => {
     const states = new Set();
-    const { browserMock } = env;
 
     // Generate multiple states
-    for (let i = 0; i < 10; i++) {
-      browserMock.__resetSessionStorage();
-
-      if (global.window.AletheiaAuth) {
-        try {
-          await global.window.AletheiaAuth.initiateLogin();
-        } catch (_e) {
-          // Expected - we just want the state
-        }
-
-        const sessionData = browserMock.__getSessionStorageData();
-        if (sessionData.oauth_state) {
-          states.add(sessionData.oauth_state);
-        }
+    if (global.window.AletheiaAuth && global.window.AletheiaAuth.generateState) {
+      for (let i = 0; i < 10; i++) {
+        const state = global.window.AletheiaAuth.generateState();
+        states.add(state);
       }
-    }
 
-    // All states should be unique
-    if (states.size > 0) {
+      // All states should be unique
       expect(states.size).toBe(10);
     }
   });
 });
 
 // ============================================================================
-// CSRF STATE VALIDATION TESTS
+// CSRF STATE VALIDATION TESTS (Tabs-based flow - Issue #256)
 // ============================================================================
 
-// SKIPPED: These tests require browser.identity API which doesn't exist in Firefox MV3.
-// Firefox OAuth must be reimplemented using a tabs-based flow.
-// See: docs/0826-audit-cross-browser-testing.md
-describe.skip('CSRF State Validation', () => {
+describe('CSRF State Validation', () => {
   let env;
 
   beforeEach(() => {
@@ -209,26 +187,77 @@ describe.skip('CSRF State Validation', () => {
   it('rejects mismatched state parameter', async () => {
     const { browserMock } = env;
 
-    // Configure mock to return a different state (CSRF attack simulation)
-    browserMock.__setOAuthReturnedState('attacker-controlled-state');
+    if (!global.window.AletheiaAuth) return;
 
-    if (global.window.AletheiaAuth) {
-      await expect(global.window.AletheiaAuth.initiateLogin())
-        .rejects.toThrow(/CSRF|state/i);
-    }
+    // Start login - this will create a tab
+    const loginPromise = global.window.AletheiaAuth.initiateLogin();
+
+    // Wait for tab to be created
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Get the stored state (we don't use it - attacker uses different state)
+    const stored = await browserMock.storage.session.get(['oauth_state']);
+    const _correctState = stored.oauth_state;
+
+    // Simulate LinkedIn callback with WRONG state (CSRF attack)
+    const callbackUrl = `${env.authConfig.LAMBDA_AUTH_URL}/auth/callback?code=fake-code&state=attacker-controlled-state`;
+    browserMock.__simulateTabUpdate(100, callbackUrl, 'complete');
+
+    // Should reject with CSRF error
+    await expect(loginPromise).rejects.toThrow(/CSRF|state/i);
   });
 
   it('accepts matching state parameter', async () => {
     const { browserMock } = env;
 
-    // Configure mock to echo back the correct state (valid flow)
-    browserMock.__setOAuthReturnedState(null); // null = echo back sent state
+    if (!global.window.AletheiaAuth) return;
 
-    if (global.window.AletheiaAuth) {
-      // Should not throw CSRF error
-      await expect(global.window.AletheiaAuth.initiateLogin())
-        .resolves.toBeDefined();
-    }
+    // Mock successful token exchange
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresIn: 3600,
+        user: { id: 'test-user-id', name: 'Test User' }
+      })
+    });
+
+    // Start login - this will create a tab
+    const loginPromise = global.window.AletheiaAuth.initiateLogin();
+
+    // Wait for tab to be created
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Get the stored state (this is what the extension expects back)
+    const stored = await browserMock.storage.session.get(['oauth_state']);
+    const correctState = stored.oauth_state;
+
+    // Simulate LinkedIn callback with CORRECT state
+    const callbackUrl = `${env.authConfig.LAMBDA_AUTH_URL}/auth/callback?code=valid-auth-code&state=${correctState}`;
+    browserMock.__simulateTabUpdate(100, callbackUrl, 'complete');
+
+    // Should succeed
+    const user = await loginPromise;
+    expect(user).toEqual({ id: 'test-user-id', name: 'Test User' });
+  });
+
+  it('handles user closing auth tab', async () => {
+    const { browserMock } = env;
+
+    if (!global.window.AletheiaAuth) return;
+
+    // Start login - this will create a tab
+    const loginPromise = global.window.AletheiaAuth.initiateLogin();
+
+    // Wait for tab to be created
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Simulate user closing the auth tab
+    browserMock.__triggerTabRemoved(100, {});
+
+    // Should reject with cancelled error
+    await expect(loginPromise).rejects.toThrow(/cancelled|closed/i);
   });
 });
 
@@ -251,43 +280,82 @@ describe('Token Storage Hierarchy', () => {
   });
 
   it('stores access token in session storage', async () => {
-    const { browserMock } = env;
+    const { browserMock, authConfig } = env;
 
-    if (global.window.AletheiaAuth) {
-      try {
-        await global.window.AletheiaAuth.initiateLogin();
-      } catch (_e) {
-        // May fail, check storage anyway
-      }
+    if (!global.window.AletheiaAuth) return;
 
-      // Verify browser.storage.session.set was called with accessToken
-      expect(browserMock.storage.session.set).toHaveBeenCalled();
+    // Mock successful token exchange
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        accessToken: 'test-access-token',
+        refreshToken: 'test-refresh-token',
+        expiresIn: 3600,
+        user: { id: 'test-user-id', name: 'Test User' }
+      })
+    });
 
-      const sessionData = browserMock.__getSessionStorageData();
-      // Access token should be in session storage
-      if (Object.keys(sessionData).length > 0) {
-        expect(sessionData.accessToken || sessionData.oauth_state).toBeDefined();
-      }
-    }
+    // Start login
+    const loginPromise = global.window.AletheiaAuth.initiateLogin();
+
+    // Wait for tab to be created
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Get the stored state
+    const stored = await browserMock.storage.session.get(['oauth_state']);
+    const correctState = stored.oauth_state;
+
+    // Simulate successful OAuth callback
+    const callbackUrl = `${authConfig.LAMBDA_AUTH_URL}/auth/callback?code=test-code&state=${correctState}`;
+    browserMock.__simulateTabUpdate(100, callbackUrl, 'complete');
+
+    // Complete login
+    await loginPromise;
+
+    // Verify access token is in session storage
+    const sessionData = browserMock.__getSessionStorageData();
+    expect(sessionData.accessToken).toBe('test-access-token');
+    expect(sessionData.expiresAt).toBeDefined();
   });
 
   it('stores refresh token in local storage', async () => {
-    const { browserMock } = env;
+    const { browserMock, authConfig } = env;
 
-    if (global.window.AletheiaAuth) {
-      try {
-        await global.window.AletheiaAuth.initiateLogin();
-      } catch (_e) {
-        // May fail, check storage anyway
-      }
+    if (!global.window.AletheiaAuth) return;
 
-      // Verify browser.storage.local.set was called
-      // After successful login, refresh token should be in local
-      const localData = browserMock.__getLocalStorageData();
-      if (localData.refreshToken) {
-        expect(localData.refreshToken).toBeDefined();
-      }
-    }
+    // Mock successful token exchange
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        accessToken: 'test-access-token',
+        refreshToken: 'test-refresh-token',
+        expiresIn: 3600,
+        user: { id: 'test-user-id', name: 'Test User' }
+      })
+    });
+
+    // Start login
+    const loginPromise = global.window.AletheiaAuth.initiateLogin();
+
+    // Wait for tab to be created
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Get the stored state
+    const stored = await browserMock.storage.session.get(['oauth_state']);
+    const correctState = stored.oauth_state;
+
+    // Simulate successful OAuth callback
+    const callbackUrl = `${authConfig.LAMBDA_AUTH_URL}/auth/callback?code=test-code&state=${correctState}`;
+    browserMock.__simulateTabUpdate(100, callbackUrl, 'complete');
+
+    // Complete login
+    await loginPromise;
+
+    // Verify refresh token and user info are in local storage
+    const localData = browserMock.__getLocalStorageData();
+    expect(localData.refreshToken).toBe('test-refresh-token');
+    expect(localData.userId).toBe('test-user-id');
+    expect(localData.displayName).toBe('Test User');
   });
 
   it('clears all tokens on logout', async () => {


### PR DESCRIPTION
## Summary

- Fixed Firefox OAuth authentication by replacing non-existent `browser.identity` API with tabs-based flow
- Added `/auth/callback` endpoint to Lambda for OAuth redirect
- Rewrote Firefox auth.js to use `browser.tabs.create()` and URL monitoring
- Updated Firefox mock with tab lifecycle simulation for testing
- All 18 Firefox auth tests pass

## Problem

Firefox MV3 does NOT have `browser.identity` API (Chrome-only). The Firefox extension was silently failing OAuth.

## Solution

Tabs-based OAuth flow:
1. Open LinkedIn OAuth page in new tab via `browser.tabs.create()`
2. Monitor tab URL changes via `browser.tabs.onUpdated`
3. Detect callback URL and extract auth code
4. Close tab and exchange code for tokens via Lambda

## Test plan

- [x] All Firefox auth tests pass (18/18)
- [x] Full test suite green (195 passed, 1 skipped)
- [x] ESLint passes
- [x] Pre-commit hooks pass
- [ ] Manual test in Firefox Developer Edition (post-merge, requires LinkedIn redirect URL registration)

## Deployment notes

After merge, register callback URL in LinkedIn Developer Portal:
`https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws/auth/callback`

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)