### PR TITLE
fix: add XSS protection to OAuth callback + unit tests (close #262)

### DIFF
--- a/docs/reports/262/implementation-report.md
+++ b/docs/reports/262/implementation-report.md
@@ -1,0 +1,50 @@
+# Implementation Report: #262 Lambda OAuth Callback Tests
+
+## Summary
+
+Added XSS protection to `handle_oauth_callback()` and comprehensive unit tests.
+
+## Changes Made
+
+### Security Fix: XSS Protection
+**File:** `src/lambda_auth_function.py`
+
+Applied `html.escape()` to all user-provided parameters:
+- `code` - OAuth authorization code
+- `state` - CSRF protection state
+- `error` - OAuth error code
+- `error_description` - Error details
+
+This prevents XSS attacks where malicious payloads in OAuth redirect parameters could execute in the user's browser.
+
+### Unit Tests
+**File:** `tests/unit/test_lambda_auth_callback.py`
+
+Added 12 test cases:
+1. `test_valid_code_and_state` - Happy path
+2. `test_missing_code` - Code parameter missing
+3. `test_missing_state` - State parameter missing
+4. `test_empty_params` - Both parameters missing
+5. `test_error_from_linkedin` - User denied access
+6. `test_error_without_description` - Error code only
+7. `test_html_structure_success` - Success HTML structure
+8. `test_html_structure_error` - Error HTML structure
+9. `test_xss_prevention_code` - XSS in code parameter
+10. `test_xss_prevention_error` - XSS in error_description
+11. `test_xss_prevention_state` - XSS in state parameter
+12. `test_xss_prevention_error_code` - XSS in error code
+
+## LLD Compliance
+
+Per `docs/lld/active/1262-lambda-oauth-callback-tests.md`:
+- [x] XSS fix applied (Section 6.0 - MANDATORY)
+- [x] Test file at `tests/unit/test_lambda_auth_callback.py` (Section 6.1)
+- [x] All 10+ test scenarios implemented (Section 11.1)
+- [x] XSS prevention tests verify proper escaping
+
+## Files Modified
+
+| File | Change Type |
+|------|-------------|
+| `src/lambda_auth_function.py` | Modified - Added html.escape() |
+| `tests/unit/test_lambda_auth_callback.py` | Created - 12 unit tests |

--- a/docs/reports/262/test-report.md
+++ b/docs/reports/262/test-report.md
@@ -1,0 +1,61 @@
+# Test Report: #262 Lambda OAuth Callback Tests
+
+## Test Execution
+
+**Date:** 2026-01-11
+**Environment:** Python 3.14, pytest 9.0.2
+**Command:** `poetry run pytest tests/unit/test_lambda_auth_callback.py -v`
+
+## Results
+
+```
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_valid_code_and_state PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_missing_code PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_missing_state PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_empty_params PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_error_from_linkedin PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_error_without_description PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_html_structure_success PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_html_structure_error PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_xss_prevention_code PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_xss_prevention_error PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_xss_prevention_state PASSED
+tests/unit/test_lambda_auth_callback.py::TestOAuthCallback::test_xss_prevention_error_code PASSED
+
+============================= 12 passed in 0.15s ==============================
+```
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | 12 |
+| Passed | 12 |
+| Failed | 0 |
+| Skipped | 0 |
+| Duration | 0.15s |
+
+## Test Coverage
+
+All test scenarios from LLD Section 11.1 implemented:
+
+| ID | Scenario | Status |
+|----|----------|--------|
+| 010 | Valid code and state | PASS |
+| 020 | Missing code | PASS |
+| 030 | Missing state | PASS |
+| 040 | Empty params | PASS |
+| 050 | Error from LinkedIn | PASS |
+| 060 | Error no description | PASS |
+| 070 | HTML structure (success) | PASS |
+| 080 | HTML structure (error) | PASS |
+| 090 | XSS in code escaped | PASS |
+| 100 | XSS in error escaped | PASS |
+
+## XSS Prevention Verification
+
+All XSS payloads properly escaped:
+- `<script>alert("xss")</script>` → `&lt;script&gt;alert("xss")&lt;/script&gt;`
+- `"><img src=x onerror=alert(1)>` → Angle brackets escaped
+
+No raw `<script>` or `<img` tags appear in test output HTML.

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -11,6 +11,7 @@ See: docs/1116-linkedin-oauth.md
 Issue #116: LinkedIn OAuth Authentication
 """
 
+import html
 import json
 import logging
 import os
@@ -462,15 +463,17 @@ def handle_oauth_callback(query_params: dict) -> dict:
     We return an HTML page that the extension can detect and extract the code from.
 
     Issue #256: Firefox OAuth tabs-based flow.
+    Issue #262: XSS fix - escape all user-provided parameters.
     """
-    code = query_params.get("code", "")
-    state = query_params.get("state", "")
-    error = query_params.get("error", "")
-    error_description = query_params.get("error_description", "")
+    # XSS prevention: escape all user-provided parameters before HTML insertion
+    code = html.escape(query_params.get("code", ""))
+    state = html.escape(query_params.get("state", ""))
+    error = html.escape(query_params.get("error", ""))
+    error_description = html.escape(query_params.get("error_description", ""))
 
     if error:
         # OAuth error from LinkedIn
-        html = f"""<!DOCTYPE html>
+        response_html = f"""<!DOCTYPE html>
 <html>
 <head>
     <title>Aletheia - Login Failed</title>
@@ -488,7 +491,7 @@ def handle_oauth_callback(query_params: dict) -> dict:
 </html>"""
     else:
         # Success - include code and state in a hidden div for extension to extract
-        html = f"""<!DOCTYPE html>
+        response_html = f"""<!DOCTYPE html>
 <html>
 <head>
     <title>Aletheia - Login Successful</title>
@@ -510,7 +513,7 @@ def handle_oauth_callback(query_params: dict) -> dict:
         "headers": {
             "Content-Type": "text/html; charset=utf-8",
         },
-        "body": html,
+        "body": response_html,
     }
 
 

--- a/tests/unit/test_lambda_auth_callback.py
+++ b/tests/unit/test_lambda_auth_callback.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for handle_oauth_callback() - Firefox OAuth redirect endpoint.
+
+Issue #262: Lambda OAuth callback endpoint tests.
+See: docs/lld/active/1262-lambda-oauth-callback-tests.md
+"""
+
+from src.lambda_auth_function import handle_oauth_callback
+
+
+class TestOAuthCallback:
+    """Tests for GET /auth/callback endpoint."""
+
+    def test_valid_code_and_state(self):
+        """Happy path: LinkedIn returns code and state."""
+        query_params = {"code": "test_auth_code_123", "state": "test_state_abc"}
+
+        response = handle_oauth_callback(query_params)
+
+        assert response["statusCode"] == 200
+        assert "text/html" in response["headers"]["Content-Type"]
+
+        body = response["body"]
+        assert "Login Successful" in body
+        assert 'data-code="test_auth_code_123"' in body
+        assert 'data-state="test_state_abc"' in body
+
+    def test_missing_code(self):
+        """Code parameter missing - returns success HTML with empty code."""
+        query_params = {"state": "test_state_abc"}
+
+        response = handle_oauth_callback(query_params)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        # Empty code still renders (extension handles validation)
+        assert 'data-code=""' in body
+
+    def test_missing_state(self):
+        """State parameter missing - returns success HTML with empty state."""
+        query_params = {"code": "test_auth_code_123"}
+
+        response = handle_oauth_callback(query_params)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert 'data-state=""' in body
+
+    def test_empty_params(self):
+        """Both parameters missing - returns success HTML with empty values."""
+        query_params = {}
+
+        response = handle_oauth_callback(query_params)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert 'data-code=""' in body
+        assert 'data-state=""' in body
+
+    def test_error_from_linkedin(self):
+        """User denied access - LinkedIn returns error."""
+        query_params = {
+            "error": "access_denied",
+            "error_description": "User denied access",
+        }
+
+        response = handle_oauth_callback(query_params)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert "Login Failed" in body
+        assert 'data-error="access_denied"' in body
+        assert "User denied access" in body
+
+    def test_error_without_description(self):
+        """Error without description - shows error code only."""
+        query_params = {"error": "server_error"}
+
+        response = handle_oauth_callback(query_params)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert "Login Failed" in body
+        assert 'data-error="server_error"' in body
+
+    def test_html_structure_success(self):
+        """Verify success HTML has required structure for extension parsing."""
+        query_params = {"code": "abc", "state": "xyz"}
+
+        response = handle_oauth_callback(query_params)
+        body = response["body"]
+
+        # Required elements for extension
+        assert "<title>Aletheia" in body
+        assert 'id="oauth-result"' in body
+        assert "data-code=" in body
+        assert "data-state=" in body
+
+    def test_html_structure_error(self):
+        """Verify error HTML has required structure."""
+        query_params = {"error": "test_error"}
+
+        response = handle_oauth_callback(query_params)
+        body = response["body"]
+
+        assert "<title>Aletheia" in body
+        assert 'id="oauth-result"' in body
+        assert "data-error=" in body
+
+    def test_xss_prevention_code(self):
+        """Code parameter with XSS attempt is HTML-escaped."""
+        query_params = {"code": '<script>alert("xss")</script>', "state": "safe"}
+
+        response = handle_oauth_callback(query_params)
+        body = response["body"]
+
+        # Raw script tags MUST NOT appear - must be escaped
+        assert response["statusCode"] == 200
+        assert "<script>" not in body
+        assert "&lt;script&gt;" in body  # Escaped version present
+
+    def test_xss_prevention_error(self):
+        """Error description with XSS attempt is HTML-escaped."""
+        query_params = {
+            "error": "test",
+            "error_description": '<script>alert("xss")</script>',
+        }
+
+        response = handle_oauth_callback(query_params)
+        body = response["body"]
+
+        # Raw script tags MUST NOT appear - must be escaped
+        assert response["statusCode"] == 200
+        assert "<script>" not in body
+        assert "&lt;script&gt;" in body  # Escaped version present
+
+    def test_xss_prevention_state(self):
+        """State parameter with XSS attempt is HTML-escaped."""
+        query_params = {"code": "safe", "state": '"><img src=x onerror=alert(1)>'}
+
+        response = handle_oauth_callback(query_params)
+        body = response["body"]
+
+        # Angle brackets must be escaped
+        assert response["statusCode"] == 200
+        assert "<img" not in body
+        assert "&lt;img" in body or "&gt;" in body
+
+    def test_xss_prevention_error_code(self):
+        """Error code with XSS attempt is HTML-escaped."""
+        query_params = {"error": '<script>bad</script>"}'}
+
+        response = handle_oauth_callback(query_params)
+        body = response["body"]
+
+        assert response["statusCode"] == 200
+        assert "<script>" not in body


### PR DESCRIPTION
## Summary
- Apply `html.escape()` to OAuth callback parameters (code, state, error, error_description)
- Add 12 unit tests for `handle_oauth_callback()` function
- Fixes XSS vulnerability in Firefox OAuth redirect endpoint

## Test plan
- [x] All 12 unit tests pass locally
- [x] XSS prevention tests verify proper escaping
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)