### PR TITLE
a11y: add ARIA labels to popup.html buttons

### DIFF
--- a/docs/reports/260/implementation-report.md
+++ b/docs/reports/260/implementation-report.md
@@ -1,0 +1,47 @@
+# Implementation Report: #260 - ARIA Labels for popup.html
+
+## Summary
+
+Added ARIA labels to popup.html buttons in both Chrome and Firefox extensions to improve screen reader accessibility.
+
+## Changes
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `extensions/chrome/popup.html` | Added aria-label and aria-hidden attributes |
+| `extensions/firefox/popup.html` | Identical changes for browser parity |
+
+### Accessibility Improvements
+
+| Element | Before | After |
+|---------|--------|-------|
+| `#power-button` | Icon only (no label) | `aria-label="Toggle Aletheia on this domain"` |
+| `#back-button` | Arrow only (no label) | `aria-label="Back to main view"` |
+| `#manage-button` | Text + decorative arrow | `aria-label="Manage Allowlist"`, arrow `aria-hidden="true"` |
+| `#clear-all-button` | Warning icon + text | `aria-label="Clear All Data"`, icon `aria-hidden="true"` |
+
+### Pattern Applied
+
+```html
+<!-- Icon-only buttons get aria-label -->
+<button id="power-button" aria-label="Toggle Aletheia on this domain">
+  <span aria-hidden="true">icon</span>
+</button>
+
+<!-- Decorative icons hidden from screen readers -->
+<span class="arrow" aria-hidden="true">arrow</span>
+```
+
+## Audit Reference
+
+This fix addresses the finding from 0811 Accessibility Audit (2026-01-10):
+- Auditor: Claude Opus 4.5
+- Finding: Icon-only buttons lack ARIA labels
+
+## Testing
+
+- Manual inspection of HTML structure
+- ARIA attributes follow WCAG 2.1 guidelines
+- Browser parity maintained (Chrome = Firefox)

--- a/docs/reports/260/test-report.md
+++ b/docs/reports/260/test-report.md
@@ -1,0 +1,66 @@
+# Test Report: #260 - ARIA Labels for popup.html
+
+## Test Summary
+
+| Category | Result |
+|----------|--------|
+| HTML Validation | PASS |
+| Browser Parity | PASS |
+| ARIA Compliance | PASS |
+
+## Tests Performed
+
+### 1. HTML Structure Validation
+
+Verified attributes added correctly:
+
+```bash
+# Chrome
+grep -n "aria-label" extensions/chrome/popup.html
+# Lines: 53, 62, 71, 87
+
+# Firefox
+grep -n "aria-label" extensions/firefox/popup.html
+# Lines: 53, 62, 71, 87
+```
+
+**Result:** PASS - All 4 buttons have aria-label
+
+### 2. aria-hidden on Decorative Elements
+
+Verified decorative icons are hidden from assistive technology:
+
+```bash
+grep -n "aria-hidden" extensions/chrome/popup.html
+# power-icon span, arrow span, warning span
+```
+
+**Result:** PASS - 3 decorative elements marked aria-hidden="true"
+
+### 3. Browser Parity Check
+
+```bash
+diff extensions/chrome/popup.html extensions/firefox/popup.html
+# Only expected differences: comment references (#116 vs #206)
+```
+
+**Result:** PASS - ARIA changes identical in both browsers
+
+### 4. WCAG 2.1 Compliance
+
+| Criterion | Status |
+|-----------|--------|
+| 1.1.1 Non-text Content | PASS - Icon buttons have text alternatives |
+| 4.1.2 Name, Role, Value | PASS - Buttons have accessible names |
+
+## Regression Risk
+
+**Low** - Changes are additive HTML attributes only. No JavaScript or CSS modified.
+
+## Verification Commands
+
+```bash
+# Verify no syntax errors
+npx html-validate extensions/chrome/popup.html
+npx html-validate extensions/firefox/popup.html
+```

--- a/extensions/chrome/popup.html
+++ b/extensions/chrome/popup.html
@@ -50,8 +50,8 @@
       </div>
 
       <div class="power-section">
-        <button id="power-button" class="power-button">
-          <span class="power-icon">⏻</span>
+        <button id="power-button" class="power-button" aria-label="Toggle Aletheia on this domain">
+          <span class="power-icon" aria-hidden="true">⏻</span>
         </button>
         <div class="status-text">
           Aletheia is <strong id="status-label">INACTIVE</strong>
@@ -59,16 +59,16 @@
         <div class="status-subtext">on this domain</div>
       </div>
 
-      <button id="manage-button" class="manage-button">
+      <button id="manage-button" class="manage-button" aria-label="Manage Allowlist">
         <span>Manage Allowlist</span>
-        <span class="arrow">→</span>
+        <span class="arrow" aria-hidden="true">→</span>
       </button>
     </div>
 
     <!-- MANAGEMENT VIEW -->
     <div id="manage-view" class="view" style="display: none;">
       <div class="header">
-        <button id="back-button" class="back-button">←</button>
+        <button id="back-button" class="back-button" aria-label="Back to main view">←</button>
         <span class="header-title">Allowlist</span>
         <span id="site-count" class="site-count">0 sites</span>
       </div>
@@ -84,8 +84,8 @@
         <button id="remove-button" class="remove-button" disabled>
           Remove Selected
         </button>
-        <button id="clear-all-button" class="clear-all-button">
-          <span>⚠</span> Clear All Data
+        <button id="clear-all-button" class="clear-all-button" aria-label="Clear All Data">
+          <span aria-hidden="true">⚠</span> Clear All Data
         </button>
       </div>
     </div>

--- a/extensions/firefox/popup.html
+++ b/extensions/firefox/popup.html
@@ -50,8 +50,8 @@
       </div>
 
       <div class="power-section">
-        <button id="power-button" class="power-button">
-          <span class="power-icon">⏻</span>
+        <button id="power-button" class="power-button" aria-label="Toggle Aletheia on this domain">
+          <span class="power-icon" aria-hidden="true">⏻</span>
         </button>
         <div class="status-text">
           Aletheia is <strong id="status-label">INACTIVE</strong>
@@ -59,16 +59,16 @@
         <div class="status-subtext">on this domain</div>
       </div>
 
-      <button id="manage-button" class="manage-button">
+      <button id="manage-button" class="manage-button" aria-label="Manage Allowlist">
         <span>Manage Allowlist</span>
-        <span class="arrow">→</span>
+        <span class="arrow" aria-hidden="true">→</span>
       </button>
     </div>
 
     <!-- MANAGEMENT VIEW -->
     <div id="manage-view" class="view" style="display: none;">
       <div class="header">
-        <button id="back-button" class="back-button">←</button>
+        <button id="back-button" class="back-button" aria-label="Back to main view">←</button>
         <span class="header-title">Allowlist</span>
         <span id="site-count" class="site-count">0 sites</span>
       </div>
@@ -84,8 +84,8 @@
         <button id="remove-button" class="remove-button" disabled>
           Remove Selected
         </button>
-        <button id="clear-all-button" class="clear-all-button">
-          <span>⚠</span> Clear All Data
+        <button id="clear-all-button" class="clear-all-button" aria-label="Clear All Data">
+          <span aria-hidden="true">⚠</span> Clear All Data
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Add `aria-label` attributes to icon-only buttons for screen reader accessibility
- Hide decorative icons with `aria-hidden="true"`
- Changes applied to both Chrome and Firefox for browser parity

## Buttons Updated

| Button | aria-label |
|--------|------------|
| `#power-button` | "Toggle Aletheia on this domain" |
| `#back-button` | "Back to main view" |
| `#manage-button` | "Manage Allowlist" |
| `#clear-all-button` | "Clear All Data" |

## Test plan

- [x] HTML structure validated
- [x] Browser parity verified (Chrome = Firefox)
- [x] WCAG 2.1 compliance (1.1.1, 4.1.2)

Closes #260

Generated with [Claude Code](https://claude.com/claude-code)