### PR TITLE
fix(firefox): add data_collection_permissions to manifest (close #282)

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -17,7 +17,11 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "extension@aletheia.study",
-      "strict_min_version": "115.0"
+      "strict_min_version": "115.0",
+      "data_collection_permissions": {
+        "required": ["authenticationInfo", "websiteContent"],
+        "optional": []
+      }
     },
     "gecko_android": {
       "strict_min_version": "120.0"


### PR DESCRIPTION
## Summary

Add required `data_collection_permissions` to Firefox manifest.

## Problem

Mozilla Add-ons submission failed:
```
The "/browser_specific_settings/gecko/data_collection_permissions" property is required for all new Firefox extensions
```

## Fix

Added to `browser_specific_settings.gecko`:
```json
"data_collection_permissions": {
  "required": ["authenticationInfo", "websiteContent"],
  "optional": []
}
```

- `authenticationInfo` - LinkedIn OAuth tokens
- `websiteContent` - Selected text sent to API

## Test plan

- [x] web-ext lint passes (warnings only for version compat)
- [x] build_release.py completes successfully
- [x] Manifest JSON valid

## References

- https://mzl.la/firefox-builtin-data-consent
- https://blog.mozilla.org/addons/2025/10/23/data-collection-consent-changes-for-new-firefox-extensions/

---

Generated with [Claude Code](https://claude.ai/claude-code)