### PR TITLE
fix(ci): add ESLint security plugin validation (close #251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify ESLint security plugins installed
+        run: |
+          echo "=== ESLint Version ==="
+          npx eslint --version
+          echo ""
+          echo "=== Installed ESLint Plugins ==="
+          npm ls eslint-plugin-security eslint-plugin-no-unsanitized --depth=0
+          echo ""
+          echo "=== ESLint Config Validation ==="
+          npx eslint --print-config extensions/chrome/popup.js | head -20
+
       - name: Lint Chrome extension
         run: npx eslint extensions/chrome/
 

--- a/docs/reports/251/implementation-report.md
+++ b/docs/reports/251/implementation-report.md
@@ -1,0 +1,44 @@
+# Implementation Report: Issue #251 - ESLint Security Plugin CI Validation
+
+## Summary
+Added CI validation step to verify ESLint security plugins are installed and configured correctly, preventing silent failures where ESLint crashes but CI passes.
+
+## Problem
+Issue #246 revealed that ESLint security plugins (eslint-plugin-security, eslint-plugin-no-unsanitized) were declared but not installed due to a package.json misconfiguration. CI passed because there was no validation that the plugins actually loaded.
+
+## Solution
+Added a verification step in `.github/workflows/ci.yml` before the ESLint linting steps:
+
+1. **ESLint version check** - Confirms ESLint CLI is available
+2. **Plugin installation check** - `npm ls` verifies both security plugins are installed
+3. **Config validation** - `--print-config` confirms plugins load and rules are active
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | Added "Verify ESLint security plugins installed" step (lines 102-111) |
+
+## CI Workflow Changes
+
+```yaml
+- name: Verify ESLint security plugins installed
+  run: |
+    echo "=== ESLint Version ==="
+    npx eslint --version
+    echo ""
+    echo "=== Installed ESLint Plugins ==="
+    npm ls eslint-plugin-security eslint-plugin-no-unsanitized --depth=0
+    echo ""
+    echo "=== ESLint Config Validation ==="
+    npx eslint --print-config extensions/chrome/popup.js | head -20
+```
+
+## Why This Works
+
+- `npm ls` exits with non-zero if packages are missing, failing CI
+- `--print-config` errors if ESLint config is invalid or plugins fail to load
+- This step runs BEFORE linting, providing early failure with clear diagnostics
+
+## Backward Compatibility
+No breaking changes. Existing CI behavior is preserved; this adds validation only.

--- a/docs/reports/251/test-report.md
+++ b/docs/reports/251/test-report.md
@@ -1,0 +1,55 @@
+# Test Report: Issue #251 - ESLint Security Plugin CI Validation
+
+## Test Environment
+- Node.js 20.x
+- ESLint 9.x (flat config)
+- Windows 11 / Git Bash
+
+## Manual Tests Performed
+
+### 1. Plugin Installation Check
+```bash
+$ npm ls eslint-plugin-security eslint-plugin-no-unsanitized --depth=0
+aletheia@1.0.0 C:\Users\mcwiz\Projects\Aletheia
+├── eslint-plugin-no-unsanitized@4.1.4
+└── eslint-plugin-security@3.0.1
+```
+**Result:** PASS - Both plugins installed
+
+### 2. ESLint Config Validation
+```bash
+$ npx eslint --print-config extensions/chrome/popup.js | grep "security/"
+    "security/detect-object-injection": [
+    "security/detect-non-literal-regexp": [
+    "security/detect-unsafe-regex": [
+    "security/detect-eval-with-expression": [
+```
+**Result:** PASS - Security rules active in config
+
+### 3. Chrome Extension Lint
+```bash
+$ npx eslint extensions/chrome/
+```
+**Result:** PASS - No errors, no warnings
+
+### 4. Firefox Extension Lint
+```bash
+$ npx eslint extensions/firefox/
+```
+**Result:** PASS - No errors, no warnings
+
+## CI Validation
+
+The PR CI run will confirm:
+- [ ] `npm ls` exits 0 when plugins are installed
+- [ ] `--print-config` outputs valid JSON config
+- [ ] ESLint runs successfully on both extensions
+
+## Acceptance Criteria Verification
+
+| Criteria | Status |
+|----------|--------|
+| Run npm install to install declared dependencies | COMPLETE (already done in #246) |
+| Verify eslint-plugin-security is working | COMPLETE |
+| Add CI check that ESLint produces output | COMPLETE |
+| No silent ESLint failures | COMPLETE |


### PR DESCRIPTION
## Summary
- Add CI validation step to verify ESLint security plugins are installed before linting
- Prevents silent failures where ESLint crashes but CI passes (issue #246 root cause)
- Verifies eslint-plugin-security and eslint-plugin-no-unsanitized are loaded

## Test plan
- [ ] CI passes with new validation step
- [ ] `npm ls` verifies plugins installed
- [ ] `--print-config` confirms security rules active

🤖 Generated with [Claude Code](https://claude.com/claude-code)