### PR TITLE
test(firefox): add e2e overlay tests with shadow dom patch

### DIFF
--- a/docs/0003-file-inventory.md
+++ b/docs/0003-file-inventory.md
@@ -352,6 +352,9 @@
 | `tests/e2e/waf-integration.spec.js` | **Test** | 🟢 **Stable** | #95 | Playwright E2E tests for WAF integration. |
 | `tests/e2e/age-gate.spec.js` | **Test** | 🟢 **Stable** | #104 | Playwright E2E tests for age-restricted site blocking. |
 | `tests/e2e/xss-protection.spec.js` | **Test** | 🟢 **Stable** | #95 | Playwright E2E tests for XSS protection. |
+| `tests/e2e/museum-label.spec.js` | **Test** | 🟡 **Beta** | #125 | Playwright E2E tests for Museum Label UI (Chrome). |
+| `tests/e2e/firefox/overlay.spec.js` | **Test** | 🟢 **Stable** | #265 | Playwright E2E tests for Firefox overlay rendering. |
+| `tests/e2e/helpers/overlay-helpers.js` | **Helper** | 🟢 **Stable** | #265 | Shared helpers for overlay E2E tests (shadow DOM access). |
 | `tests/fixtures/html/test-waf.html` | **Fixture** | 🟢 **Stable** | #95 | Test page for WAF E2E tests. |
 | `tests/fixtures/html/test-adult.html` | **Fixture** | 🟢 **Stable** | #104 | Test page with adult rating meta tag. |
 | `tests/fixtures/html/test-rta.html` | **Fixture** | 🟢 **Stable** | #104 | Test page with RTA label pattern. |

--- a/docs/reports/265/implementation-report.md
+++ b/docs/reports/265/implementation-report.md
@@ -1,0 +1,77 @@
+# Implementation Report: #265 Firefox Overlay E2E Tests
+
+## Summary
+
+Added E2E tests for Firefox overlay.js to verify rendering and behavior in the Gecko engine. Tests use script injection approach (not full extension loading) matching the existing Chrome test pattern.
+
+## Implementation Approach
+
+### Key Decision: Shadow DOM Access in Firefox
+
+**Problem:** Firefox doesn't expose closed shadow roots like Chrome DevTools does. The existing Chrome tests attempt to access `host.shadowRoot`, which returns `null` for `mode: 'closed'` shadow DOM.
+
+**Solution:** Added shadow DOM patching in `injectOverlay()` helper that forces `mode: 'open'` for testing:
+
+```javascript
+if (browser === 'firefox') {
+    await page.evaluate(() => {
+        const originalAttachShadow = Element.prototype.attachShadow;
+        Element.prototype.attachShadow = function(options) {
+            return originalAttachShadow.call(this, { ...options, mode: 'open' });
+        });
+    });
+}
+```
+
+This allows tests to query shadow DOM contents while preserving production security (closed shadow root).
+
+### Files Created/Modified
+
+| File | Action | Description |
+|------|--------|-------------|
+| `tests/e2e/helpers/overlay-helpers.js` | Created | Shared test helpers extracted for reuse |
+| `tests/e2e/firefox/overlay.spec.js` | Created | 10 Firefox-specific E2E tests |
+| `playwright.config.js` | Modified | Added `firefox-overlay` project |
+
+### Test Coverage
+
+| Test ID | Description | Status |
+|---------|-------------|--------|
+| 010 | Neutral badge renders correctly | PASS |
+| 020 | Warning badge renders correctly | PASS |
+| 030 | Block badge renders correctly | PASS |
+| 040 | Shadow DOM isolation (styles don't bleed) | PASS |
+| 050 | Z-index stacking above page elements | PASS |
+| 060 | Expand/collapse context | PASS |
+| 070 | Close button | PASS |
+| 080 | Escape key closes | PASS |
+| 090 | Focus management | PASS |
+| 100 | XSS prevention | PASS |
+
+### Firefox-Specific Additions
+
+1. **Gecko-specific Shadow DOM tests** (040, 050): Verify style isolation and z-index stacking work correctly in Firefox's rendering engine.
+
+2. **Z-index test improvement**: Test creates high z-index page elements (`z-index: 999999` and `z-index: 9999999`) to verify overlay stays on top at `z-index: 2147483647`.
+
+## Pre-existing Issue Discovered
+
+**Chrome museum-label tests are broken on main branch** (12/16 failing). Root cause: they access `host.shadowRoot` which returns `null` for closed shadow DOM. This is NOT a regression from this PR - tests fail on main too.
+
+The same patching technique used for Firefox tests could fix Chrome tests, but that's out of scope for #265.
+
+## LLD Compliance
+
+Per `docs/lld/active/1265-firefox-overlay-e2e.md`:
+
+- [x] `tests/e2e/firefox/overlay.spec.js` created
+- [x] `tests/e2e/helpers/overlay-helpers.js` extracted
+- [x] 10 Firefox overlay tests pass (exceeds LLD's 9 target)
+- [x] Playwright config updated for Firefox project
+- [x] No regression in Firefox tests (Chrome tests have pre-existing failure)
+
+## Out of Scope
+
+- Fixing pre-existing Chrome test failures (separate issue)
+- Full Firefox extension loading in Playwright
+- Firefox popup.js E2E tests

--- a/docs/reports/265/test-report.md
+++ b/docs/reports/265/test-report.md
@@ -1,0 +1,85 @@
+# Test Report: #265 Firefox Overlay E2E Tests
+
+## Test Execution Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | 10 |
+| Passed | 10 |
+| Failed | 0 |
+| Duration | 10.1s |
+| Browser | Firefox (Playwright) |
+| Mode | Headless |
+
+## Test Results
+
+```
+Running 10 tests using 1 worker
+
+  ✓  1 [firefox-overlay] › firefox/overlay.spec.js:31:9 › Firefox Overlay (#265) › Rendering (Gecko) › 010: Neutral badge renders correctly in Firefox (1.0s)
+  ✓  2 [firefox-overlay] › firefox/overlay.spec.js:54:9 › Firefox Overlay (#265) › Rendering (Gecko) › 020: Warning badge renders correctly in Firefox (730ms)
+  ✓  3 [firefox-overlay] › firefox/overlay.spec.js:69:9 › Firefox Overlay (#265) › Rendering (Gecko) › 030: Block badge renders correctly in Firefox (771ms)
+  ✓  4 [firefox-overlay] › firefox/overlay.spec.js:89:9 › Firefox Overlay (#265) › Shadow DOM Isolation (Gecko-specific) › 040: Styles do not bleed in or out in Firefox (883ms)
+  ✓  5 [firefox-overlay] › firefox/overlay.spec.js:120:9 › Firefox Overlay (#265) › Shadow DOM Isolation (Gecko-specific) › 050: Z-index stacking above complex page elements (981ms)
+  ✓  6 [firefox-overlay] › firefox/overlay.spec.js:160:9 › Firefox Overlay (#265) › Interaction › 060: Expand/collapse context works in Firefox (1.3s)
+  ✓  7 [firefox-overlay] › firefox/overlay.spec.js:185:9 › Firefox Overlay (#265) › Interaction › 070: Close button works in Firefox (767ms)
+  ✓  8 [firefox-overlay] › firefox/overlay.spec.js:205:9 › Firefox Overlay (#265) › Interaction › 080: Escape key closes overlay in Firefox (754ms)
+  ✓  9 [firefox-overlay] › firefox/overlay.spec.js:229:9 › Firefox Overlay (#265) › Accessibility › 090: Focus management works in Firefox (762ms)
+  ✓ 10 [firefox-overlay] › firefox/overlay.spec.js:248:9 › Firefox Overlay (#265) › Security › 100: XSS prevention works in Firefox (1.2s)
+
+  10 passed (10.1s)
+```
+
+## Test Categories
+
+### Rendering (Gecko) - 3 tests
+Verifies badge rendering for all severity levels in Firefox's rendering engine:
+- Neutral (blue) badge
+- Warning (amber) badge
+- Block (red) badge with hard-block card class
+
+### Shadow DOM Isolation - 2 tests
+Firefox-specific tests for Shadow DOM behavior:
+- **040**: Page styles (Comic Sans, pink background, hidden badges) don't leak into shadow DOM
+- **050**: Overlay maintains `z-index: 2147483647` above competing high-z elements
+
+### Interaction - 3 tests
+Standard interaction tests validated in Firefox:
+- Expand/collapse context via Show More/Less toggle
+- Close button removes overlay
+- Escape key closes overlay
+
+### Accessibility - 1 test
+Focus management: Close button receives focus on overlay open
+
+### Security - 1 test
+XSS prevention: Script tags in signal/gem/context are escaped, not executed
+
+## Known Issues
+
+### Chrome Tests Failing (Pre-existing)
+
+Chrome `museum-label.spec.js` tests fail on **main branch** (12/16 failures). This is NOT caused by this PR:
+
+```
+Main branch: 12 failed, 4 passed
+Worktree: 12 failed, 4 passed (identical)
+```
+
+Root cause: Tests access `host.shadowRoot` which returns `null` for closed shadow DOM. The same fix applied to Firefox tests (patching `attachShadow` to `mode: 'open'`) would fix Chrome tests, but that's a separate issue.
+
+## Artifacts
+
+- Test results: `test-results/`
+- Playwright report: `playwright-report/` (run `npx playwright show-report`)
+- Traces available for failed tests (none in this run)
+
+## Acceptance Criteria Verification
+
+| Criteria | Status |
+|----------|--------|
+| Firefox overlay tests created | PASS |
+| Museum label rendering tested | PASS |
+| Shadow DOM isolation verified | PASS |
+| Overlay dismiss behavior tested | PASS |
+| No regression introduced | PASS (Chrome failures pre-existing) |

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* global require, module, process, __dirname */
 const { defineConfig } = require('@playwright/test');
 const path = require('path');
 
@@ -81,7 +82,9 @@ module.exports = defineConfig({
         }
     },
 
-    // Only use Chromium (extensions not supported in Firefox/WebKit)
+    // Browser projects
+    // - chromium: Full extension loading (requires headed mode)
+    // - firefox-overlay: Script injection only (headless OK) - Issue #265
     projects: [
         {
             name: 'chromium',
@@ -89,6 +92,19 @@ module.exports = defineConfig({
                 browserName: 'chromium',
                 // Extensions require headed mode
                 headless: false
+            }
+        },
+        {
+            name: 'firefox-overlay',
+            testMatch: /firefox\/.*\.spec\.js/,
+            use: {
+                browserName: 'firefox',
+                // Script injection doesn't require extension loading
+                headless: true,
+                // Remove Chrome extension args for Firefox
+                launchOptions: {
+                    args: []
+                }
             }
         }
     ],

--- a/tests/e2e/firefox/overlay.spec.js
+++ b/tests/e2e/firefox/overlay.spec.js
@@ -1,0 +1,282 @@
+// tests/e2e/firefox/overlay.spec.js
+// Firefox Overlay E2E tests (#265)
+//
+// Verifies Firefox overlay.js rendering and behavior in Gecko engine.
+// Uses script injection approach (no full extension loading).
+//
+// LLD: docs/lld/active/1265-firefox-overlay-e2e.md
+
+const { test, expect } = require('@playwright/test');
+const {
+    injectOverlay,
+    selectText,
+    shadowQuery,
+    isOverlayVisible,
+    shadowClick,
+    isShadowElementFocused,
+    getOverlayZIndex,
+    verifyShadowDOMIsolation,
+    TEST_DATA
+} = require('../helpers/overlay-helpers');
+
+test.describe('Firefox Overlay (#265)', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/test-museum-label.html');
+        await page.waitForLoadState('domcontentloaded');
+    });
+
+    test.describe('Rendering (Gecko)', () => {
+
+        test('010: Neutral badge renders correctly in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            // Verify overlay exists
+            const visible = await isOverlayVisible(page);
+            expect(visible).toBe(true);
+
+            // Check badge has neutral class
+            const badge = await shadowQuery(page, '.aletheia-badge');
+            expect(badge).not.toBeNull();
+            expect(badge.className).toContain('neutral');
+
+            // Check signal text renders correctly
+            const signal = await shadowQuery(page, '.aletheia-signal');
+            expect(signal).not.toBeNull();
+            expect(signal.textContent).toBe('Historical Term');
+        });
+
+        test('020: Warning badge renders correctly in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-warning');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.warning);
+
+            const badge = await shadowQuery(page, '.aletheia-badge');
+            expect(badge.className).toContain('warning');
+
+            const signal = await shadowQuery(page, '.aletheia-signal');
+            expect(signal.textContent).toBe('Archaic Pejorative');
+        });
+
+        test('030: Block badge renders correctly in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-blocked');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 403);
+            }, TEST_DATA.blocked);
+
+            const badge = await shadowQuery(page, '.aletheia-badge');
+            expect(badge.className).toContain('block');
+
+            // Card should have hard-block class
+            const card = await shadowQuery(page, '.aletheia-card');
+            expect(card.className).toContain('hard-block');
+        });
+
+    });
+
+    test.describe('Shadow DOM Isolation (Gecko-specific)', () => {
+
+        test('040: Styles do not bleed in or out in Firefox', async ({ page }) => {
+            // Add conflicting page styles
+            await page.addStyleTag({
+                content: `
+                    body { font-family: 'Comic Sans MS', cursive !important; }
+                    .aletheia-card { background: pink !important; }
+                    .aletheia-badge { display: none !important; }
+                `
+            });
+
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            const isolation = await verifyShadowDOMIsolation(page);
+
+            // Shadow DOM should protect overlay from page styles
+            expect(isolation.hostStylesIsolated).toBe(true);
+
+            // Page styles should not be affected by shadow styles
+            expect(isolation.pageStylesUnaffected).toBe(true);
+
+            // Badge should still be visible despite page trying to hide it
+            const badge = await shadowQuery(page, '.aletheia-badge');
+            expect(badge).not.toBeNull();
+            expect(badge.isVisible).toBe(true);
+        });
+
+        test('050: Z-index stacking above complex page elements', async ({ page }) => {
+            // First inject overlay and show it
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            // Now add high z-index elements AFTER the overlay is shown
+            await page.addStyleTag({
+                content: `
+                    .high-z-modal { position: fixed; z-index: 999999; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); pointer-events: none; }
+                    .higher-z-dialog { position: fixed; z-index: 9999999; top: 50%; left: 50%; pointer-events: none; }
+                `
+            });
+            await page.evaluate(() => {
+                const modal = document.createElement('div');
+                modal.className = 'high-z-modal';
+                document.body.appendChild(modal);
+
+                const dialog = document.createElement('div');
+                dialog.className = 'higher-z-dialog';
+                dialog.textContent = 'High z-index dialog';
+                document.body.appendChild(dialog);
+            });
+
+            // Overlay should have max z-index (higher than the elements we added)
+            const overlayZIndex = await getOverlayZIndex(page);
+            expect(overlayZIndex).toBe(2147483647); // Max 32-bit signed int
+
+            // Overlay should still be visible above the modal
+            const visible = await isOverlayVisible(page);
+            expect(visible).toBe(true);
+        });
+
+    });
+
+    test.describe('Interaction', () => {
+
+        test('060: Expand/collapse context works in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            // Initially context should not be expanded
+            let context = await shadowQuery(page, '.aletheia-context');
+            expect(context.className).not.toContain('expanded');
+
+            // Click "Show More"
+            await shadowClick(page, '.aletheia-toggle');
+            await page.waitForTimeout(500);
+
+            // Context should be expanded
+            context = await shadowQuery(page, '.aletheia-context');
+            expect(context.className).toContain('expanded');
+
+            // Button text should change
+            const toggle = await shadowQuery(page, '.aletheia-toggle');
+            expect(toggle.textContent).toBe('Show Less');
+        });
+
+        test('070: Close button works in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            let visible = await isOverlayVisible(page);
+            expect(visible).toBe(true);
+
+            // Click close button
+            await shadowClick(page, '.aletheia-close');
+            await page.waitForTimeout(100);
+
+            // Overlay should be removed
+            visible = await isOverlayVisible(page);
+            expect(visible).toBe(false);
+        });
+
+        test('080: Escape key closes overlay in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            let visible = await isOverlayVisible(page);
+            expect(visible).toBe(true);
+
+            // Press Escape
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(100);
+
+            // Overlay should be removed
+            visible = await isOverlayVisible(page);
+            expect(visible).toBe(false);
+        });
+
+    });
+
+    test.describe('Accessibility', () => {
+
+        test('090: Focus management works in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, TEST_DATA.neutral);
+
+            await page.waitForTimeout(100);
+
+            // Close button should be focused by default
+            const focused = await isShadowElementFocused(page, '.aletheia-close');
+            expect(focused).toBe(true);
+        });
+
+    });
+
+    test.describe('Security', () => {
+
+        test('100: XSS prevention works in Firefox', async ({ page }) => {
+            await injectOverlay(page, 'firefox');
+            await selectText(page, 'test-neutral');
+
+            // Malicious payload
+            const xssData = {
+                signal: '<script>alert("xss")</script>',
+                gem: '<img src=x onerror=alert("img-xss")>',
+                context: '<svg onload=alert("svg-xss")>'
+            };
+
+            // Setup dialog listener to detect XSS
+            let alertTriggered = false;
+            page.on('dialog', async dialog => {
+                alertTriggered = true;
+                await dialog.dismiss();
+            });
+
+            await page.evaluate((data) => {
+                window.showAletheiaResult(data, 200);
+            }, xssData);
+
+            await page.waitForTimeout(500);
+
+            // Text should be escaped, not executed
+            const signal = await shadowQuery(page, '.aletheia-signal');
+            expect(signal.textContent).toBe('<script>alert("xss")</script>');
+
+            // No alert was triggered
+            expect(alertTriggered).toBe(false);
+        });
+
+    });
+
+});

--- a/tests/e2e/helpers/overlay-helpers.js
+++ b/tests/e2e/helpers/overlay-helpers.js
@@ -1,0 +1,211 @@
+// tests/e2e/helpers/overlay-helpers.js
+// Shared helper functions for overlay E2E tests
+// Extracted from museum-label.spec.js for reuse in Firefox tests (#265)
+
+const path = require('path');
+
+/**
+ * Inject overlay.js into the page
+ * @param {import('@playwright/test').Page} page - Playwright page
+ * @param {string} browser - 'chrome' or 'firefox'
+ */
+async function injectOverlay(page, browser = 'chrome') {
+    // For Firefox tests, we need to patch attachShadow to use 'open' mode
+    // because Firefox doesn't expose closed shadow roots like Chrome does
+    if (browser === 'firefox') {
+        await page.evaluate(() => {
+            const originalAttachShadow = Element.prototype.attachShadow;
+            Element.prototype.attachShadow = function(options) {
+                // Force open mode for testing
+                return originalAttachShadow.call(this, { ...options, mode: 'open' });
+            };
+        });
+    }
+
+    const overlayPath = browser === 'firefox'
+        ? path.join(__dirname, '../../../extensions/firefox/overlay.js')
+        : path.join(__dirname, '../../../extensions/chrome/overlay.js');
+    await page.addScriptTag({ path: overlayPath });
+    // Wait for functions to be defined
+    await page.waitForFunction(() => window.showAletheiaResult !== undefined);
+}
+
+/**
+ * Select text element to establish selection geometry
+ * @param {import('@playwright/test').Page} page
+ * @param {string} testId - data-testid attribute value
+ */
+async function selectText(page, testId) {
+    const element = page.locator(`[data-testid="${testId}"]`);
+    await element.click({ clickCount: 3 }); // Triple-click to select all
+    await page.waitForTimeout(100);
+}
+
+/**
+ * Query element inside Shadow DOM
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - CSS selector within shadow root
+ * @returns {Promise<{className: string, textContent: string, ariaExpanded: string|null, isVisible: boolean}|null>}
+ */
+async function shadowQuery(page, selector) {
+    return page.evaluate((sel) => {
+        const host = document.getElementById('aletheia-overlay-host');
+        if (!host || !host.shadowRoot) return null;
+        const el = host.shadowRoot.querySelector(sel);
+        return el ? {
+            className: el.className,
+            textContent: el.textContent,
+            ariaExpanded: el.getAttribute('aria-expanded'),
+            isVisible: el.offsetParent !== null || getComputedStyle(el).display !== 'none'
+        } : null;
+    }, selector);
+}
+
+/**
+ * Check if overlay host exists and is visible
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<boolean>}
+ */
+async function isOverlayVisible(page) {
+    return page.evaluate(() => {
+        const host = document.getElementById('aletheia-overlay-host');
+        return host !== null && host.offsetParent !== null;
+    });
+}
+
+/**
+ * Click element inside Shadow DOM
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - CSS selector within shadow root
+ */
+async function shadowClick(page, selector) {
+    await page.evaluate((sel) => {
+        const host = document.getElementById('aletheia-overlay-host');
+        if (host && host.shadowRoot) {
+            const el = host.shadowRoot.querySelector(sel);
+            if (el) el.click();
+        }
+    }, selector);
+}
+
+/**
+ * Hover over element inside Shadow DOM
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - CSS selector within shadow root
+ */
+async function shadowHover(page, selector) {
+    await page.evaluate((sel) => {
+        const host = document.getElementById('aletheia-overlay-host');
+        if (host && host.shadowRoot) {
+            const el = host.shadowRoot.querySelector(sel);
+            if (el) {
+                el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+            }
+        }
+    }, selector);
+}
+
+/**
+ * Check if element inside Shadow DOM is focused
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - CSS selector within shadow root
+ * @returns {Promise<boolean>}
+ */
+async function isShadowElementFocused(page, selector) {
+    return page.evaluate((sel) => {
+        const host = document.getElementById('aletheia-overlay-host');
+        if (!host || !host.shadowRoot) return false;
+        const el = host.shadowRoot.querySelector(sel);
+        return el === host.shadowRoot.activeElement;
+    }, selector);
+}
+
+/**
+ * Get computed z-index of overlay card (inside shadow DOM)
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<number>}
+ */
+async function getOverlayZIndex(page) {
+    return page.evaluate(() => {
+        const host = document.getElementById('aletheia-overlay-host');
+        if (!host || !host.shadowRoot) return 0;
+        const card = host.shadowRoot.querySelector('.aletheia-card');
+        if (!card) return 0;
+        return parseInt(getComputedStyle(card).zIndex, 10) || 0;
+    });
+}
+
+/**
+ * Verify Shadow DOM isolation - styles don't leak in or out
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{hostStylesIsolated: boolean, pageStylesUnaffected: boolean}>}
+ */
+async function verifyShadowDOMIsolation(page) {
+    return page.evaluate(() => {
+        const host = document.getElementById('aletheia-overlay-host');
+        if (!host || !host.shadowRoot) {
+            return { hostStylesIsolated: false, pageStylesUnaffected: false };
+        }
+
+        // Check that shadow elements aren't affected by page styles
+        const card = host.shadowRoot.querySelector('.aletheia-card');
+        if (!card) {
+            return { hostStylesIsolated: false, pageStylesUnaffected: false };
+        }
+
+        // The card should have its own font-family, not inherit from page
+        const cardStyle = getComputedStyle(card);
+        const hasOwnFont = cardStyle.fontFamily.includes('system') ||
+                          cardStyle.fontFamily.includes('Segoe') ||
+                          cardStyle.fontFamily.includes('Roboto');
+
+        // Check page elements aren't affected by shadow styles
+        const pageBody = document.body;
+        const bodyStyle = getComputedStyle(pageBody);
+        // Body should NOT have aletheia-specific styles
+        const pageUnaffected = !bodyStyle.fontFamily.includes('aletheia');
+
+        return {
+            hostStylesIsolated: hasOwnFont,
+            pageStylesUnaffected: pageUnaffected
+        };
+    });
+}
+
+// Test data fixtures (shared across Chrome and Firefox tests)
+const TEST_DATA = {
+    neutral: {
+        signal: 'Historical Term',
+        gem: 'A word from early 20th century usage.',
+        context: 'First documented in 1923. Common in academic writing. Still used in historical contexts today.'
+    },
+    warning: {
+        signal: 'Archaic Pejorative',
+        gem: 'Once clinical, now outdated and considered offensive.',
+        context: 'First used in 18th century medicine. Fell out of clinical use by 1950. Now recognized as dehumanizing.'
+    },
+    blocked: {
+        signal: 'Hard Block',
+        gem: 'This content is blocked.',
+        context: 'Content blocked by safety filter.',
+        blocked: 'Content blocked by safety filter'
+    },
+    longContext: {
+        signal: 'Etymological Analysis',
+        gem: 'A term with complex historical roots spanning multiple centuries.',
+        context: 'This is a much longer context that will test the typewriter animation. The word originated in ancient Greek, traveled through Latin during the Roman Empire, was adopted into Old French during the medieval period, and finally entered English through Norman influence. Its meaning has shifted considerably over the centuries, from a technical term to everyday usage.'
+    }
+};
+
+module.exports = {
+    injectOverlay,
+    selectText,
+    shadowQuery,
+    isOverlayVisible,
+    shadowClick,
+    shadowHover,
+    isShadowElementFocused,
+    getOverlayZIndex,
+    verifyShadowDOMIsolation,
+    TEST_DATA
+};


### PR DESCRIPTION
## Summary
- Add Firefox overlay E2E tests using script injection approach
- Extract shared `overlay-helpers.js` for cross-browser test reuse
- Add shadow DOM patching to enable test access to closed shadow roots
- 10 tests covering rendering, isolation, interaction, accessibility, security

## Test Results
All 10 Firefox overlay tests pass (10.1s)

## Files Changed
- `tests/e2e/firefox/overlay.spec.js` - Firefox E2E test suite
- `tests/e2e/helpers/overlay-helpers.js` - Shared helpers with shadow DOM patch
- `playwright.config.js` - Added firefox-overlay project
- `docs/reports/265/` - Implementation and test reports

Closes #265