### PR TITLE
fix: remove time bomb from parse_session_logs date filtering

### DIFF
--- a/docs/adrs/10200-ADR-index.md
+++ b/docs/adrs/10200-ADR-index.md
@@ -121,7 +121,7 @@ None yet.
 ## Adding New ADRs
 
 1. Copy `AgentOS:templates/0104-adr-template`
-2. Use next available number (currently 10216)
+2. Use next available number (currently 10217)
 3. Name format: `102xx-ADR-{short-topic}.md`
 4. Fill in all sections (Security Risk Analysis is mandatory)
 5. Update this index

--- a/tools/verify_audits.py
+++ b/tools/verify_audits.py
@@ -102,16 +102,13 @@ def parse_session_logs(
 
     Args:
         log_dir: Directory containing session log files
-        since: Only scan logs after this date (default: 4 weeks ago)
+        since: Only scan logs after this date (None = no filter)
         files: Explicit file list (overrides since)
 
     Returns:
         List of AuditClaim dictionaries
     """
     claims: list[AuditClaim] = []
-
-    if since is None:
-        since = datetime.now() - timedelta(weeks=4)
 
     # Get files to scan
     if files:
@@ -122,14 +119,15 @@ def parse_session_logs(
     for log_file in log_files:
         # Skip files older than since date based on filename
         # Filenames are either YYYY-MM-DD.md or Week-starting-YYYY-MM-DD.md
-        try:
-            date_match = re.search(r"(\d{4}-\d{2}-\d{2})", log_file.name)
-            if date_match:
-                file_date = datetime.strptime(date_match.group(1), "%Y-%m-%d")
-                if file_date < since:
-                    continue
-        except ValueError:
-            pass  # Can't parse date, include the file
+        if since is not None:
+            try:
+                date_match = re.search(r"(\d{4}-\d{2}-\d{2})", log_file.name)
+                if date_match:
+                    file_date = datetime.strptime(date_match.group(1), "%Y-%m-%d")
+                    if file_date < since:
+                        continue
+            except ValueError:
+                pass  # Can't parse date, include the file
 
         try:
             content = log_file.read_text(encoding="utf-8")
@@ -471,14 +469,18 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    # Parse since date
-    since = None
-    if args.since:
+    # Parse since date — default to 4 weeks ago for CLI usage
+    since: datetime | None = None
+    if args.files:
+        since = None  # Explicit file list overrides date filtering
+    elif args.since:
         try:
             since = datetime.strptime(args.since, "%Y-%m-%d")
         except ValueError:
             print(f"ERROR: Invalid date format: {args.since}", file=sys.stderr)
             return 2
+    else:
+        since = datetime.now() - timedelta(weeks=4)
 
     # Validate paths
     log_dir = args.docs_dir / "session-logs"


### PR DESCRIPTION
## Summary
- `parse_session_logs()` silently defaulted `since` to 4 weeks ago, causing test fixtures with hardcoded dates to fail after aging out of the window
- Moved the 4-week default to the CLI `main()`; library function now treats `since=None` as "no filter"
- Fixed stale ADR index next-available number (10216 → 10217)

Closes #360

## Test plan
- [x] 3 previously-failing tests now pass (test_010, test_070, test_full_verification_flow)
- [x] ADR index consistency test passes
- [x] Full suite: 738 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)