### PR TITLE
fix: handle mixed quote pairs in Bedrock JSON responses (0829 audit)

### DIFF
--- a/src/etymologist.py
+++ b/src/etymologist.py
@@ -174,6 +174,47 @@ def normalize_unicode_quotes(text: str) -> str:
     return text
 
 
+def fix_mixed_quote_pairs(text: str) -> str:
+    """Fix mixed quote pairs where LLM used curly LEFT but ASCII RIGHT quotes.
+
+    After unicode normalization, curly quotes become single quotes. But if
+    the LLM inconsistently used a curly left quote and ASCII right quote,
+    we get patterns like:  'diffidere", meaning 'to distrust'
+
+    The 'word" pattern indicates a mixed quote pair that should be 'word'.
+
+    This specifically targets the pattern:
+    - Single quote followed by word characters (letters, digits, spaces, hyphens)
+    - Followed by ASCII double quote
+    - Convert the double quote to single quote
+
+    IMPORTANT: Only match word-like content, NOT JSON structural elements.
+    Exclude: commas, colons, brackets, braces (to avoid breaking JSON structure)
+
+    Example:
+        Input:  'diffidere", meaning
+        Output: 'diffidere', meaning
+
+    See 0829 Lambda Failure Remediation audit for context.
+    """
+    # Pattern: 'word" where word is the quoted term (word-like content only)
+    # Match: single quote, word chars (letters, digits, spaces, hyphens),
+    # then ASCII double quote
+    # We convert the trailing " to '
+    #
+    # CRITICAL: Exclude JSON structural chars (,:{}[]) to avoid matching
+    # across JSON boundaries like '.", "context' -> '.", 'context'
+    #
+    # The regex matches: 'word" where word is alphanumeric with spaces/hyphens
+    pattern = r"'([a-zA-Z][a-zA-Z0-9\s\-]*)\""
+
+    def replace_mixed(match: re.Match) -> str:
+        # Replace the trailing " with '
+        return f"'{match.group(1)}'"
+
+    return re.sub(pattern, replace_mixed, text)
+
+
 def fix_unescaped_inner_quotes(text: str) -> str:
     """Fix unescaped ASCII double quotes inside JSON string values.
 
@@ -297,7 +338,12 @@ def extract_json(raw_response: str) -> dict | None:
     # Uses QUOTE_NORMALIZATION_MAP to handle 22+ Unicode quote variants
     text = normalize_unicode_quotes(text)
 
-    # Step 0b: Fix unescaped ASCII double quotes inside string values (Issue #288)
+    # Step 0b: Fix mixed quote pairs (0829 audit)
+    # LLM sometimes uses curly LEFT quote + ASCII RIGHT quote
+    # After normalization: 'word" - fix this to 'word'
+    text = fix_mixed_quote_pairs(text)
+
+    # Step 0c: Fix unescaped ASCII double quotes inside string values (Issue #288)
     # Bedrock sometimes returns invalid JSON with unescaped " inside strings
     text = fix_unescaped_inner_quotes(text)
 

--- a/tests/unit/test_etymologist.py
+++ b/tests/unit/test_etymologist.py
@@ -18,6 +18,7 @@ from src.etymologist import (
     count_words,
     escape_xml,
     extract_json,
+    fix_mixed_quote_pairs,
     get_fallback_response,
     process_bedrock_response,
     validate_response_schema,
@@ -359,6 +360,71 @@ class TestFixUnescapedInnerQuotes:
         input_json = '{"outer":{"inner":"The "word" here."}}'
         expected = """{"outer":{"inner":"The 'word' here."}}"""
         result = fix_unescaped_inner_quotes(input_json)
+        assert result == expected
+
+
+class TestFixMixedQuotePairs:
+    """Tests for mixed quote pair fixing (0829 audit).
+
+    When LLM uses curly LEFT quote + ASCII RIGHT quote, after unicode
+    normalization we get 'word" which breaks JSON parsing. This fixes
+    'word" -> 'word'.
+    """
+
+    def test_basic_mixed_pair(self):
+        """Basic case: single quote start, double quote end."""
+        input_text = """'diffidere", meaning 'to distrust'"""
+        expected = """'diffidere', meaning 'to distrust'"""
+        result = fix_mixed_quote_pairs(input_text)
+        assert result == expected
+
+    def test_multiple_mixed_pairs(self):
+        """Multiple mixed quote pairs in one string."""
+        input_text = """The words 'one" and 'two" are here."""
+        expected = """The words 'one' and 'two' are here."""
+        result = fix_mixed_quote_pairs(input_text)
+        assert result == expected
+
+    def test_no_mixed_pairs(self):
+        """String with no mixed pairs should be unchanged."""
+        input_text = """Normal text with 'proper' quotes."""
+        result = fix_mixed_quote_pairs(input_text)
+        assert result == input_text
+
+    def test_in_json_context(self):
+        """Mixed pair inside a JSON string value."""
+        input_text = '{"context": "From the Latin \'diffidere\", meaning trust."}'
+        expected = '{"context": "From the Latin \'diffidere\', meaning trust."}'
+        result = fix_mixed_quote_pairs(input_text)
+        assert result == expected
+
+    def test_real_world_bedrock_response(self):
+        """Real-world case from 0829 audit - diffidere with mixed quotes."""
+        # After unicode normalization, curly LEFT becomes ', but ASCII RIGHT stays "
+        input_text = """{"signal": "Formal Academic Term", "gem": "Test.", "context": "Derived from the Latin 'diffidere", meaning 'to distrust', the word emerged in the 16th century."}"""
+        result = extract_json(input_text)
+        assert result is not None
+        assert result["signal"] == "Formal Academic Term"
+        assert "'diffidere'" in result["context"]
+
+    def test_preserves_proper_double_quotes(self):
+        """Should not affect properly placed double quotes (JSON delimiters)."""
+        input_text = '{"key": "value"}'
+        result = fix_mixed_quote_pairs(input_text)
+        assert result == input_text
+
+    def test_empty_quoted_string(self):
+        """Empty string between quotes."""
+        input_text = """'", test"""
+        # Pattern 'X" requires at least one char between quotes
+        result = fix_mixed_quote_pairs(input_text)
+        assert result == input_text  # No change - empty match
+
+    def test_phrase_with_spaces(self):
+        """Quoted phrase with spaces."""
+        input_text = """'to be or not to be", that is the question."""
+        expected = """'to be or not to be', that is the question."""
+        result = fix_mixed_quote_pairs(input_text)
         assert result == expected
 
 


### PR DESCRIPTION
## Summary
- Fix JSON parsing failures caused by mixed quote styles in Bedrock responses
- Added `fix_mixed_quote_pairs()` to normalize `'word"` patterns to `'word'`
- Discovered via 0829 Lambda Failure Remediation audit from CloudWatch logs

## Root Cause
After unicode normalization converts curly quotes to single quotes, if Bedrock returned mixed quote styles (curly LEFT + ASCII RIGHT), we got broken patterns like `'word"` which broke JSON parsing.

The failure occurred when analyzing "diffident" - the LLM's etymology response included quoted Latin terms with mixed quote styles that broke JSON parsing.

## Test plan
- [x] Added 8 unit tests for `fix_mixed_quote_pairs` 
- [x] Verified all 104 etymologist tests pass
- [x] Real-world test case from CloudWatch logs now parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)