### PR TITLE
feat: transcript archival and 0808 audit mining infrastructure

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -165,6 +165,12 @@ Then stage (do NOT commit yet):
 git -C /c/Users/mcwiz/Projects/Aletheia add docs/6000-open-issues.md
 ```
 
+**Full mode only: Transcript Archival**
+```bash
+poetry run python /c/Users/mcwiz/Projects/Aletheia/tools/archive_transcripts.py
+```
+Archives verbatim transcripts older than 7 days to monthly archive directories (`~/.claude/projects/.../archive/YYYY-MM/`).
+
 **Full mode only: Additional checks**
 
 1. **Inventory audit**: Use Glob tool with patterns **/*.py, **/*.js, **/*.md, **/*.sh

--- a/docs/reports/276/implementation-report.md
+++ b/docs/reports/276/implementation-report.md
@@ -1,0 +1,83 @@
+# Implementation Report: Issue #276
+
+## Summary
+
+Implemented transcript archival infrastructure and redesigned 0808 audit from a static configuration checklist to an active permission problem mining system.
+
+## Changes Made
+
+### 1. Redesigned 0808 Audit (`docs/0808-audit-permission-permissiveness.md`)
+
+**Before:** Static checklist verifying settings.local.json configuration.
+
+**After:** Active mining audit that:
+- Searches verbatim transcripts for "zugzwang violation:" markers
+- Searches for permission denial patterns
+- Maintains checkpoint to avoid re-processing
+- Proposes remediations for recurring patterns
+- Integrates with transcript archival system
+
+### 2. Created Checkpoint Infrastructure
+
+**New file:** `docs/audit-state/0808-checkpoint.json`
+
+JSON structure tracking:
+- `last_run`: Timestamp of last audit
+- `logs_processed`: List of already-searched transcript filenames
+- `zugzwang_violations`: Array of found violations with status
+
+### 3. Created Transcript Archival Script
+
+**New file:** `tools/archive_transcripts.py`
+
+Python script that:
+- Identifies verbatim transcripts older than 7 days
+- Moves to `archive/YYYY-MM/` subdirectories
+- Skips subagent files (`agent-*.jsonl`)
+- Supports `--dry-run` for safe preview
+- Reports summary with counts
+
+### 4. Updated Cleanup Command
+
+**Modified:** `.claude/commands/cleanup.md`
+
+Added transcript archival to Full mode (Phase 2):
+```bash
+poetry run python /c/Users/mcwiz/Projects/Aletheia/tools/archive_transcripts.py
+```
+
+### 5. Updated Documentation
+
+- **`docs/0800-audit-index.md`**: Updated 0808 description from "permission policy" to "permission problem mining"
+- **`docs/0003-file-inventory.md`**: Added new files (checkpoint.json, archive_transcripts.py)
+
+## Design Decisions
+
+1. **Separate archival script** - Chosen over inline cleanup.md logic for reusability and testability
+2. **7-day retention window** - Balances accessibility with disk space
+3. **Monthly archive structure** - Keeps archives organized for historical searches
+4. **Checkpoint system** - Prevents re-processing of already-searched transcripts
+5. **Keep archives forever** - Per user preference, no rotation/deletion
+
+## Files Modified/Created
+
+| File | Change |
+|------|--------|
+| `docs/0808-audit-permission-permissiveness.md` | Replaced (complete rewrite) |
+| `docs/audit-state/0808-checkpoint.json` | Created |
+| `tools/archive_transcripts.py` | Created |
+| `.claude/commands/cleanup.md` | Modified (added archival step) |
+| `docs/0800-audit-index.md` | Modified (updated 0808 description) |
+| `docs/0003-file-inventory.md` | Modified (added new files) |
+
+## Verification
+
+- [x] Dry-run test shows correct file identification
+- [x] Monthly archive directories calculated correctly
+- [x] Agent files properly skipped
+- [x] Summary statistics accurate
+
+## References
+
+- Issue: #276
+- Plan: `C:\Users\mcwiz\.claude\plans\pure-snuggling-engelbart.md`

--- a/docs/reports/276/test-report.md
+++ b/docs/reports/276/test-report.md
@@ -1,0 +1,86 @@
+# Test Report: Issue #276
+
+## Test Summary
+
+| Test | Result | Notes |
+|------|--------|-------|
+| Archival script dry-run | PASS | Correctly identifies files |
+| Age calculation | PASS | Files correctly aged |
+| Monthly bucketing | PASS | 2025-12 and 2026-01 directories |
+| Agent file filtering | PASS | 183 agent-* files skipped |
+| Summary statistics | PASS | Accurate counts |
+
+## Test 1: Archive Script Dry-Run
+
+**Command:**
+```bash
+poetry run python tools/archive_transcripts.py --dry-run
+```
+
+**Output:**
+```
+Transcript directory: C:\Users\mcwiz\.claude\projects\C--Users-mcwiz-Projects-Aletheia
+Archive directory: C:\Users\mcwiz\.claude\projects\C--Users-mcwiz-Projects-Aletheia\archive
+Retention: 7 days
+
+[DRY-RUN] Would archive: 11fe4a65-819a-43f4-a26c-317dafc0ec58.jsonl -> archive/2025-12/ (11.9 days old)
+[DRY-RUN] Would archive: 1f5c510b-48f5-4d63-a2d2-8ad014fc1664.jsonl -> archive/2026-01/ (8.6 days old)
+... (16 more files)
+
+[DRY-RUN] === Archive Summary ===
+[DRY-RUN] Archived: 18 transcripts
+[DRY-RUN] Active (< 7 days): 88 transcripts
+[DRY-RUN] Skipped (agent-*): 183 files
+```
+
+**Result:** PASS
+
+**Evidence:**
+- Script found 18 transcripts older than 7 days
+- Correctly identifies archive month from file modification time
+- Skips 183 agent-* subagent files
+- 88 recent transcripts remain active
+
+## Test 2: Monthly Bucketing
+
+**Verified files are bucketed by modification month:**
+- `2025-12/` - Files from December 2025 (9-24 days old)
+- `2026-01/` - Files from January 2026 (8-9 days old)
+
+**Result:** PASS
+
+## Test 3: Checkpoint Structure
+
+**Verified:** `docs/audit-state/0808-checkpoint.json` exists with correct structure:
+```json
+{
+  "last_run": null,
+  "logs_processed": [],
+  "zugzwang_violations": []
+}
+```
+
+**Result:** PASS
+
+## Test 4: Cleanup Integration
+
+**Verified:** `.claude/commands/cleanup.md` contains archival step in Full mode.
+
+**Result:** PASS
+
+## Test 5: Inventory Updates
+
+**Verified:** Both new files added to `docs/0003-file-inventory.md`:
+- `docs/audit-state/0808-checkpoint.json`
+- `tools/archive_transcripts.py`
+
+**Result:** PASS
+
+## Limitations
+
+- Actual file movement not tested (would require manual cleanup)
+- 0808 mining procedure not executed (requires zugzwang violations in transcripts)
+
+## Conclusion
+
+All testable components pass. The archival script correctly identifies, categorizes, and reports on transcripts. Integration with cleanup command and documentation updates are complete.

--- a/tools/archive_transcripts.py
+++ b/tools/archive_transcripts.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Archive verbatim session transcripts older than 7 days.
+
+Moves *.jsonl files from the active transcript directory to archive/YYYY-MM/
+based on modification time. Subagent files (agent-*.jsonl) are skipped.
+
+Usage:
+    poetry run python tools/archive_transcripts.py [--dry-run]
+
+Options:
+    --dry-run    Show what would be archived without moving files
+"""
+
+import argparse
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TypedDict
+
+
+class ArchiveResult(TypedDict):
+    """Result of archive operation."""
+
+    archived_count: int
+    skipped_count: int
+    active_count: int
+    errors: list[str]
+
+
+# Claude Code stores transcripts here (Windows path with Unix-style separators)
+TRANSCRIPT_DIR = Path.home() / ".claude/projects/C--Users-mcwiz-Projects-Aletheia"
+ARCHIVE_DIR = TRANSCRIPT_DIR / "archive"
+RETENTION_DAYS = 7
+
+
+def get_file_age_days(filepath: Path) -> float:
+    """Return age of file in days based on modification time."""
+    mtime = datetime.fromtimestamp(filepath.stat().st_mtime)
+    age = datetime.now() - mtime
+    return age.total_seconds() / 86400  # Convert to days
+
+
+def archive_transcripts(dry_run: bool = False) -> ArchiveResult:
+    """
+    Archive transcripts older than RETENTION_DAYS.
+
+    Returns:
+        dict with keys: archived_count, skipped_count, active_count, errors
+    """
+    cutoff = datetime.now() - timedelta(days=RETENTION_DAYS)
+
+    result: ArchiveResult = {
+        "archived_count": 0,
+        "skipped_count": 0,
+        "active_count": 0,
+        "errors": [],
+    }
+
+    if not TRANSCRIPT_DIR.exists():
+        print(f"ERROR: Transcript directory not found: {TRANSCRIPT_DIR}")
+        result["errors"].append(f"Directory not found: {TRANSCRIPT_DIR}")
+        return result
+
+    for jsonl in TRANSCRIPT_DIR.glob("*.jsonl"):
+        # Skip subagent files
+        if jsonl.name.startswith("agent-"):
+            result["skipped_count"] += 1
+            continue
+
+        try:
+            mtime = datetime.fromtimestamp(jsonl.stat().st_mtime)
+            age_days = get_file_age_days(jsonl)
+
+            if mtime < cutoff:
+                # File is old, archive it
+                month_str = mtime.strftime("%Y-%m")
+                month_dir = ARCHIVE_DIR / month_str
+
+                if dry_run:
+                    print(f"[DRY-RUN] Would archive: {jsonl.name} -> archive/{month_str}/ ({age_days:.1f} days old)")
+                else:
+                    month_dir.mkdir(parents=True, exist_ok=True)
+                    dest = month_dir / jsonl.name
+                    shutil.move(str(jsonl), str(dest))
+                    print(f"Archived: {jsonl.name} -> archive/{month_str}/")
+
+                result["archived_count"] += 1
+            else:
+                # File is recent, keep it active
+                result["active_count"] += 1
+
+        except Exception as e:
+            error_msg = f"Error processing {jsonl.name}: {e}"
+            print(f"ERROR: {error_msg}")
+            result["errors"].append(error_msg)
+
+    return result
+
+
+def print_summary(result: ArchiveResult, dry_run: bool = False) -> None:
+    """Print summary of archival operation."""
+    prefix = "[DRY-RUN] " if dry_run else ""
+    print()
+    print(f"{prefix}=== Archive Summary ===")
+    print(f"{prefix}Archived: {result['archived_count']} transcripts")
+    print(f"{prefix}Active (< {RETENTION_DAYS} days): {result['active_count']} transcripts")
+    print(f"{prefix}Skipped (agent-*): {result['skipped_count']} files")
+
+    if result["errors"]:
+        print(f"{prefix}Errors: {len(result['errors'])}")
+        for error in result["errors"]:
+            print(f"  - {error}")
+
+    if not dry_run:
+        # Count total files in archive
+        if ARCHIVE_DIR.exists():
+            archived_total = sum(1 for _ in ARCHIVE_DIR.glob("**/*.jsonl"))
+            print(f"Total in archive: {archived_total} transcripts")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Archive verbatim session transcripts older than 7 days."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be archived without moving files"
+    )
+    args = parser.parse_args()
+
+    print(f"Transcript directory: {TRANSCRIPT_DIR}")
+    print(f"Archive directory: {ARCHIVE_DIR}")
+    print(f"Retention: {RETENTION_DAYS} days")
+    print()
+
+    result = archive_transcripts(dry_run=args.dry_run)
+    print_summary(result, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `tools/archive_transcripts.py` for 7-day retention archival of verbatim transcripts
- Update `/cleanup --full` to run archival in Full mode
- Add implementation and test reports for #276

## Changes

| File | Change |
|------|--------|
| `tools/archive_transcripts.py` | New Python script for transcript archival |
| `.claude/commands/cleanup.md` | Added archival step to Full mode |
| `docs/reports/276/*` | Implementation and test reports |

## Test Plan

- [x] Dry-run test passes (18 files identified for archival)
- [x] Monthly bucketing works correctly (2025-12, 2026-01)
- [x] Agent files properly skipped (183 files)
- [x] Mypy type checking passes

## Note

Related doc changes (0808 audit redesign, checkpoint file, inventory updates) are on main branch and will be committed via `/cleanup` per commit discipline.

Closes #276

---
Generated with [Claude Code](https://claude.com/claude-code)