### PR TITLE
test: add Unicode quote handling regression test (ref #288)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ ignore = [
 "tools/print/**/*.py" = ["S603"]
 # S105 false positive: URLs containing "Token" are flagged as passwords
 "src/lambda_auth_function.py" = ["S105"]
+# Smoke test intentionally uses subprocess for AWS CLI and opens URLs from CLI args
+"tools/smoke_test.py" = ["S603", "S607", "S310"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -221,9 +221,50 @@ def verify_prompt_injection(url: str) -> bool:
         return False
 
 
+def verify_unicode_quote_handling(url: str) -> bool:
+    """Verify 5: Unicode quotes in Bedrock response don't cause parse failures (Issue #288).
+
+    Regression test: Terms like "cryptocurrency" triggered curly quotes from Bedrock
+    which caused JSON parsing to fail, returning "Analysis Failed" to users.
+    """
+    print("\n[TEST 5] Unicode Quote Handling (Issue #288 regression)")
+    # "cryptocurrency" historically triggered curly quotes in Bedrock responses
+    payload = {"text": "cryptocurrency", "url": "https://test.example.com"}
+    print(f"  Payload: {json.dumps(payload)}")
+
+    status, body, latency = send_request(url, payload)
+
+    print(f"  Status:  {status}")
+    print(f"  Latency: {latency:.2f}s")
+
+    if status != 200:
+        print(f"  Result:  FAIL (expected 200, got {status})")
+        return False
+
+    # Check for fallback response (indicates JSON parsing failed)
+    if body.get("status") == "fallback":
+        print("  Result:  FAIL (fallback response - JSON parsing likely failed)")
+        return False
+
+    if body.get("signal") == "Analysis Failed":
+        print("  Result:  FAIL (Analysis Failed - quote normalization regression)")
+        return False
+
+    # Verify we got a proper structured response
+    has_structure = all(k in body for k in ["signal", "gem", "context", "status"])
+    if not has_structure:
+        print("  Result:  FAIL (missing required fields)")
+        return False
+
+    print(f"  Signal:  {body.get('signal', 'N/A')}")
+    print(f"  Status:  {body.get('status', 'N/A')}")
+    print("  Result:  PASS (proper response, no quote parsing issues)")
+    return True
+
+
 def verify_tone_neutrality(url: str) -> bool:
-    """Verify 5: Response should have neutral academic tone (Issue #124)."""
-    print("\n[TEST 5] Tone Neutrality Check")
+    """Verify 6: Response should have neutral academic tone (Issue #124)."""
+    print("\n[TEST 6] Tone Neutrality Check")
     # Use a term that might trigger moralizing in a non-neutral model
     payload = {"text": "lunatic", "url": "https://test.example.com"}
     print(f"  Payload: {json.dumps(payload)}")
@@ -294,9 +335,11 @@ def main():
     # Issue #124 specific tests
     if not args.quick:
         results.append(("Prompt Injection", verify_prompt_injection(url)))
+        results.append(("Unicode Quote Handling", verify_unicode_quote_handling(url)))
         results.append(("Tone Neutrality", verify_tone_neutrality(url)))
     else:
         print("\n[SKIPPED] Prompt Injection (--quick mode)")
+        print("[SKIPPED] Unicode Quote Handling (--quick mode)")
         print("[SKIPPED] Tone Neutrality (--quick mode)")
 
     # Summary


### PR DESCRIPTION
## Summary
- Adds `verify_unicode_quote_handling()` to smoke_test.py as regression test for Issue #288
- Tests "cryptocurrency" term which historically triggered curly quotes from Bedrock
- Fails if fallback response or "Analysis Failed" is returned (indicating JSON parse failure)
- Adds per-file-ignore in pyproject.toml for intentional subprocess/URL usage in smoke test

## Test plan
- [ ] `poetry run python tools/smoke_test.py` passes all 6 tests including new Unicode test

🤖 Generated with [Claude Code](https://claude.com/claude-code)