### PR TITLE
fix: handle unescaped ASCII double quotes in Bedrock JSON (ref #288)

### DIFF
--- a/src/etymologist.py
+++ b/src/etymologist.py
@@ -174,6 +174,74 @@ def normalize_unicode_quotes(text: str) -> str:
     return text
 
 
+def fix_unescaped_inner_quotes(text: str) -> str:
+    """Fix unescaped ASCII double quotes inside JSON string values.
+
+    Bedrock sometimes returns ASCII double quotes (U+0022) inside JSON
+    string values without proper escaping. For example:
+        {"context": "The word "glamour" is nice."}
+
+    This is invalid JSON. This function converts inner quotes to single quotes:
+        {"context": "The word 'glamour' is nice."}
+
+    Algorithm:
+    - Walk through string tracking whether we're inside a JSON string value
+    - When inside a string, replace unescaped " with '
+    - Properly handle escaped characters (\\")
+
+    See Issue #288 for context.
+    """
+    if not text:
+        return text
+
+    result = []
+    i = 0
+    in_string = False
+
+    while i < len(text):
+        char = text[i]
+
+        if char == '\\' and i + 1 < len(text):
+            # Escape sequence - copy both characters
+            result.append(char)
+            result.append(text[i + 1])
+            i += 2
+            continue
+
+        if char == '"':
+            if not in_string:
+                # Starting a string
+                in_string = True
+                result.append(char)
+            else:
+                # Could be end of string or unescaped inner quote
+                # Heuristic: If next non-whitespace is : , } ] or end, it's a delimiter
+                next_meaningful = _peek_next_meaningful_char(text, i + 1)
+                if next_meaningful in (':', ',', '}', ']', None):
+                    # This is a string delimiter
+                    in_string = False
+                    result.append(char)
+                else:
+                    # This is an unescaped inner quote - replace with single quote
+                    result.append("'")
+            i += 1
+        else:
+            result.append(char)
+            i += 1
+
+    return ''.join(result)
+
+
+def _peek_next_meaningful_char(text: str, start: int) -> str | None:
+    """Look ahead to find the next non-whitespace character."""
+    i = start
+    while i < len(text):
+        if not text[i].isspace():
+            return text[i]
+        i += 1
+    return None
+
+
 def _log_unicode_diagnostics(text: str, context: str) -> None:
     """Log Unicode codepoints for debugging JSON parse failures.
 
@@ -225,9 +293,13 @@ def extract_json(raw_response: str) -> dict | None:
 
     text = raw_response.strip()
 
-    # Step 0: Comprehensive quote normalization (Issue #288)
+    # Step 0a: Comprehensive Unicode quote normalization (Issue #288)
     # Uses QUOTE_NORMALIZATION_MAP to handle 22+ Unicode quote variants
     text = normalize_unicode_quotes(text)
+
+    # Step 0b: Fix unescaped ASCII double quotes inside string values (Issue #288)
+    # Bedrock sometimes returns invalid JSON with unescaped " inside strings
+    text = fix_unescaped_inner_quotes(text)
 
     # Step 1: Strip markdown code fences
     # Handle ```json and ``` variants

--- a/tests/unit/test_etymologist.py
+++ b/tests/unit/test_etymologist.py
@@ -301,6 +301,67 @@ class TestComprehensiveQuoteNormalization:
         assert result == '"test"'
 
 
+class TestFixUnescapedInnerQuotes:
+    """Tests for ASCII double quote fixing inside JSON strings (Issue #288)."""
+
+    def test_basic_inner_quotes(self):
+        """Basic case: unescaped double quotes around a word."""
+        from src.etymologist import fix_unescaped_inner_quotes
+
+        input_json = '{"context":"The word "glamour" is nice."}'
+        expected = """{"context":"The word 'glamour' is nice."}"""
+        result = fix_unescaped_inner_quotes(input_json)
+        assert result == expected
+
+    def test_multiple_inner_quotes(self):
+        """Multiple pairs of inner quotes."""
+        from src.etymologist import fix_unescaped_inner_quotes
+
+        input_json = '{"context":"From "glamour" to "glamorous" in usage."}'
+        expected = """{"context":"From 'glamour' to 'glamorous' in usage."}"""
+        result = fix_unescaped_inner_quotes(input_json)
+        assert result == expected
+
+    def test_no_inner_quotes(self):
+        """Valid JSON without inner quotes should be unchanged."""
+        from src.etymologist import fix_unescaped_inner_quotes
+
+        input_json = '{"signal": "Test","context":"No inner quotes here."}'
+        result = fix_unescaped_inner_quotes(input_json)
+        assert result == input_json
+
+    def test_properly_escaped_quotes(self):
+        """Properly escaped quotes should be preserved."""
+        from src.etymologist import fix_unescaped_inner_quotes
+
+        input_json = '{"context":"The word \\"glamour\\" is nice."}'
+        result = fix_unescaped_inner_quotes(input_json)
+        assert result == input_json
+
+    def test_real_world_bedrock_response(self):
+        """Real-world example from Bedrock that caused failures."""
+        input_json = '{"signal": "Formal Academic Term","gem":"A term denoting high-class appeal.","context":"Derived from the word "glamour" in the 19th century."}'
+        result = extract_json(input_json)
+        assert result is not None
+        assert result["signal"] == "Formal Academic Term"
+        assert "'glamour'" in result["context"]
+
+    def test_empty_string(self):
+        """Empty string should return empty."""
+        from src.etymologist import fix_unescaped_inner_quotes
+
+        assert fix_unescaped_inner_quotes("") == ""
+
+    def test_nested_json_objects(self):
+        """Should handle nested structures correctly."""
+        from src.etymologist import fix_unescaped_inner_quotes
+
+        input_json = '{"outer":{"inner":"The "word" here."}}'
+        expected = """{"outer":{"inner":"The 'word' here."}}"""
+        result = fix_unescaped_inner_quotes(input_json)
+        assert result == expected
+
+
 class TestCountWords:
     """Tests for word counting utility."""
 


### PR DESCRIPTION
## Summary
- Adds `fix_unescaped_inner_quotes()` to handle Bedrock returning ASCII double quotes inside JSON string values without escaping
- The function walks through JSON, tracks string context, and converts unescaped inner quotes to single quotes
- Complements the existing Unicode quote normalization (Step 0a → 0b)
- Verified: "glamorous" now returns success instead of fallback

## Root cause
Bedrock sometimes returns responses like:
```json
{"context":"Derived from the word "glamour" in the 19th century."}
```
Those inner quotes are ASCII U+0022, not Unicode curly quotes. The previous Unicode normalization didn't handle this case.

## Test plan
- [ ] 7 new unit tests in `TestFixUnescapedInnerQuotes` pass
- [ ] 96 total etymologist unit tests pass
- [ ] `poetry run python tools/test_lambda.py --term "glamorous" --noarchive` returns success

🤖 Generated with [Claude Code](https://claude.com/claude-code)