### PR TITLE
fix(firefox): bump min version to 140/142 for consent UI (close #284)

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -17,14 +17,14 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "extension@aletheia.study",
-      "strict_min_version": "115.0",
+      "strict_min_version": "140.0",
       "data_collection_permissions": {
         "required": ["authenticationInfo", "websiteContent"],
         "optional": []
       }
     },
     "gecko_android": {
-      "strict_min_version": "120.0"
+      "strict_min_version": "142.0"
     }
   },
   "icons": {


### PR DESCRIPTION
Bump strict_min_version to enable built-in data consent UI.

- Desktop: 115 → 140
- Android: 120 → 142

web-ext lint: 0 errors, 0 warnings