### PR TITLE
fix: semantic guardrail incorrectly blocks descriptive terms

### DIFF
--- a/extensions/chrome/overlay.js
+++ b/extensions/chrome/overlay.js
@@ -736,7 +736,8 @@ function showResultOverlay(response, httpStatus = 200) {
     // Extract data (will be set via textContent for XSS safety)
     const signal = response?.signal || 'Analysis';
     const gem = response?.gem || '';
-    const blockedReason = response?.blocked || 'Content blocked by safety filter';
+    // Issue #339: Use message/reason fields, not the boolean blocked field
+    const blockedReason = response?.message || response?.reason || 'Content blocked by safety filter';
 
     // Card container
     const cardClass = `aletheia-card ${pos.position}${hardBlock ? ' hard-block' : ''}`;

--- a/extensions/firefox/overlay.js
+++ b/extensions/firefox/overlay.js
@@ -736,7 +736,8 @@ function showResultOverlay(response, httpStatus = 200) {
     // Extract data (will be set via textContent for XSS safety)
     const signal = response?.signal || 'Analysis';
     const gem = response?.gem || '';
-    const blockedReason = response?.blocked || 'Content blocked by safety filter';
+    // Issue #339: Use message/reason fields, not the boolean blocked field
+    const blockedReason = response?.message || response?.reason || 'Content blocked by safety filter';
 
     // Card container
     const cardClass = `aletheia-card ${pos.position}${hardBlock ? ' hard-block' : ''}`;

--- a/src/guardrails/resources/taxonomy.json
+++ b/src/guardrails/resources/taxonomy.json
@@ -51,6 +51,16 @@
       "text": "The derivative of velocity is acceleration",
       "scores": {"Archaic": 0.0, "Provocative": 0.0, "Hate": 0.0, "Neologism": 0.0, "None": 1.0},
       "category": "None"
+    },
+    {
+      "text": "The article discusses misogyny and misogynists in modern society",
+      "scores": {"Archaic": 0.0, "Provocative": 0.0, "Hate": 0.0, "Neologism": 0.0, "None": 1.0},
+      "category": "None"
+    },
+    {
+      "text": "Critics called him a misandrist for his views",
+      "scores": {"Archaic": 0.0, "Provocative": 0.0, "Hate": 0.0, "Neologism": 0.0, "None": 1.0},
+      "category": "None"
     }
   ]
 }

--- a/tests/unit/test_semantic.py
+++ b/tests/unit/test_semantic.py
@@ -272,3 +272,78 @@ class TestHardSoftBlockingLogic:
         assert result["block_type"] == BLOCK_TYPE_SOFT
         assert result["is_fallback"] is True
         assert result["is_safe"] is False
+
+
+class TestDescriptiveTermsClassification:
+    """Tests for Issue #339: Descriptive terms should NOT be classified as Hate."""
+
+    def test_taxonomy_has_descriptive_term_examples(self):
+        """Verify few-shot examples include descriptive terms classified as None (safe)."""
+        with open(TAXONOMY_PATH) as f:
+            taxonomy = json.load(f)
+
+        examples = taxonomy["few_shot_examples"]
+
+        # Find examples containing descriptive terms
+        descriptive_terms = ["misogyn", "misandr"]
+        found_descriptive_safe = False
+
+        for example in examples:
+            text_lower = example["text"].lower()
+            if any(term in text_lower for term in descriptive_terms):
+                # Descriptive terms should be classified as "None" (safe), NOT "Hate"
+                assert example["category"] == "None", (
+                    f"Descriptive term in '{example['text']}' should be category 'None', "
+                    f"got '{example['category']}'"
+                )
+                found_descriptive_safe = True
+
+        assert found_descriptive_safe, (
+            "No descriptive term examples (misogynist/misandrist) found in taxonomy few-shot examples"
+        )
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_misogynist_returns_no_block(self, mock_boto_client):
+        """Descriptive term 'misogynist' should return BLOCK_TYPE_NONE, not HATE."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        # Mock Bedrock response: LLM correctly classifies as None (after seeing few-shot examples)
+        llm_output = json.dumps({"scores": {"None": 1.0}, "category": "None"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("The article discusses misogynists in modern society")
+
+        assert result["block_type"] == BLOCK_TYPE_NONE
+        assert result["category"] == "None"
+        assert result["is_safe"] is True
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_misandrist_returns_no_block(self, mock_boto_client):
+        """Descriptive term 'misandrist' should return BLOCK_TYPE_NONE, not HATE."""
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+
+        # Mock Bedrock response: LLM correctly classifies as None
+        llm_output = json.dumps({"scores": {"None": 1.0}, "category": "None"})
+        bedrock_response_body = json.dumps({
+            "content": [{"text": llm_output}]
+        }).encode("utf-8")
+
+        mock_body = Mock()
+        mock_body.read.return_value = bedrock_response_body
+        mock_client_instance.invoke_model.return_value = {"body": mock_body}
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("Critics called him a misandrist for his views")
+
+        assert result["block_type"] == BLOCK_TYPE_NONE
+        assert result["category"] == "None"
+        assert result["is_safe"] is True


### PR DESCRIPTION
## Summary
- Add few-shot examples for "misogynist" and "misandrist" as safe descriptive terms (not hate speech)
- Fix overlay display bug that showed raw boolean `true` instead of proper block reason message
- Add unit tests verifying descriptive terms are correctly classified as "None" (safe)

Closes #339

## Changes
| File | Change |
|------|--------|
| `src/guardrails/resources/taxonomy.json` | Added 2 few-shot examples for descriptive terms |
| `extensions/chrome/overlay.js` | Fixed blockedReason to use message/reason fields |
| `extensions/firefox/overlay.js` | Same fix as Chrome |
| `tests/unit/test_semantic.py` | Added 3 tests for descriptive term classification |

## Test plan
- [x] All 392 unit tests pass
- [x] New tests verify descriptive terms (misogynist/misandrist) are classified as "None"
- [x] Pre-commit hooks pass (ESLint, mypy, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)