### PR TITLE
fix: add aria-expanded attribute to context element (close #299)

### DIFF
--- a/docs/reports/299/implementation-report.md
+++ b/docs/reports/299/implementation-report.md
@@ -1,0 +1,75 @@
+# 299 - Implementation Report: Add aria-expanded to Context Element
+
+## 1. Metadata
+
+| Field | Value |
+|-------|-------|
+| **Issue** | #299 |
+| **LLD** | N/A - Bug fix |
+| **Test Report** | `docs/reports/299/test-report.md` |
+| **Implementer** | Claude Opus 4.5 via Claude Code |
+| **Date** | 2026-01-10 |
+| **PR** | TBD |
+
+## 2. Summary
+
+Added `aria-expanded` attribute to the `.aletheia-context` element for proper ARIA accessibility. The attribute is:
+- Set to `"false"` on element creation
+- Updated to `"true"` when context is expanded
+- Updated to `"false"` when context is collapsed
+
+This fixes test 140 (ARIA attributes update on expand) which was failing because the context element lacked the `aria-expanded` attribute.
+
+## 3. Files Created
+
+| File | Description |
+|------|-------------|
+| `docs/reports/299/implementation-report.md` | This report |
+| `docs/reports/299/test-report.md` | Test results documentation |
+
+## 4. Files Modified
+
+| File | Changes | Description |
+|------|---------|-------------|
+| `extensions/chrome/overlay.js` | +3 lines | Added aria-expanded to context element creation and toggle handler |
+| `extensions/firefox/overlay.js` | +3 lines | Same changes for Firefox parity |
+
+## 5. Deviations from LLD
+
+None - straightforward bug fix as described in issue #299.
+
+## 6. Test Harness
+
+No new test infrastructure. Existing test 140 now passes.
+
+## 7. Test Coverage
+
+| Area | Coverage | Notes |
+|------|----------|-------|
+| ARIA attributes on context | Covered | Test 140 |
+| All other museum-label tests | Covered | Tests 010-160 |
+| Firefox overlay tests | Covered | Tests 010-100 |
+
+**Willison Protocol Compliance:**
+- [x] Automated tests written (existing)
+- [x] Tests fail on revert (verified - test 140 fails without fix)
+- [x] Proof captured in Test Report
+
+## 8. Lessons Learned
+
+- Both the toggle button AND the region being controlled should have `aria-expanded` for complete accessibility support
+- Keep Chrome and Firefox overlay.js in sync - same accessibility fixes apply to both
+
+## 9. Open Issues
+
+None.
+
+## 10. Orchestrator Review Notes
+
+**Reviewer:** TBD
+**Date:** TBD
+
+### Approval
+- [ ] Code reviewed
+- [ ] Manual tests passed (see Test Report)
+- [ ] Ready for merge

--- a/docs/reports/299/test-report.md
+++ b/docs/reports/299/test-report.md
@@ -1,0 +1,121 @@
+# Test Report: Add aria-expanded to Context Element
+
+## 1. Metadata
+
+| Field | Value |
+|-------|-------|
+| **Issue** | #299 |
+| **LLD** | N/A - Bug fix |
+| **Implementation Report** | `docs/reports/299/implementation-report.md` |
+| **Raw Output** | Inline |
+| **Date** | 2026-01-10 |
+
+## 2. Willison Protocol Compliance
+
+### Step 1: Automated Tests Written
+- **Test file:** `tests/e2e/museum-label.spec.js`
+- **Scenarios covered:** Test 140 (ARIA attributes update on expand)
+
+### Step 2: Tests Fail on Revert
+
+Before fix: Test 140 fails with `Expected: "false", Received: null`
+After fix: Test 140 passes
+
+**Verified:** [x] Yes
+
+### Step 3: Proof Captured
+
+See Section 3 below.
+
+## 3. Automated Test Results
+
+### Chrome (museum-label.spec.js)
+
+| Metric | Value |
+|--------|-------|
+| **Total tests** | 16 |
+| **Passed** | 16 |
+| **Failed** | 0 |
+| **Duration** | 18.8s |
+
+```
+Running 16 tests using 1 worker
+
+  ✓   1 › 010: Shows neutral badge (blue) for neutral signal (540ms)
+  ✓   2 › 020: Shows warning badge (amber) for pejorative signal (354ms)
+  ✓   3 › 030: Shows block badge (red) for hard block (336ms)
+  ✓   4 › 040: Gem appears on hover for non-blocked content (552ms)
+  ✓   5 › 050: Gem hidden for hard block (549ms)
+  ✓   6 › 060: Context expands on Show More click (867ms)
+  ✓   7 › 070: Context collapses on Show Less click (1.4s)
+  ✓   8 › 080: Toggle button hidden for hard block (358ms)
+  ✓   9 › 090: Typewriter animation plays for context (7.6s)
+  ✓  10 › 100: Close button removes overlay (477ms)
+  ✓  11 › 110: Escape key closes overlay (454ms)
+  ✓  12 › 120: Typewriter stops on close mid-animation (647ms)
+  ✓  13 › 130: Close button receives focus on open (444ms)
+  ✓  14 › 140: ARIA attributes update on expand (668ms)  ← FIXED
+  ✓  15 › 150: Loading overlay shows spinner (347ms)
+  ✓  16 › 160: Script in signal is escaped (856ms)
+
+  16 passed (18.8s)
+```
+
+### Firefox (firefox/overlay.spec.js)
+
+| Metric | Value |
+|--------|-------|
+| **Total tests** | 10 |
+| **Passed** | 10 |
+| **Failed** | 0 |
+| **Duration** | 10.6s |
+
+```
+Running 10 tests using 1 worker
+
+  ✓   1 › 010: Neutral badge renders correctly in Firefox (1.2s)
+  ✓   2 › 020: Warning badge renders correctly in Firefox (410ms)
+  ✓   3 › 030: Block badge renders correctly in Firefox (621ms)
+  ✓   4 › 040: Styles do not bleed in or out in Firefox (1.0s)
+  ✓   5 › 050: Z-index stacking above complex page elements (719ms)
+  ✓   6 › 060: Expand/collapse context works in Firefox (924ms)
+  ✓   7 › 070: Close button works in Firefox (512ms)
+  ✓   8 › 080: Escape key closes overlay in Firefox (528ms)
+  ✓   9 › 090: Focus management works in Firefox (556ms)
+  ✓  10 › 100: XSS prevention works in Firefox (1.0s)
+
+  10 passed (10.6s)
+```
+
+## 4. Manual Verification (Orchestrator)
+
+**Tester:** TBD
+**Date:** TBD
+
+## 5. Failed Tests Detail
+
+None - all tests pass.
+
+## 6. Regression Check
+
+| Existing Functionality | Verified | Notes |
+|------------------------|----------|-------|
+| Chrome overlay tests | [x] | 16/16 pass |
+| Firefox overlay tests | [x] | 10/10 pass |
+| No performance degradation | [x] | Test durations similar |
+
+## 7. Environment
+
+| Component | Version/State |
+|-----------|---------------|
+| **Node.js** | v25.2.1 |
+| **OS** | Windows 11 (MINGW64) |
+| **Browsers** | Chromium, Firefox (Playwright) |
+
+## 8. Approval
+
+| Role | Name | Date | Status |
+|------|------|------|--------|
+| **Automated Tests** | Claude Opus 4.5 | 2026-01-10 | 26/26 pass |
+| **Manual Verification** | TBD | TBD | Pending |
+| **Ready for Merge** | TBD | TBD | Pending |

--- a/extensions/chrome/overlay.js
+++ b/extensions/chrome/overlay.js
@@ -652,7 +652,8 @@ function showResultOverlay(response, httpStatus = 200) {
             className: 'aletheia-context',
             id: 'aletheia-context-section',
             role: 'region',
-            'aria-label': 'Full context'
+            'aria-label': 'Full context',
+            'aria-expanded': 'false'
         });
 
         // Toggle button
@@ -742,6 +743,7 @@ function handleToggleClick(shadow) {
         stopTypewriter();
         if (contextEl) {
             contextEl.classList.remove('expanded');
+            updateAriaExpanded(contextEl, false);
         }
         if (gemEl) {
             gemEl.classList.remove('visible');
@@ -758,6 +760,7 @@ function handleToggleClick(shadow) {
         }
         if (contextEl) {
             contextEl.classList.add('expanded');
+            updateAriaExpanded(contextEl, true);
             // Start typewriter animation
             const contextText = overlayData?.context || '';
             typewriterRender(contextEl, contextText);

--- a/extensions/firefox/overlay.js
+++ b/extensions/firefox/overlay.js
@@ -652,7 +652,8 @@ function showResultOverlay(response, httpStatus = 200) {
             className: 'aletheia-context',
             id: 'aletheia-context-section',
             role: 'region',
-            'aria-label': 'Full context'
+            'aria-label': 'Full context',
+            'aria-expanded': 'false'
         });
 
         // Toggle button
@@ -742,6 +743,7 @@ function handleToggleClick(shadow) {
         stopTypewriter();
         if (contextEl) {
             contextEl.classList.remove('expanded');
+            updateAriaExpanded(contextEl, false);
         }
         if (gemEl) {
             gemEl.classList.remove('visible');
@@ -758,6 +760,7 @@ function handleToggleClick(shadow) {
         }
         if (contextEl) {
             contextEl.classList.add('expanded');
+            updateAriaExpanded(contextEl, true);
             // Start typewriter animation
             const contextText = overlayData?.context || '';
             typewriterRender(contextEl, contextText);


### PR DESCRIPTION
## Summary
- Add `aria-expanded="false"` to `.aletheia-context` element on creation
- Update attribute to `"true"`/`"false"` on expand/collapse toggle
- Applied to both Chrome and Firefox overlay.js

## Test plan
- [x] Run Chrome E2E tests: 16/16 pass
- [x] Run Firefox E2E tests: 10/10 pass
- [x] Test 140 (ARIA attributes) now passes

## Result
All 26 E2E tests pass (was 25/26 before this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)