### PR TITLE
fix: use full npx path in subprocess call (close #277)

### DIFF
--- a/docs/reports/277/implementation-report.md
+++ b/docs/reports/277/implementation-report.md
@@ -1,0 +1,29 @@
+# Implementation Report: #277 Fix npx subprocess on Windows
+
+## Summary
+
+One-line fix to use full path for npx in subprocess call.
+
+## Change
+
+**File:** `tools/build_release.py` line 112
+
+**Before:**
+```python
+result = subprocess.run(
+    ["npx", "web-ext", "lint", ...],
+```
+
+**After:**
+```python
+result = subprocess.run(
+    [npx, "web-ext", "lint", ...],
+```
+
+## Root Cause
+
+`shutil.which("npx")` returns the full path (e.g., `C:/Program Files/nodejs/npx`), but the subprocess call used the bare string `"npx"` instead of the `npx` variable. On Windows, subprocess cannot resolve bare command names without the full path.
+
+## Testing
+
+- `poetry run python tools/build_release.py` - PASS (build completes successfully)

--- a/docs/reports/277/test-report.md
+++ b/docs/reports/277/test-report.md
@@ -1,0 +1,27 @@
+# Test Report: #277 Fix npx subprocess on Windows
+
+## Test Execution
+
+| Test | Result |
+|------|--------|
+| `poetry run python tools/build_release.py` | PASS |
+| Firefox lint step executes | PASS |
+| Chrome artifact created | PASS |
+| Firefox artifact created | PASS |
+
+## Evidence
+
+```
+Step 3: Running Firefox linter...
+  [OK] Firefox lint passed
+
+==================================================
+Build complete!
+==================================================
+  Chrome:  aletheia-chrome-v1.0.zip (13 files)
+  Firefox: aletheia-firefox-v1.0.zip (13 files)
+```
+
+## Regression Risk
+
+Minimal - single-character change using existing variable.

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -108,8 +108,9 @@ def run_firefox_lint() -> None:
         return
 
     # Run web-ext lint
+    # npx path is from shutil.which(), not user input - safe to use
     result = subprocess.run(
-        ["npx", "web-ext", "lint", "--source-dir", str(FIREFOX_DIR)],
+        [npx, "web-ext", "lint", "--source-dir", str(FIREFOX_DIR)],  # noqa: S603
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,


### PR DESCRIPTION
## Summary

- Fix Windows subprocess failure in build_release.py by using full npx path from shutil.which()

## Problem

build_release.py fails at Step 3 (Firefox linter) with:
ERROR: [WinError 2] The system cannot find the file specified

## Root Cause

Line 112 used ["npx", ...] instead of the full path variable npx returned by shutil.which("npx").

## Test plan

- [x] poetry run python tools/build_release.py completes successfully
- [x] Firefox lint step executes
- [x] Both Chrome and Firefox artifacts created

---

Generated with [Claude Code](https://claude.ai/claude-code)