### PR TITLE
feat: tiered rate limiting with multi-window caps (close #364)

### DIFF
--- a/docs/reports/364/implementation-report.md
+++ b/docs/reports/364/implementation-report.md
@@ -1,0 +1,62 @@
+# Implementation Report — Issue #364: Tiered Rate Limiting with Multi-Window Caps
+
+**Date:** 2026-02-18
+**Branch:** `364-tiered-rate-limiting`
+**Commit:** `65c0a27`
+
+---
+
+## Summary
+
+Added per-request rate limiting with three time windows (hourly/daily/monthly) and three user tiers (free/subscriber/admin), enforced at request time in the `require_auth` middleware. Uses DynamoDB transactions for atomic 3-counter increments. Implements hybrid fail mode: free tier fail-closed (503), subscriber/admin fail-open on DynamoDB errors.
+
+## Files Changed (14 files, +2287 lines)
+
+### New Files (7)
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `src/auth/models/__init__.py` | 24 | Re-exports all model types |
+| `src/auth/models/rate_limit.py` | 66 | Core types: UserTier, WindowType, TierConfig, RateLimitResult |
+| `src/auth/models/user.py` | 17 | UserRecord TypedDict |
+| `src/auth/tier_config_service.py` | 197 | TierConfigService with 5-min TTL cache + DynamoDB persistence |
+| `tests/unit/test_multi_window_counter.py` | 669 | 47 tests for MultiWindowCounter (T010-T160) |
+| `tests/unit/test_tier_config_service.py` | 333 | 21 tests for TierConfigService (T130, T150, T170, T180) |
+| `tests/fixtures/rate_limit_429_response.json` | 7 | Sample 429 response fixture |
+
+### Modified Files (7)
+
+| File | Delta | Changes |
+|------|-------|---------|
+| `src/auth/token_cap_service.py` | +418 | Added MultiWindowCounter class (existing daily cap code untouched) |
+| `src/auth/auth_middleware.py` | +131 | Rate limiting in require_auth, extract_tier_from_jwt, check_rate_limit |
+| `src/auth/jwt_service.py` | +19 | tier/billing_anchor_day in JWT, claims field in AuthResult |
+| `src/lambda_auth_function.py` | +37 | get_user_tier(), tier embedding in token exchange |
+| `src/auth/__init__.py` | +29 | New exports |
+| `tests/unit/test_auth_middleware.py` | +284 | 20 new tests (T070, T120, T140) + autouse rate limit mock |
+| `tests/unit/test_jwt_service.py` | +66 | 8 new tests (T220: tier claims) |
+
+## Key Design Decisions
+
+1. **Hybrid fail mode:** Free tier fail-closed protects against abuse during outages; subscriber/admin fail-open avoids blocking paying users on infra blips
+2. **Module-level singletons:** `_tier_config_service` and `_multi_window_counter` in `auth_middleware.py` for connection reuse across Lambda invocations
+3. **DynamoDB transactions:** `transact_write_items` ensures all 3 counters increment atomically (no partial writes)
+4. **Monthly billing anchor:** Supports per-user billing cycle via `billing_anchor_day` with clamping for short months
+5. **Existing code untouched:** All existing daily cap code in `token_cap_service.py` is preserved; MultiWindowCounter is added alongside
+
+## DynamoDB Key Design (same `aletheia-token-cap` table)
+
+| PK | SK | TTL |
+|----|-----|-----|
+| `USER#{user_id}` | `RATE#HOURLY#{window}` | 2h |
+| `USER#{user_id}` | `RATE#DAILY#{window}` | 2d |
+| `USER#{user_id}` | `RATE#MONTHLY#{window}` | 35d |
+| `CONFIG` | `TIER#{tier}` | none |
+
+## Tier Caps (Defaults)
+
+| Tier | Hourly | Daily | Monthly |
+|------|--------|-------|---------|
+| Free | 5 | 15 | 100 |
+| Subscriber | 20 | 200 | 2000 |
+| Admin | 50 | 500 | 10000 |

--- a/docs/reports/364/test-report.md
+++ b/docs/reports/364/test-report.md
@@ -1,0 +1,56 @@
+# Test Report — Issue #364: Tiered Rate Limiting with Multi-Window Caps
+
+**Date:** 2026-02-18
+**Branch:** `364-tiered-rate-limiting`
+
+---
+
+## Test Results
+
+### Targeted Tests (195 total)
+
+| Test File | Tests | Status |
+|-----------|-------|--------|
+| `test_multi_window_counter.py` | 47 | All passed |
+| `test_tier_config_service.py` | 21 | All passed |
+| `test_auth_middleware.py` | 80 (20 new) | All passed |
+| `test_jwt_service.py` | 47 (8 new) | All passed |
+
+### Full Regression
+
+```
+834 passed, 2 skipped, 7 warnings in 25.36s
+```
+
+- **0 failures** — no regressions
+- **2 skipped** — pre-existing (LinkedIn OAuth tests requiring live credentials)
+- **7 warnings** — pre-existing PyJWT InsecureKeyLengthWarning from test fixtures using short HMAC keys
+
+## LLD Test Matrix Coverage
+
+| ID | Scenario | Test | Status |
+|----|----------|------|--------|
+| T010 | Request under all limits → allowed | `TestUnderAllLimits::test_allowed_when_under_caps` | Pass |
+| T020 | Hourly limit exceeded → 429 | `TestHourlyLimitExceeded::test_hourly_exceeded_returns_denied` | Pass |
+| T030 | Daily limit exceeded → 429 | `TestDailyLimitExceeded::test_daily_exceeded_returns_denied` | Pass |
+| T040 | Monthly limit exceeded → 429 | `TestMonthlyLimitExceeded::test_monthly_exceeded_returns_denied` | Pass |
+| T050 | Free tier boundary (5th OK, 6th fails) | `TestFreeTierBoundary::test_5th_request_allowed` / `test_6th_request_denied` | Pass |
+| T060 | Subscriber tier boundary (20th OK, 21st fails) | `TestSubscriberTierBoundary::test_20th_request_allowed` / `test_21st_request_denied` | Pass |
+| T070 | JWT contains tier → correct limits | `TestMiddlewareRateLimitWithTier::test_free_tier_rate_limited` | Pass |
+| T080a | DynamoDB timeout + free → fail-closed | `TestFailClosedFree::test_timeout_free_tier_denied` | Pass |
+| T080b | DynamoDB timeout + subscriber → fail-open | `TestFailOpenSubscriber::test_timeout_subscriber_allowed` | Pass |
+| T090 | Atomic transaction (single call) | `TestAtomicTransaction::test_single_transact_write_call` | Pass |
+| T100 | Monthly anniversary reset | `TestMonthlyAnchor::test_before_anchor_uses_previous_month` | Pass |
+| T110 | TTL verification (2h/2d/35d) | `TestTTLValues::test_hourly_ttl_is_2_hours` etc. | Pass |
+| T120 | 429 includes resets_at and resets_in_seconds | `TestRateLimitResponse::test_429_response_has_resets_at` | Pass |
+| T130 | Cache hit (no second DynamoDB call) | `TestCacheHit::test_cache_hit_no_second_dynamo_call` | Pass |
+| T140 | Missing tier → free limits | `TestMissingTierDefaultsFree::test_extract_tier_missing_defaults_free` | Pass |
+| T150 | Config loaded from DynamoDB | `TestLoadFromDynamoDB::test_dynamo_config_overrides_defaults` | Pass |
+| T160 | Multiple windows exceeded → hourly priority | `TestMultipleWindowsExceeded::test_hourly_and_daily_exceeded_returns_hourly` | Pass |
+| T170 | Tier config values match stored | `TestTierConfigValues::test_subscriber_config_from_dynamo` | Pass |
+| T180 | Admin tier 50/500/10000 | `TestAdminTier::test_admin_defaults_in_module` | Pass |
+| T220 | Tier embedded in JWT | `TestJwtTierClaims::test_create_jwt_contains_tier` | Pass |
+
+## Existing Test Compatibility
+
+Four existing tests (`TestMiddlewareValidToken`, `TestMiddlewareDualSecret`) required an `autouse` fixture to mock `check_rate_limit` — the new rate limiting code in `require_auth` tries to instantiate real DynamoDB clients. Fix: `@pytest.fixture(autouse=True)` with `patch("auth.auth_middleware.check_rate_limit", return_value=(True, None))`.

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,6 +1,7 @@
-"""Auth package for JWT authentication and daily token cap.
+"""Auth package for JWT authentication, daily token cap, and rate limiting.
 
 Issue #341: Add JWT authentication to analysis endpoint with daily token cap.
+Issue #364: Tiered rate limiting with multi-window caps.
 """
 
 from .jwt_service import (
@@ -14,11 +15,25 @@ from .token_cap_service import (
     get_current_cap,
     set_daily_cap,
     get_today_key,
+    MultiWindowCounter,
 )
 from .auth_middleware import (
     require_auth,
     extract_token,
     log_auth_failure,
+    extract_tier_from_jwt,
+    check_rate_limit,
+    build_rate_limit_error_response,
+)
+from .tier_config_service import TierConfigService
+from .models import (
+    UserTier,
+    WindowType,
+    TierConfig,
+    CounterState,
+    RateLimitResult,
+    RateLimitErrorResponse,
+    UserRecord,
 )
 
 __all__ = [
@@ -30,7 +45,19 @@ __all__ = [
     "get_current_cap",
     "set_daily_cap",
     "get_today_key",
+    "MultiWindowCounter",
     "require_auth",
     "extract_token",
     "log_auth_failure",
+    "extract_tier_from_jwt",
+    "check_rate_limit",
+    "build_rate_limit_error_response",
+    "TierConfigService",
+    "UserTier",
+    "WindowType",
+    "TierConfig",
+    "CounterState",
+    "RateLimitResult",
+    "RateLimitErrorResponse",
+    "UserRecord",
 ]

--- a/src/auth/auth_middleware.py
+++ b/src/auth/auth_middleware.py
@@ -1,9 +1,10 @@
 """JWT validation middleware for analysis endpoint.
 
 Issue: #341 - Add JWT authentication to analysis endpoint with daily token cap.
+Issue: #364 - Tiered rate limiting with multi-window caps.
 
 Provides a decorator-based middleware for clean separation of auth concerns.
-Fail mode: Fail Closed - deny authentication if any component is unavailable.
+Fail mode: Fail Closed for auth, hybrid for rate limiting.
 """
 
 from __future__ import annotations
@@ -21,6 +22,9 @@ from .jwt_service import (
     validate_jwt,
     validate_jwt_dual_secret,
 )
+from .models.rate_limit import RateLimitResult, UserTier
+from .tier_config_service import TierConfigService
+from .token_cap_service import MultiWindowCounter
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +111,116 @@ def _build_401_response(error_message: str) -> dict[str, Any]:
     }
 
 
+# --------------------------------------------------------------------------- #
+# Rate limiting (Issue #364)
+# --------------------------------------------------------------------------- #
+
+# Module-level singletons for rate limiting services
+_tier_config_service: TierConfigService | None = None
+_multi_window_counter: MultiWindowCounter | None = None
+
+# Upgrade URL for rate limit error responses
+_UPGRADE_URL = "https://aletheia.study/upgrade"
+
+
+def _get_tier_config_service() -> TierConfigService:
+    """Get or create the TierConfigService singleton."""
+    global _tier_config_service
+    if _tier_config_service is None:
+        _tier_config_service = TierConfigService()
+    return _tier_config_service
+
+
+def _get_multi_window_counter() -> MultiWindowCounter:
+    """Get or create the MultiWindowCounter singleton."""
+    global _multi_window_counter
+    if _multi_window_counter is None:
+        _multi_window_counter = MultiWindowCounter()
+    return _multi_window_counter
+
+
+def extract_tier_from_jwt(claims: dict) -> UserTier:
+    """Extract and validate user tier from JWT claims.
+
+    Args:
+        claims: Decoded JWT payload.
+
+    Returns:
+        UserTier enum value, defaults to FREE if missing or invalid.
+    """
+    tier_str = claims.get("tier", "free")
+    try:
+        return UserTier(tier_str)
+    except ValueError:
+        return UserTier.FREE
+
+
+def check_rate_limit(
+    user_id: str, tier: UserTier, billing_anchor_day: int = 1
+) -> tuple[bool, dict | None]:
+    """Check rate limits for a user request.
+
+    Args:
+        user_id: The user's unique identifier.
+        tier: The user's subscription tier.
+        billing_anchor_day: Day of month for billing cycle.
+
+    Returns:
+        Tuple of (allowed, error_response_dict_or_None).
+    """
+    config_service = _get_tier_config_service()
+    counter = _get_multi_window_counter()
+
+    tier_config = config_service.get_tier_config(tier)
+    result = counter.check_and_increment(user_id, tier_config, billing_anchor_day)
+
+    if result["allowed"]:
+        return True, None
+
+    error_body = build_rate_limit_error_response(result)
+    return False, error_body
+
+
+def build_rate_limit_error_response(result: RateLimitResult) -> dict:
+    """Build error response body for a rate limit violation.
+
+    Args:
+        result: The RateLimitResult from the counter check.
+
+    Returns:
+        Dict suitable for JSON serialization in a 429 response body.
+    """
+    if result.get("exceeded_window") == "SERVICE_UNAVAILABLE":
+        return {
+            "error": "Service temporarily unavailable, please retry",
+        }
+
+    return {
+        "error": "rate_limit_exceeded",
+        "window": result.get("exceeded_window", "unknown"),
+        "resets_at": result.get("resets_at", ""),
+        "resets_in_seconds": result.get("resets_in_seconds", 0),
+        "upgrade_url": _UPGRADE_URL,
+    }
+
+
+def _build_429_response(error_body: dict) -> dict[str, Any]:
+    """Build a 429 Too Many Requests response.
+
+    Args:
+        error_body: Error details dict.
+
+    Returns:
+        Lambda response dict with 429 status.
+    """
+    status = 503 if error_body.get("error") == "Service temporarily unavailable, please retry" else 429
+    return {
+        "statusCode": status,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(error_body),
+    }
+
+
 def require_auth(handler: Callable) -> Callable:
     """Decorator to require valid JWT authentication.
 
@@ -178,10 +292,22 @@ def require_auth(handler: Callable) -> Callable:
             log_auth_failure(auth_result.get("user_id"), reason, event)
             return _build_401_response("Unauthorized")
 
-        # Step 5: Inject user_id into event for downstream use
+        # Step 5: Check rate limits (Issue #364)
+        claims = auth_result.get("claims") or {}
+        tier = extract_tier_from_jwt(claims)
+        billing_anchor_day = claims.get("billing_anchor_day", 1)
+
+        user_id = str(auth_result["user_id"])  # guaranteed non-None after auth success
+        allowed, error_response = check_rate_limit(
+            user_id, tier, billing_anchor_day
+        )
+        if not allowed and error_response is not None:
+            return _build_429_response(error_response)
+
+        # Step 6: Inject user_id into event for downstream use
         event["auth_user_id"] = auth_result["user_id"]
 
-        # Step 6: Proceed to the wrapped handler
+        # Step 7: Proceed to the wrapped handler
         return handler(event, context, **kwargs)
 
     return wrapper

--- a/src/auth/jwt_service.py
+++ b/src/auth/jwt_service.py
@@ -1,6 +1,7 @@
 """JWT creation and validation service.
 
 Issue: #341 - Add JWT authentication to analysis endpoint with daily token cap.
+Issue: #364 - Tiered rate limiting with multi-window caps.
 """
 
 from __future__ import annotations
@@ -30,15 +31,24 @@ class AuthResult(TypedDict):
     user_id: str | None
     error: str | None
     reason: str | None
+    claims: dict | None
 
 
-def create_jwt(user_id: str, secret: str, expiry_hours: int = 24) -> str:
+def create_jwt(
+    user_id: str,
+    secret: str,
+    expiry_hours: int = 24,
+    tier: str = "free",
+    billing_anchor_day: int = 1,
+) -> str:
     """Create a signed JWT token for the given user.
 
     Args:
         user_id: The LinkedIn user ID to embed in the token.
         secret: The signing secret.
         expiry_hours: Token lifetime in hours (default 24).
+        tier: User subscription tier (default "free").
+        billing_anchor_day: Day of month for billing cycle (default 1).
 
     Returns:
         Encoded JWT string.
@@ -49,6 +59,8 @@ def create_jwt(user_id: str, secret: str, expiry_hours: int = 24) -> str:
         "exp": now + (expiry_hours * 3600),
         "iat": now,
         "jti": str(uuid.uuid4()),
+        "tier": tier,
+        "billing_anchor_day": billing_anchor_day,
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 
@@ -79,6 +91,7 @@ def validate_jwt(token: str, secret: str, leeway_seconds: int = 300) -> AuthResu
             user_id=payload["user_id"],
             error=None,
             reason=None,
+            claims=payload,
         )
     except jwt.ExpiredSignatureError:
         return AuthResult(
@@ -86,6 +99,7 @@ def validate_jwt(token: str, secret: str, leeway_seconds: int = 300) -> AuthResu
             user_id=None,
             error="Token has expired",
             reason="token_expired",
+            claims=None,
         )
     except jwt.InvalidSignatureError:
         return AuthResult(
@@ -93,6 +107,7 @@ def validate_jwt(token: str, secret: str, leeway_seconds: int = 300) -> AuthResu
             user_id=None,
             error="Invalid token signature",
             reason="invalid_signature",
+            claims=None,
         )
     except jwt.DecodeError:
         return AuthResult(
@@ -100,6 +115,7 @@ def validate_jwt(token: str, secret: str, leeway_seconds: int = 300) -> AuthResu
             user_id=None,
             error="Malformed token",
             reason="malformed",
+            claims=None,
         )
     except jwt.InvalidTokenError as e:
         return AuthResult(
@@ -107,6 +123,7 @@ def validate_jwt(token: str, secret: str, leeway_seconds: int = 300) -> AuthResu
             user_id=None,
             error=str(e),
             reason="invalid_token",
+            claims=None,
         )
 
 

--- a/src/auth/models/__init__.py
+++ b/src/auth/models/__init__.py
@@ -1,0 +1,24 @@
+"""Auth data models.
+
+Issue: #364 - Tiered rate limiting with multi-window caps.
+"""
+
+from .rate_limit import (
+    CounterState,
+    RateLimitErrorResponse,
+    RateLimitResult,
+    TierConfig,
+    UserTier,
+    WindowType,
+)
+from .user import UserRecord
+
+__all__ = [
+    "CounterState",
+    "RateLimitErrorResponse",
+    "RateLimitResult",
+    "TierConfig",
+    "UserRecord",
+    "UserTier",
+    "WindowType",
+]

--- a/src/auth/models/rate_limit.py
+++ b/src/auth/models/rate_limit.py
@@ -1,0 +1,66 @@
+"""Rate limiting data models.
+
+Issue: #364 - Tiered rate limiting with multi-window caps.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TypedDict
+
+
+class UserTier(str, Enum):
+    """User subscription tier for rate limiting."""
+
+    FREE = "free"
+    SUBSCRIBER = "subscriber"
+    ADMIN = "admin"
+
+
+class WindowType(str, Enum):
+    """Rate limit time window."""
+
+    HOURLY = "hourly"
+    DAILY = "daily"
+    MONTHLY = "monthly"
+
+
+class TierConfig(TypedDict):
+    """Rate limit configuration for a user tier."""
+
+    tier: str
+    hourly_cap: int
+    daily_cap: int
+    monthly_cap: int
+
+
+class CounterState(TypedDict):
+    """Current counter state for a user across all windows."""
+
+    user_id: str
+    hourly_count: int
+    hourly_window: str
+    daily_count: int
+    daily_window: str
+    monthly_count: int
+    monthly_window: str
+
+
+class RateLimitResult(TypedDict):
+    """Result of a rate limit check."""
+
+    allowed: bool
+    exceeded_window: str | None
+    resets_at: str | None
+    resets_in_seconds: int | None
+    current_counts: dict[str, int]
+
+
+class RateLimitErrorResponse(TypedDict):
+    """Error response body for 429 Too Many Requests."""
+
+    error: str
+    window: str
+    resets_at: str
+    resets_in_seconds: int
+    upgrade_url: str

--- a/src/auth/models/user.py
+++ b/src/auth/models/user.py
@@ -1,0 +1,17 @@
+"""User data models.
+
+Issue: #364 - Tiered rate limiting with multi-window caps.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class UserRecord(TypedDict):
+    """User record from DynamoDB."""
+
+    user_id: str
+    tier: str
+    billing_anchor_day: int
+    created_at: str

--- a/src/auth/tier_config_service.py
+++ b/src/auth/tier_config_service.py
@@ -1,0 +1,197 @@
+"""Tier configuration service for rate limiting.
+
+Issue: #364 - Tiered rate limiting with multi-window caps.
+
+Manages per-tier rate limit caps (hourly/daily/monthly) with
+in-memory caching and DynamoDB persistence.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models.rate_limit import TierConfig, UserTier
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL in seconds
+_CACHE_TTL = 300  # 5 minutes
+
+# Default tier configurations (hardcoded fallbacks)
+_DEFAULT_CONFIGS: dict[str, TierConfig] = {
+    UserTier.FREE: TierConfig(tier="free", hourly_cap=5, daily_cap=15, monthly_cap=100),
+    UserTier.SUBSCRIBER: TierConfig(tier="subscriber", hourly_cap=20, daily_cap=200, monthly_cap=2000),
+    UserTier.ADMIN: TierConfig(tier="admin", hourly_cap=50, daily_cap=500, monthly_cap=10000),
+}
+
+
+class TierConfigService:
+    """Service for managing tier rate limit configurations.
+
+    Uses an in-memory cache with 5-minute TTL. Falls back to
+    hardcoded defaults if DynamoDB is unavailable.
+    """
+
+    def __init__(
+        self,
+        table_name: str | None = None,
+        dynamodb_client: Any = None,
+    ) -> None:
+        self._table_name = table_name or os.environ.get(
+            "TOKEN_CAP_TABLE", "aletheia-token-cap"
+        )
+        self._client = dynamodb_client
+        self._cache: dict[str, tuple[TierConfig, float]] = {}
+
+    def _get_client(self) -> Any:
+        """Lazy-initialize DynamoDB client."""
+        if self._client is None:
+            region = os.environ.get("AWS_REGION", "us-east-1")
+            endpoint_url = os.environ.get("DYNAMODB_ENDPOINT")
+            kwargs: dict[str, Any] = {"region_name": region}
+            if endpoint_url:
+                kwargs["endpoint_url"] = endpoint_url
+            self._client = boto3.client("dynamodb", **kwargs)
+        return self._client
+
+    def get_tier_config(self, tier: UserTier | str) -> TierConfig:
+        """Get rate limit configuration for a tier.
+
+        Checks in-memory cache first (5-min TTL), then DynamoDB,
+        then falls back to hardcoded defaults.
+
+        Args:
+            tier: The user tier to look up.
+
+        Returns:
+            TierConfig with hourly/daily/monthly caps.
+        """
+        tier_str = tier.value if isinstance(tier, UserTier) else tier
+
+        # Check cache
+        cached = self._cache.get(tier_str)
+        if cached is not None:
+            config, cached_at = cached
+            if time.time() - cached_at < _CACHE_TTL:
+                return config
+
+        # Try DynamoDB
+        db_config = self._load_from_dynamodb(tier_str)
+        if db_config is not None:
+            self._cache[tier_str] = (db_config, time.time())
+            return db_config
+
+        # Fall back to hardcoded defaults
+        default = self._get_default_config(tier_str)
+        self._cache[tier_str] = (default, time.time())
+        return default
+
+    def _get_default_config(self, tier: str) -> TierConfig:
+        """Get hardcoded default configuration for a tier.
+
+        Args:
+            tier: The tier string value.
+
+        Returns:
+            Default TierConfig for the tier.
+        """
+        return _DEFAULT_CONFIGS.get(tier, _DEFAULT_CONFIGS[UserTier.FREE])
+
+    def _load_from_dynamodb(self, tier: str) -> TierConfig | None:
+        """Load tier configuration from DynamoDB.
+
+        Args:
+            tier: The tier string value.
+
+        Returns:
+            TierConfig if found in DynamoDB, None otherwise.
+        """
+        try:
+            client = self._get_client()
+            response = client.get_item(
+                TableName=self._table_name,
+                Key={
+                    "PK": {"S": "CONFIG"},
+                    "SK": {"S": f"TIER#{tier}"},
+                },
+            )
+
+            item = response.get("Item")
+            if not item:
+                return None
+
+            return TierConfig(
+                tier=tier,
+                hourly_cap=int(item["hourly_cap"]["N"]),
+                daily_cap=int(item["daily_cap"]["N"]),
+                monthly_cap=int(item["monthly_cap"]["N"]),
+            )
+
+        except (ClientError, KeyError, ValueError) as e:
+            logger.warning("Failed to load tier config from DynamoDB: %s", str(e))
+            return None
+
+    def set_tier_config(
+        self,
+        tier: UserTier | str,
+        hourly_cap: int,
+        daily_cap: int,
+        monthly_cap: int,
+    ) -> bool:
+        """Write tier configuration to DynamoDB.
+
+        Args:
+            tier: The user tier.
+            hourly_cap: Hourly request cap.
+            daily_cap: Daily request cap.
+            monthly_cap: Monthly request cap.
+
+        Returns:
+            True if the config was saved successfully.
+        """
+        tier_str = tier.value if isinstance(tier, UserTier) else tier
+
+        try:
+            client = self._get_client()
+            client.put_item(
+                TableName=self._table_name,
+                Item={
+                    "PK": {"S": "CONFIG"},
+                    "SK": {"S": f"TIER#{tier_str}"},
+                    "tier": {"S": tier_str},
+                    "hourly_cap": {"N": str(hourly_cap)},
+                    "daily_cap": {"N": str(daily_cap)},
+                    "monthly_cap": {"N": str(monthly_cap)},
+                },
+            )
+
+            # Invalidate cache for this tier
+            self._cache.pop(tier_str, None)
+
+            logger.info(
+                "Tier config updated: tier=%s, hourly=%d, daily=%d, monthly=%d",
+                tier_str, hourly_cap, daily_cap, monthly_cap,
+            )
+            return True
+
+        except ClientError as e:
+            logger.error("Failed to save tier config: %s", str(e))
+            raise
+
+    def invalidate_cache(self, tier: UserTier | str | None = None) -> None:
+        """Clear cached tier configurations.
+
+        Args:
+            tier: Specific tier to invalidate, or None for all.
+        """
+        if tier is None:
+            self._cache.clear()
+        else:
+            tier_str = tier.value if isinstance(tier, UserTier) else tier
+            self._cache.pop(tier_str, None)

--- a/src/auth/token_cap_service.py
+++ b/src/auth/token_cap_service.py
@@ -1,17 +1,28 @@
-"""Daily token cap tracking and enforcement.
+"""Daily token cap tracking and enforcement, plus multi-window rate limiting.
 
 Issue: #341 - Add JWT authentication to analysis endpoint with daily token cap.
+Issue: #364 - Tiered rate limiting with multi-window caps.
 """
 
 from __future__ import annotations
 
+import calendar
 import logging
 import os
-from datetime import datetime, timezone
-from typing import TypedDict
+from datetime import datetime, timedelta, timezone
+from typing import Any, TypedDict
 
 import boto3
+from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
+
+from .models.rate_limit import (
+    CounterState,
+    RateLimitResult,
+    TierConfig,
+    UserTier,
+    WindowType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -246,3 +257,404 @@ def set_daily_cap(table_name: str, new_cap: int, admin_id: str) -> bool:
     except ClientError as e:
         logger.error("Failed to update daily cap: %s", str(e))
         raise
+
+
+# --------------------------------------------------------------------------- #
+# Multi-window rate limiting (Issue #364)
+# --------------------------------------------------------------------------- #
+
+# TTL durations for counter cleanup
+_HOURLY_TTL_SECONDS = 2 * 3600       # 2 hours
+_DAILY_TTL_SECONDS = 2 * 86400       # 2 days
+_MONTHLY_TTL_SECONDS = 35 * 86400    # 35 days
+
+# Window priority order for reporting which was exceeded first
+_WINDOW_PRIORITY = [WindowType.HOURLY, WindowType.DAILY, WindowType.MONTHLY]
+
+
+class MultiWindowCounter:
+    """Atomic multi-window rate limit counter using DynamoDB transactions.
+
+    Checks and increments three counters (hourly, daily, monthly) in a
+    single DynamoDB transaction. Uses conditional writes to enforce caps.
+
+    Fail mode is hybrid:
+    - Free tier → fail-closed (503) on DynamoDB errors
+    - Subscriber/Admin → fail-open (allowed) on DynamoDB errors
+    """
+
+    def __init__(
+        self,
+        table_name: str | None = None,
+        dynamodb_client: Any = None,
+        timeout_seconds: float = 2.0,
+    ) -> None:
+        self._table_name = table_name or os.environ.get(
+            "TOKEN_CAP_TABLE", "aletheia-token-cap"
+        )
+        self._client = dynamodb_client
+        self._timeout_seconds = timeout_seconds
+
+    def _get_client(self) -> Any:
+        """Lazy-initialize DynamoDB client with timeout config."""
+        if self._client is None:
+            region = os.environ.get("AWS_REGION", "us-east-1")
+            endpoint_url = os.environ.get("DYNAMODB_ENDPOINT")
+            boto_config = BotoConfig(
+                connect_timeout=self._timeout_seconds,
+                read_timeout=self._timeout_seconds,
+            )
+            kwargs: dict[str, Any] = {"region_name": region, "config": boto_config}
+            if endpoint_url:
+                kwargs["endpoint_url"] = endpoint_url
+            self._client = boto3.client("dynamodb", **kwargs)
+        return self._client
+
+    def check_and_increment(
+        self,
+        user_id: str,
+        tier_config: TierConfig,
+        billing_anchor_day: int = 1,
+    ) -> RateLimitResult:
+        """Check rate limits and atomically increment all three counters.
+
+        Uses a DynamoDB TransactWriteItems to increment hourly, daily, and
+        monthly counters in a single atomic operation. Each counter has a
+        conditional check ensuring the current count is below the cap.
+
+        Args:
+            user_id: The user's unique identifier.
+            tier_config: The user's tier configuration with caps.
+            billing_anchor_day: Day of month for monthly window reset.
+
+        Returns:
+            RateLimitResult indicating whether the request is allowed.
+        """
+        now = datetime.now(timezone.utc)
+        hourly_window, daily_window, monthly_window = self._get_current_windows(
+            billing_anchor_day, now
+        )
+
+        pk = f"USER#{user_id}"
+        hourly_sk = f"RATE#HOURLY#{hourly_window}"
+        daily_sk = f"RATE#DAILY#{daily_window}"
+        monthly_sk = f"RATE#MONTHLY#{monthly_window}"
+
+        hourly_ttl = int((now + timedelta(seconds=_HOURLY_TTL_SECONDS)).timestamp())
+        daily_ttl = int((now + timedelta(seconds=_DAILY_TTL_SECONDS)).timestamp())
+        monthly_ttl = int((now + timedelta(seconds=_MONTHLY_TTL_SECONDS)).timestamp())
+
+        transact_items = [
+            {
+                "Update": {
+                    "TableName": self._table_name,
+                    "Key": {"PK": {"S": pk}, "SK": {"S": hourly_sk}},
+                    "UpdateExpression": (
+                        "SET #cnt = if_not_exists(#cnt, :zero) + :one, #ttl = :ttl_val"
+                    ),
+                    "ConditionExpression": (
+                        "attribute_not_exists(#cnt) OR #cnt < :cap"
+                    ),
+                    "ExpressionAttributeNames": {"#cnt": "count", "#ttl": "ttl"},
+                    "ExpressionAttributeValues": {
+                        ":zero": {"N": "0"},
+                        ":one": {"N": "1"},
+                        ":cap": {"N": str(tier_config["hourly_cap"])},
+                        ":ttl_val": {"N": str(hourly_ttl)},
+                    },
+                }
+            },
+            {
+                "Update": {
+                    "TableName": self._table_name,
+                    "Key": {"PK": {"S": pk}, "SK": {"S": daily_sk}},
+                    "UpdateExpression": (
+                        "SET #cnt = if_not_exists(#cnt, :zero) + :one, #ttl = :ttl_val"
+                    ),
+                    "ConditionExpression": (
+                        "attribute_not_exists(#cnt) OR #cnt < :cap"
+                    ),
+                    "ExpressionAttributeNames": {"#cnt": "count", "#ttl": "ttl"},
+                    "ExpressionAttributeValues": {
+                        ":zero": {"N": "0"},
+                        ":one": {"N": "1"},
+                        ":cap": {"N": str(tier_config["daily_cap"])},
+                        ":ttl_val": {"N": str(daily_ttl)},
+                    },
+                }
+            },
+            {
+                "Update": {
+                    "TableName": self._table_name,
+                    "Key": {"PK": {"S": pk}, "SK": {"S": monthly_sk}},
+                    "UpdateExpression": (
+                        "SET #cnt = if_not_exists(#cnt, :zero) + :one, #ttl = :ttl_val"
+                    ),
+                    "ConditionExpression": (
+                        "attribute_not_exists(#cnt) OR #cnt < :cap"
+                    ),
+                    "ExpressionAttributeNames": {"#cnt": "count", "#ttl": "ttl"},
+                    "ExpressionAttributeValues": {
+                        ":zero": {"N": "0"},
+                        ":one": {"N": "1"},
+                        ":cap": {"N": str(tier_config["monthly_cap"])},
+                        ":ttl_val": {"N": str(monthly_ttl)},
+                    },
+                }
+            },
+        ]
+
+        try:
+            client = self._get_client()
+            client.transact_write_items(TransactItems=transact_items)
+
+            return RateLimitResult(
+                allowed=True,
+                exceeded_window=None,
+                resets_at=None,
+                resets_in_seconds=None,
+                current_counts={},
+            )
+
+        except ClientError as e:
+            error_code = e.response["Error"].get("Code", "")
+
+            if error_code == "TransactionCanceledException":
+                # Determine which window(s) were exceeded
+                reasons = e.response.get("CancellationReasons", [])
+                exceeded = self._find_exceeded_window(
+                    reasons, hourly_window, daily_window, monthly_window,
+                    billing_anchor_day, now,
+                )
+                return exceeded
+
+            # Non-transaction error: hybrid fail mode
+            return self._handle_dynamo_error(e, tier_config, user_id)
+
+        except Exception as e:
+            # Any other error (timeout, connection, etc.): hybrid fail mode
+            logger.error("Unexpected error in rate limit check: %s", str(e))
+            return self._handle_dynamo_error(e, tier_config, user_id)
+
+    def _find_exceeded_window(
+        self,
+        reasons: list[dict],
+        hourly_window: str,
+        daily_window: str,
+        monthly_window: str,
+        billing_anchor_day: int,
+        now: datetime,
+    ) -> RateLimitResult:
+        """Determine which window was exceeded from transaction cancellation reasons.
+
+        Returns the highest-priority (hourly > daily > monthly) exceeded window.
+        """
+        window_map = {
+            0: (WindowType.HOURLY, hourly_window),
+            1: (WindowType.DAILY, daily_window),
+            2: (WindowType.MONTHLY, monthly_window),
+        }
+
+        for idx in range(3):  # Check in priority order: hourly, daily, monthly
+            if idx < len(reasons):
+                reason = reasons[idx]
+                code = reason.get("Code", "")
+                if code == "ConditionalCheckFailed":
+                    window_type, window_id = window_map[idx]
+                    resets_at = self._calculate_reset_time(
+                        window_type, window_id, billing_anchor_day, now
+                    )
+                    resets_in = max(0, int((resets_at - now).total_seconds()))
+
+                    return RateLimitResult(
+                        allowed=False,
+                        exceeded_window=window_type.value,
+                        resets_at=resets_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        resets_in_seconds=resets_in,
+                        current_counts={},
+                    )
+
+        # Fallback: shouldn't happen but return denied with hourly
+        resets_at = self._calculate_reset_time(
+            WindowType.HOURLY, hourly_window, billing_anchor_day, now
+        )
+        resets_in = max(0, int((resets_at - now).total_seconds()))
+        return RateLimitResult(
+            allowed=False,
+            exceeded_window=WindowType.HOURLY.value,
+            resets_at=resets_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            resets_in_seconds=resets_in,
+            current_counts={},
+        )
+
+    def _handle_dynamo_error(
+        self, error: Exception, tier_config: TierConfig, user_id: str
+    ) -> RateLimitResult:
+        """Handle DynamoDB errors with hybrid fail mode.
+
+        Free tier → fail-closed (503 "retry")
+        Subscriber/Admin → fail-open (allowed)
+        """
+        tier = tier_config.get("tier", "free")
+
+        if tier == UserTier.FREE or tier == "free":
+            logger.warning(
+                "Rate limit DynamoDB error for free user %s, fail-closed: %s",
+                user_id, str(error),
+            )
+            return RateLimitResult(
+                allowed=False,
+                exceeded_window="SERVICE_UNAVAILABLE",
+                resets_at=None,
+                resets_in_seconds=None,
+                current_counts={},
+            )
+        else:
+            logger.warning(
+                "Rate limit DynamoDB error for %s user %s, fail-open: %s",
+                tier, user_id, str(error),
+            )
+            return RateLimitResult(
+                allowed=True,
+                exceeded_window=None,
+                resets_at=None,
+                resets_in_seconds=None,
+                current_counts={},
+            )
+
+    @staticmethod
+    def _get_current_windows(
+        billing_anchor_day: int = 1,
+        now: datetime | None = None,
+    ) -> tuple[str, str, str]:
+        """Calculate current window identifiers for hourly, daily, monthly.
+
+        Args:
+            billing_anchor_day: Day of month when monthly billing resets.
+            now: Current UTC datetime (defaults to now).
+
+        Returns:
+            Tuple of (hourly_window, daily_window, monthly_window) strings.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        hourly_window = now.strftime("%Y-%m-%dT%H")
+        daily_window = now.strftime("%Y-%m-%d")
+
+        # Monthly window: if current day >= anchor, use current month
+        # Otherwise, use previous month
+        current_day = now.day
+        # Clamp anchor to last day of current month
+        last_day = calendar.monthrange(now.year, now.month)[1]
+        effective_anchor = min(billing_anchor_day, last_day)
+
+        if current_day >= effective_anchor:
+            monthly_window = now.strftime("%Y-%m")
+        else:
+            # Previous month
+            prev = now.replace(day=1) - timedelta(days=1)
+            monthly_window = prev.strftime("%Y-%m")
+
+        return hourly_window, daily_window, monthly_window
+
+    @staticmethod
+    def _calculate_reset_time(
+        window_type: WindowType,
+        current_window: str,
+        billing_anchor_day: int = 1,
+        now: datetime | None = None,
+    ) -> datetime:
+        """Calculate when a rate limit window resets.
+
+        Args:
+            window_type: Which window to calculate reset for.
+            current_window: Current window identifier string.
+            billing_anchor_day: Day of month for monthly reset.
+            now: Current UTC datetime.
+
+        Returns:
+            datetime when the window resets.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        if window_type == WindowType.HOURLY:
+            # Reset at the start of the next hour
+            next_hour = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+            return next_hour
+
+        elif window_type == WindowType.DAILY:
+            # Reset at midnight UTC tomorrow
+            tomorrow = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+            return tomorrow
+
+        else:  # MONTHLY
+            # Reset at the next billing anchor day
+            last_day = calendar.monthrange(now.year, now.month)[1]
+            effective_anchor = min(billing_anchor_day, last_day)
+
+            if now.day < effective_anchor:
+                # Resets later this month
+                return now.replace(
+                    day=effective_anchor, hour=0, minute=0, second=0, microsecond=0
+                )
+            else:
+                # Resets next month
+                next_month = now.replace(day=1) + timedelta(days=last_day)
+                next_last = calendar.monthrange(next_month.year, next_month.month)[1]
+                anchor = min(billing_anchor_day, next_last)
+                return next_month.replace(
+                    day=anchor, hour=0, minute=0, second=0, microsecond=0
+                )
+
+    def get_counter_state(
+        self, user_id: str, billing_anchor_day: int = 1
+    ) -> CounterState:
+        """Read current counter values without incrementing.
+
+        Args:
+            user_id: The user's unique identifier.
+            billing_anchor_day: Day of month for monthly window reset.
+
+        Returns:
+            CounterState with current counts for all windows.
+        """
+        now = datetime.now(timezone.utc)
+        hourly_window, daily_window, monthly_window = self._get_current_windows(
+            billing_anchor_day, now
+        )
+        pk = f"USER#{user_id}"
+
+        counts: dict[str, int] = {}
+        windows = [
+            (f"RATE#HOURLY#{hourly_window}", "hourly"),
+            (f"RATE#DAILY#{daily_window}", "daily"),
+            (f"RATE#MONTHLY#{monthly_window}", "monthly"),
+        ]
+
+        try:
+            client = self._get_client()
+            for sk, name in windows:
+                response = client.get_item(
+                    TableName=self._table_name,
+                    Key={"PK": {"S": pk}, "SK": {"S": sk}},
+                )
+                item = response.get("Item")
+                if item and "count" in item:
+                    counts[name] = int(item["count"]["N"])
+                else:
+                    counts[name] = 0
+        except (ClientError, Exception) as e:
+            logger.warning("Failed to read counter state: %s", str(e))
+            counts = {"hourly": 0, "daily": 0, "monthly": 0}
+
+        return CounterState(
+            user_id=user_id,
+            hourly_count=counts.get("hourly", 0),
+            hourly_window=hourly_window,
+            daily_count=counts.get("daily", 0),
+            daily_window=daily_window,
+            monthly_count=counts.get("monthly", 0),
+            monthly_window=monthly_window,
+        )

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -13,6 +13,7 @@ See: docs/1116-linkedin-oauth.md
 
 Issue #116: LinkedIn OAuth Authentication
 Issue #341: JWT authentication and daily token cap
+Issue #364: Tiered rate limiting with multi-window caps
 """
 
 import html
@@ -390,6 +391,34 @@ def get_or_create_user(user_info: dict) -> dict:
         raise
 
 
+def get_user_tier(user_id: str) -> tuple[str, int]:
+    """Look up user tier and billing anchor day from DynamoDB.
+
+    Issue #364: Embed tier in JWT for per-request rate limiting.
+
+    Args:
+        user_id: The user's unique identifier (LinkedIn sub).
+
+    Returns:
+        Tuple of (tier, billing_anchor_day). Defaults to ("free", 1)
+        if user record doesn't have these fields.
+    """
+    try:
+        client = get_dynamodb_client()
+        response = client.get_item(
+            TableName=USERS_TABLE,
+            Key={"user_id": {"S": user_id}},
+            ProjectionExpression="tier, billing_anchor_day",
+        )
+        item = response.get("Item", {})
+        tier = item.get("tier", {}).get("S", "free")
+        billing_anchor_day = int(item.get("billing_anchor_day", {}).get("N", "1"))
+        return tier, billing_anchor_day
+    except (ClientError, KeyError, ValueError) as e:
+        logger.warning(f"Failed to get user tier for {user_id}: {e}")
+        return "free", 1
+
+
 def handle_token_exchange(body: dict) -> dict:
     """
     Handle POST /auth/token - Exchange auth code for tokens and issue JWT.
@@ -473,10 +502,14 @@ def handle_token_exchange(body: dict) -> dict:
                 }),
             }
 
-        # 5. Generate JWT (Issue #341)
+        # 5. Generate JWT with tier (Issue #341, #364)
         try:
             jwt_secret = get_jwt_secret()
-            jwt_token = create_jwt(user["user_id"], jwt_secret, expiry_hours=24)
+            tier, billing_anchor_day = get_user_tier(user["user_id"])
+            jwt_token = create_jwt(
+                user["user_id"], jwt_secret, expiry_hours=24,
+                tier=tier, billing_anchor_day=billing_anchor_day,
+            )
         except Exception as e:
             logger.error(f"JWT generation failed: {e}")
             return {

--- a/tests/fixtures/rate_limit_429_response.json
+++ b/tests/fixtures/rate_limit_429_response.json
@@ -1,0 +1,7 @@
+{
+  "error": "rate_limit_exceeded",
+  "window": "hourly",
+  "resets_at": "2026-02-16T15:00:00Z",
+  "resets_in_seconds": 1800,
+  "upgrade_url": "https://aletheia.study/upgrade"
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,6 +49,19 @@ USERS_TABLE_SCHEMA = {
     "BillingMode": "PAY_PER_REQUEST",
 }
 
+TOKEN_CAP_TABLE_SCHEMA = {
+    "TableName": "aletheia-token-cap",
+    "KeySchema": [
+        {"AttributeName": "PK", "KeyType": "HASH"},
+        {"AttributeName": "SK", "KeyType": "RANGE"},
+    ],
+    "AttributeDefinitions": [
+        {"AttributeName": "PK", "AttributeType": "S"},
+        {"AttributeName": "SK", "AttributeType": "S"},
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+}
+
 
 @pytest.fixture(scope="session")
 def dynamodb_endpoint() -> Generator[str, None, None]:
@@ -111,6 +124,8 @@ def dynamodb_client(dynamodb_endpoint: str):
     table_name: str = AGENT_STATE_TABLE_SCHEMA["TableName"]  # type: ignore[assignment]
     os.environ["DYNAMODB_TABLE"] = table_name
     os.environ["AGENT_STATE_TABLE"] = table_name
+    token_cap_name: str = TOKEN_CAP_TABLE_SCHEMA["TableName"]  # type: ignore[assignment]
+    os.environ["TOKEN_CAP_TABLE"] = token_cap_name
 
     client = boto3.client(
         "dynamodb",
@@ -127,6 +142,7 @@ def dynamodb_client(dynamodb_endpoint: str):
         del os.environ["DYNAMODB_ENDPOINT"]
     del os.environ["DYNAMODB_TABLE"]
     del os.environ["AGENT_STATE_TABLE"]
+    del os.environ["TOKEN_CAP_TABLE"]
 
 
 @pytest.fixture(scope="session")
@@ -166,8 +182,24 @@ def users_table(dynamodb_client) -> str:
     return table_name
 
 
+@pytest.fixture(scope="session")
+def token_cap_table(dynamodb_client) -> str:
+    """Create aletheia-token-cap table for rate limiting (Issue #364)."""
+    table_name: str = TOKEN_CAP_TABLE_SCHEMA["TableName"]  # type: ignore[assignment]
+
+    try:
+        dynamodb_client.create_table(**TOKEN_CAP_TABLE_SCHEMA)
+        waiter = dynamodb_client.get_waiter("table_exists")
+        waiter.wait(TableName=table_name, WaiterConfig={"Delay": 1, "MaxAttempts": 30})
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ResourceInUseException":
+            raise
+
+    return table_name
+
+
 @pytest.fixture(autouse=True)
-def cleanup_tables(dynamodb_client, agent_state_table, users_table):
+def cleanup_tables(dynamodb_client, agent_state_table, users_table, token_cap_table):
     """
     Delete all items after each test.
 
@@ -221,6 +253,26 @@ def cleanup_tables(dynamodb_client, agent_state_table, users_table):
             )
     except ClientError:
         pass
+
+    # Cleanup token_cap_table (rate limit counters)
+    try:
+        response = dynamodb_client.scan(
+            TableName=token_cap_table,
+            ProjectionExpression="PK, SK",
+        )
+        for item in response.get("Items", []):
+            dynamodb_client.delete_item(
+                TableName=token_cap_table,
+                Key={"PK": item["PK"], "SK": item["SK"]},
+            )
+    except ClientError:
+        pass
+
+    # Reset rate limiter singletons so they pick up fresh DynamoDB clients
+    import src.auth.auth_middleware as _mw
+
+    _mw._tier_config_service = None  # noqa: SLF001
+    _mw._multi_window_counter = None  # noqa: SLF001
 
 
 @pytest.fixture

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -1,12 +1,16 @@
 """Unit tests for auth middleware.
 
 Issue: #341 - Add JWT authentication to analysis endpoint with daily token cap.
+Issue: #364 - Tiered rate limiting with multi-window caps.
 
 Tests cover:
 - T090: Auth middleware - missing header (REQ-1, REQ-9)
 - T100: Auth middleware - invalid format (REQ-1, REQ-9)
 - T110: Auth middleware - valid token (REQ-4)
 - T130: Auth failure logging format (REQ-9)
+- T070: JWT tier claim → rate limit with correct tier (#364)
+- T120: 429 response includes resets_at and resets_in_seconds (#364)
+- T140: Missing tier in JWT → free limits applied (#364)
 """
 
 from __future__ import annotations
@@ -22,6 +26,9 @@ import pytest
 
 from auth.auth_middleware import (
     _build_401_response,
+    _build_429_response,
+    build_rate_limit_error_response,
+    extract_tier_from_jwt,
     extract_token,
     log_auth_failure,
     require_auth,
@@ -30,6 +37,7 @@ from auth.jwt_service import (
     create_jwt,
     invalidate_secret_cache,
 )
+from auth.models.rate_limit import RateLimitResult, UserTier
 
 # --------------------------------------------------------------------------- #
 # Constants
@@ -342,6 +350,12 @@ class TestMiddlewareInvalidFormat:
 class TestMiddlewareValidToken:
     """T110: Request with valid JWT proceeds to handler with user_id."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_rate_limit(self):
+        """Bypass rate limiting for valid-token tests."""
+        with patch("auth.auth_middleware.check_rate_limit", return_value=(True, None)):
+            yield
+
     def test_valid_token_calls_handler(self, valid_token: str):
         """REQ-4: Valid JWT → handler is invoked."""
         handler = MagicMock(return_value={"statusCode": 200, "body": "{}"})
@@ -618,6 +632,12 @@ class TestMiddlewareSecretUnavailable:
 class TestMiddlewareDualSecret:
     """Dual-secret rotation support in middleware."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_rate_limit(self):
+        """Bypass rate limiting for dual-secret tests."""
+        with patch("auth.auth_middleware.check_rate_limit", return_value=(True, None)):
+            yield
+
     def test_secondary_secret_validates_old_token(self):
         """Token signed with old (secondary) secret validates during rotation."""
         old_token = create_jwt(TEST_USER_ID, TEST_SECRET_ALT)
@@ -838,3 +858,267 @@ class TestRequireAuthDecorator:
         """Decorated handler is callable."""
         protected = require_auth(_dummy_handler)
         assert callable(protected)
+
+
+# --------------------------------------------------------------------------- #
+# T070 - JWT tier claim → rate limit with correct tier (#364)
+# --------------------------------------------------------------------------- #
+
+
+class TestMiddlewareRateLimitWithTier:
+    """T070: JWT tier claim is used for rate limiting."""
+
+    def test_free_tier_rate_limited(self):
+        """Free tier JWT triggers rate limit check with free config."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET, tier="free")
+        protected = require_auth(_dummy_handler)
+        event = _make_event(f"Bearer {token}")
+
+        with (
+            patch("auth.auth_middleware.get_jwt_secret", return_value=TEST_SECRET),
+            patch("auth.auth_middleware.check_rate_limit", return_value=(True, None)) as mock_check,
+        ):
+            response = protected(event, None)
+
+        assert response["statusCode"] == 200
+        # Verify check_rate_limit was called with FREE tier
+        mock_check.assert_called_once()
+        call_args = mock_check.call_args
+        assert call_args[0][1] == UserTier.FREE
+
+    def test_subscriber_tier_rate_limited(self):
+        """Subscriber tier JWT triggers rate limit check with subscriber config."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET, tier="subscriber")
+        protected = require_auth(_dummy_handler)
+        event = _make_event(f"Bearer {token}")
+
+        with (
+            patch("auth.auth_middleware.get_jwt_secret", return_value=TEST_SECRET),
+            patch("auth.auth_middleware.check_rate_limit", return_value=(True, None)) as mock_check,
+        ):
+            response = protected(event, None)
+
+        assert response["statusCode"] == 200
+        call_args = mock_check.call_args
+        assert call_args[0][1] == UserTier.SUBSCRIBER
+
+    def test_rate_limit_exceeded_returns_429(self):
+        """Rate limit exceeded → 429 response."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET, tier="free")
+        protected = require_auth(_dummy_handler)
+        event = _make_event(f"Bearer {token}")
+
+        error_body = {
+            "error": "rate_limit_exceeded",
+            "window": "hourly",
+            "resets_at": "2026-02-16T15:00:00Z",
+            "resets_in_seconds": 1800,
+            "upgrade_url": "https://aletheia.study/upgrade",
+        }
+
+        with (
+            patch("auth.auth_middleware.get_jwt_secret", return_value=TEST_SECRET),
+            patch("auth.auth_middleware.check_rate_limit", return_value=(False, error_body)),
+        ):
+            response = protected(event, None)
+
+        assert response["statusCode"] == 429
+
+    def test_rate_limit_exceeded_handler_not_called(self):
+        """Handler is NOT invoked when rate limit exceeded."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET)
+        handler = MagicMock(return_value={"statusCode": 200})
+        protected = require_auth(handler)
+        event = _make_event(f"Bearer {token}")
+
+        error_body = {"error": "rate_limit_exceeded", "window": "daily"}
+
+        with (
+            patch("auth.auth_middleware.get_jwt_secret", return_value=TEST_SECRET),
+            patch("auth.auth_middleware.check_rate_limit", return_value=(False, error_body)),
+        ):
+            protected(event, None)
+
+        handler.assert_not_called()
+
+    def test_rate_limit_passes_billing_anchor_day(self):
+        """billing_anchor_day from JWT is passed to rate limit check."""
+        token = create_jwt(
+            TEST_USER_ID, TEST_SECRET, tier="subscriber", billing_anchor_day=15
+        )
+        protected = require_auth(_dummy_handler)
+        event = _make_event(f"Bearer {token}")
+
+        with (
+            patch("auth.auth_middleware.get_jwt_secret", return_value=TEST_SECRET),
+            patch("auth.auth_middleware.check_rate_limit", return_value=(True, None)) as mock_check,
+        ):
+            protected(event, None)
+
+        call_args = mock_check.call_args
+        assert call_args[0][2] == 15  # billing_anchor_day
+
+
+# --------------------------------------------------------------------------- #
+# T120 - 429 response includes resets_at and resets_in_seconds (#364)
+# --------------------------------------------------------------------------- #
+
+
+class TestRateLimitResponse:
+    """T120: 429 response body contains rate limit details."""
+
+    def test_429_response_has_error_field(self):
+        """429 body includes 'error' field."""
+        result = RateLimitResult(
+            allowed=False,
+            exceeded_window="hourly",
+            resets_at="2026-02-16T15:00:00Z",
+            resets_in_seconds=1800,
+            current_counts={},
+        )
+        body = build_rate_limit_error_response(result)
+        assert body["error"] == "rate_limit_exceeded"
+
+    def test_429_response_has_window(self):
+        """429 body includes 'window' field."""
+        result = RateLimitResult(
+            allowed=False,
+            exceeded_window="daily",
+            resets_at="2026-02-17T00:00:00Z",
+            resets_in_seconds=3600,
+            current_counts={},
+        )
+        body = build_rate_limit_error_response(result)
+        assert body["window"] == "daily"
+
+    def test_429_response_has_resets_at(self):
+        """429 body includes 'resets_at' ISO timestamp."""
+        result = RateLimitResult(
+            allowed=False,
+            exceeded_window="hourly",
+            resets_at="2026-02-16T15:00:00Z",
+            resets_in_seconds=1800,
+            current_counts={},
+        )
+        body = build_rate_limit_error_response(result)
+        assert body["resets_at"] == "2026-02-16T15:00:00Z"
+
+    def test_429_response_has_resets_in_seconds(self):
+        """429 body includes 'resets_in_seconds' integer."""
+        result = RateLimitResult(
+            allowed=False,
+            exceeded_window="hourly",
+            resets_at="2026-02-16T15:00:00Z",
+            resets_in_seconds=1800,
+            current_counts={},
+        )
+        body = build_rate_limit_error_response(result)
+        assert body["resets_in_seconds"] == 1800
+
+    def test_429_response_has_upgrade_url(self):
+        """429 body includes upgrade URL."""
+        result = RateLimitResult(
+            allowed=False,
+            exceeded_window="hourly",
+            resets_at="2026-02-16T15:00:00Z",
+            resets_in_seconds=1800,
+            current_counts={},
+        )
+        body = build_rate_limit_error_response(result)
+        assert "upgrade_url" in body
+        assert "aletheia.study" in body["upgrade_url"]
+
+    def test_service_unavailable_response(self):
+        """SERVICE_UNAVAILABLE produces retry message instead of 429 fields."""
+        result = RateLimitResult(
+            allowed=False,
+            exceeded_window="SERVICE_UNAVAILABLE",
+            resets_at=None,
+            resets_in_seconds=None,
+            current_counts={},
+        )
+        body = build_rate_limit_error_response(result)
+        assert "retry" in body["error"].lower()
+
+    def test_build_429_response_status_code(self):
+        """_build_429_response returns 429 status code."""
+        response = _build_429_response({"error": "rate_limit_exceeded"})
+        assert response["statusCode"] == 429
+
+    def test_build_429_response_json_content_type(self):
+        """_build_429_response has JSON content type."""
+        response = _build_429_response({"error": "rate_limit_exceeded"})
+        assert response["headers"]["Content-Type"] == "application/json"
+
+    def test_build_503_for_service_unavailable(self):
+        """SERVICE_UNAVAILABLE gets 503 status code, not 429."""
+        response = _build_429_response(
+            {"error": "Service temporarily unavailable, please retry"}
+        )
+        assert response["statusCode"] == 503
+
+
+# --------------------------------------------------------------------------- #
+# T140 - Missing tier in JWT → free limits applied (#364)
+# --------------------------------------------------------------------------- #
+
+
+class TestMissingTierDefaultsFree:
+    """T140: Missing tier in JWT defaults to free tier limits."""
+
+    def test_extract_tier_missing_defaults_free(self):
+        """Missing tier claim defaults to FREE."""
+        claims = {"user_id": "test", "exp": 999, "iat": 0, "jti": "x"}
+        tier = extract_tier_from_jwt(claims)
+        assert tier == UserTier.FREE
+
+    def test_extract_tier_invalid_value_defaults_free(self):
+        """Invalid tier string defaults to FREE."""
+        claims = {"tier": "premium_deluxe", "user_id": "test"}
+        tier = extract_tier_from_jwt(claims)
+        assert tier == UserTier.FREE
+
+    def test_extract_tier_free(self):
+        """tier='free' extracts correctly."""
+        claims = {"tier": "free"}
+        tier = extract_tier_from_jwt(claims)
+        assert tier == UserTier.FREE
+
+    def test_extract_tier_subscriber(self):
+        """tier='subscriber' extracts correctly."""
+        claims = {"tier": "subscriber"}
+        tier = extract_tier_from_jwt(claims)
+        assert tier == UserTier.SUBSCRIBER
+
+    def test_extract_tier_admin(self):
+        """tier='admin' extracts correctly."""
+        claims = {"tier": "admin"}
+        tier = extract_tier_from_jwt(claims)
+        assert tier == UserTier.ADMIN
+
+    def test_old_jwt_without_tier_gets_free_rate_limit(self):
+        """Pre-#364 JWT without tier claim is rate-limited as free."""
+        # Create a JWT without tier/billing_anchor_day (simulating old format)
+        import jwt as pyjwt
+        now = int(time.time())
+        old_payload = {
+            "user_id": TEST_USER_ID,
+            "exp": now + 86400,
+            "iat": now,
+            "jti": "old-format-jti",
+        }
+        old_token = pyjwt.encode(old_payload, TEST_SECRET, algorithm="HS256")
+
+        protected = require_auth(_dummy_handler)
+        event = _make_event(f"Bearer {old_token}")
+
+        with (
+            patch("auth.auth_middleware.get_jwt_secret", return_value=TEST_SECRET),
+            patch("auth.auth_middleware.check_rate_limit", return_value=(True, None)) as mock_check,
+        ):
+            response = protected(event, None)
+
+        assert response["statusCode"] == 200
+        call_args = mock_check.call_args
+        assert call_args[0][1] == UserTier.FREE  # tier
+        assert call_args[0][2] == 1  # billing_anchor_day default

--- a/tests/unit/test_jwt_service.py
+++ b/tests/unit/test_jwt_service.py
@@ -1,6 +1,7 @@
 """Unit tests for JWT service.
 
 Issue: #341 - Add JWT authentication to analysis endpoint with daily token cap.
+Issue: #364 - Tiered rate limiting with multi-window caps.
 
 Tests cover:
 - T010: JWT creation with valid inputs (REQ-5, REQ-6)
@@ -10,6 +11,7 @@ Tests cover:
 - T050: JWT validation - malformed token (REQ-2)
 - T140: Secret retrieval from Secrets Manager (REQ-10)
 - T150: Dual-secret validation during rotation (REQ-10)
+- T220: Tier and billing_anchor_day embedded in JWT (#364)
 """
 
 from __future__ import annotations
@@ -514,3 +516,67 @@ class TestValidateJwtDualSecret:
         # Should get token_expired, not try secondary
         assert result["success"] is False
         assert result["reason"] == "token_expired"
+
+
+# --------------------------------------------------------------------------- #
+# T220 - Tier and billing_anchor_day in JWT (#364)
+# --------------------------------------------------------------------------- #
+
+
+class TestJwtTierClaims:
+    """T220: Tier and billing_anchor_day are embedded in JWT."""
+
+    def test_create_jwt_contains_tier(self):
+        """JWT contains tier claim."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET, tier="subscriber")
+        payload = pyjwt.decode(token, TEST_SECRET, algorithms=["HS256"])
+        assert payload["tier"] == "subscriber"
+
+    def test_create_jwt_contains_billing_anchor_day(self):
+        """JWT contains billing_anchor_day claim."""
+        token = create_jwt(
+            TEST_USER_ID, TEST_SECRET, billing_anchor_day=15
+        )
+        payload = pyjwt.decode(token, TEST_SECRET, algorithms=["HS256"])
+        assert payload["billing_anchor_day"] == 15
+
+    def test_default_tier_is_free(self):
+        """Default tier claim is 'free'."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET)
+        payload = pyjwt.decode(token, TEST_SECRET, algorithms=["HS256"])
+        assert payload["tier"] == "free"
+
+    def test_default_billing_anchor_day_is_1(self):
+        """Default billing_anchor_day is 1."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET)
+        payload = pyjwt.decode(token, TEST_SECRET, algorithms=["HS256"])
+        assert payload["billing_anchor_day"] == 1
+
+    def test_tier_roundtrip_through_validate(self):
+        """Tier survives create → validate roundtrip in claims."""
+        token = create_jwt(
+            TEST_USER_ID, TEST_SECRET, tier="admin", billing_anchor_day=20
+        )
+        result = validate_jwt(token, TEST_SECRET)
+        assert result["success"] is True
+        assert result["claims"]["tier"] == "admin"
+        assert result["claims"]["billing_anchor_day"] == 20
+
+    def test_validate_returns_claims_on_success(self, valid_token: str):
+        """Successful validation includes claims dict."""
+        result = validate_jwt(valid_token, TEST_SECRET)
+        assert result["claims"] is not None
+        assert "user_id" in result["claims"]
+        assert "exp" in result["claims"]
+
+    def test_validate_returns_none_claims_on_failure(self):
+        """Failed validation has claims=None."""
+        result = validate_jwt("invalid.token.here", TEST_SECRET)
+        assert result["success"] is False
+        assert result["claims"] is None
+
+    def test_admin_tier_in_jwt(self):
+        """Admin tier value embeds correctly."""
+        token = create_jwt(TEST_USER_ID, TEST_SECRET, tier="admin")
+        payload = pyjwt.decode(token, TEST_SECRET, algorithms=["HS256"])
+        assert payload["tier"] == "admin"

--- a/tests/unit/test_multi_window_counter.py
+++ b/tests/unit/test_multi_window_counter.py
@@ -1,0 +1,669 @@
+"""Unit tests for MultiWindowCounter.
+
+Issue: #364 - Tiered rate limiting with multi-window caps.
+
+Tests cover:
+- T010: Request under all limits → allowed
+- T020: Hourly limit exceeded → 429 with hourly window
+- T030: Daily limit exceeded → 429 with daily window
+- T040: Monthly limit exceeded → 429 with monthly window
+- T050: Free tier boundary (5th hourly OK, 6th fails)
+- T060: Subscriber tier boundary (20th hourly OK, 21st fails)
+- T080a: DynamoDB timeout + free tier → fail-closed
+- T080b: DynamoDB timeout + subscriber tier → fail-open
+- T090: Atomic transaction failure → no partial increments
+- T100: Monthly anniversary reset with billing_anchor_day
+- T110: TTL verification (2h/2d/35d)
+- T160: Multiple windows exceeded → returns first (hourly priority)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from auth.models.rate_limit import TierConfig, WindowType
+from auth.token_cap_service import (
+    MultiWindowCounter,
+    _DAILY_TTL_SECONDS,
+    _HOURLY_TTL_SECONDS,
+    _MONTHLY_TTL_SECONDS,
+)
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+TABLE_NAME = "test-token-cap-table"
+TEST_USER_ID = "test-user-001"
+
+FREE_CONFIG = TierConfig(tier="free", hourly_cap=5, daily_cap=15, monthly_cap=100)
+SUBSCRIBER_CONFIG = TierConfig(tier="subscriber", hourly_cap=20, daily_cap=200, monthly_cap=2000)
+ADMIN_CONFIG = TierConfig(tier="admin", hourly_cap=50, daily_cap=500, monthly_cap=10000)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _client_error(code: str, message: str = "test error") -> ClientError:
+    """Build a botocore ClientError for testing."""
+    return ClientError(
+        {"Error": {"Code": code, "Message": message}},
+        "TestOperation",
+    )
+
+
+def _transaction_canceled(
+    hourly_failed: bool = False,
+    daily_failed: bool = False,
+    monthly_failed: bool = False,
+) -> ClientError:
+    """Build a TransactionCanceledException with specific cancellation reasons."""
+    reasons = []
+    for failed in [hourly_failed, daily_failed, monthly_failed]:
+        if failed:
+            reasons.append({"Code": "ConditionalCheckFailed", "Message": "cap exceeded"})
+        else:
+            reasons.append({"Code": "None", "Message": ""})
+
+    error = _client_error("TransactionCanceledException", "Transaction cancelled")
+    error.response["CancellationReasons"] = reasons
+    return error
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def mock_client():
+    """Provide a mock DynamoDB client."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def counter(mock_client):
+    """Provide a MultiWindowCounter with mock client."""
+    return MultiWindowCounter(
+        table_name=TABLE_NAME,
+        dynamodb_client=mock_client,
+        timeout_seconds=2.0,
+    )
+
+
+@pytest.fixture()
+def frozen_now():
+    """Freeze time to a deterministic datetime."""
+    now = datetime(2026, 2, 16, 14, 30, 0, tzinfo=timezone.utc)
+    with patch("auth.token_cap_service.datetime") as mock_dt:
+        mock_dt.now.return_value = now
+        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        yield now
+
+
+# --------------------------------------------------------------------------- #
+# T010: Request under all limits → allowed
+# --------------------------------------------------------------------------- #
+
+
+class TestUnderAllLimits:
+    """T010: Request under all rate limits returns allowed."""
+
+    def test_allowed_when_under_caps(self, counter, mock_client):
+        """All counters under cap → allowed=True."""
+        mock_client.transact_write_items.return_value = {}
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is True
+        assert result["exceeded_window"] is None
+        mock_client.transact_write_items.assert_called_once()
+
+    def test_transaction_has_three_updates(self, counter, mock_client):
+        """Transaction includes 3 Update items (hourly, daily, monthly)."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        assert len(call_kwargs["TransactItems"]) == 3
+
+    def test_all_updates_use_conditional_write(self, counter, mock_client):
+        """Each update has ConditionExpression for cap enforcement."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        for item in call_kwargs["TransactItems"]:
+            assert "ConditionExpression" in item["Update"]
+
+    def test_pk_format(self, counter, mock_client):
+        """PK uses USER#{user_id} format."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        for item in call_kwargs["TransactItems"]:
+            pk = item["Update"]["Key"]["PK"]["S"]
+            assert pk == f"USER#{TEST_USER_ID}"
+
+    def test_sk_format_hourly(self, counter, mock_client):
+        """SK for hourly counter uses RATE#HOURLY#{window} format."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        hourly_sk = call_kwargs["TransactItems"][0]["Update"]["Key"]["SK"]["S"]
+        assert hourly_sk.startswith("RATE#HOURLY#")
+
+
+# --------------------------------------------------------------------------- #
+# T020: Hourly limit exceeded → 429 with hourly window
+# --------------------------------------------------------------------------- #
+
+
+class TestHourlyLimitExceeded:
+    """T020: Hourly rate limit exceeded returns correct response."""
+
+    def test_hourly_exceeded_returns_denied(self, counter, mock_client):
+        """Hourly cap exceeded → allowed=False."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "hourly"
+
+    def test_hourly_exceeded_has_reset_time(self, counter, mock_client):
+        """Hourly exceeded response includes resets_at."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["resets_at"] is not None
+        assert "T" in result["resets_at"]  # ISO format
+
+    def test_hourly_exceeded_has_resets_in_seconds(self, counter, mock_client):
+        """Hourly exceeded response includes resets_in_seconds."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["resets_in_seconds"] is not None
+        assert result["resets_in_seconds"] >= 0
+
+
+# --------------------------------------------------------------------------- #
+# T030: Daily limit exceeded → 429 with daily window
+# --------------------------------------------------------------------------- #
+
+
+class TestDailyLimitExceeded:
+    """T030: Daily rate limit exceeded returns correct response."""
+
+    def test_daily_exceeded_returns_denied(self, counter, mock_client):
+        """Daily cap exceeded → allowed=False with daily window."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            daily_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "daily"
+
+
+# --------------------------------------------------------------------------- #
+# T040: Monthly limit exceeded → 429 with monthly window
+# --------------------------------------------------------------------------- #
+
+
+class TestMonthlyLimitExceeded:
+    """T040: Monthly rate limit exceeded returns correct response."""
+
+    def test_monthly_exceeded_returns_denied(self, counter, mock_client):
+        """Monthly cap exceeded → allowed=False with monthly window."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            monthly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "monthly"
+
+
+# --------------------------------------------------------------------------- #
+# T050: Free tier boundary (5th hourly OK, 6th fails)
+# --------------------------------------------------------------------------- #
+
+
+class TestFreeTierBoundary:
+    """T050: Free tier boundary behavior at cap limit."""
+
+    def test_5th_request_allowed(self, counter, mock_client):
+        """5th request under free hourly cap of 5 is allowed."""
+        mock_client.transact_write_items.return_value = {}
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is True
+
+    def test_6th_request_denied(self, counter, mock_client):
+        """6th request exceeding free hourly cap of 5 is denied."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "hourly"
+
+    def test_free_hourly_cap_in_condition(self, counter, mock_client):
+        """Free tier cap of 5 is used in condition expression."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        hourly_item = call_kwargs["TransactItems"][0]["Update"]
+        cap_value = hourly_item["ExpressionAttributeValues"][":cap"]["N"]
+        assert cap_value == "5"
+
+
+# --------------------------------------------------------------------------- #
+# T060: Subscriber tier boundary
+# --------------------------------------------------------------------------- #
+
+
+class TestSubscriberTierBoundary:
+    """T060: Subscriber tier boundary at 20 hourly cap."""
+
+    def test_20th_request_allowed(self, counter, mock_client):
+        """20th request under subscriber hourly cap of 20 is allowed."""
+        mock_client.transact_write_items.return_value = {}
+
+        result = counter.check_and_increment(TEST_USER_ID, SUBSCRIBER_CONFIG)
+
+        assert result["allowed"] is True
+
+    def test_21st_request_denied(self, counter, mock_client):
+        """21st request exceeding subscriber hourly cap is denied."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, SUBSCRIBER_CONFIG)
+
+        assert result["allowed"] is False
+
+    def test_subscriber_hourly_cap_in_condition(self, counter, mock_client):
+        """Subscriber tier cap of 20 is used in condition expression."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, SUBSCRIBER_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        hourly_item = call_kwargs["TransactItems"][0]["Update"]
+        cap_value = hourly_item["ExpressionAttributeValues"][":cap"]["N"]
+        assert cap_value == "20"
+
+
+# --------------------------------------------------------------------------- #
+# T080a: DynamoDB timeout + free tier → fail-closed
+# --------------------------------------------------------------------------- #
+
+
+class TestFailClosedFree:
+    """T080a: DynamoDB errors with free tier → fail-closed."""
+
+    def test_timeout_free_tier_denied(self, counter, mock_client):
+        """DynamoDB timeout for free user → denied."""
+        mock_client.transact_write_items.side_effect = _client_error(
+            "ProvisionedThroughputExceededException"
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+
+    def test_timeout_free_tier_service_unavailable(self, counter, mock_client):
+        """DynamoDB error for free user → SERVICE_UNAVAILABLE window."""
+        mock_client.transact_write_items.side_effect = _client_error(
+            "InternalServerError"
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["exceeded_window"] == "SERVICE_UNAVAILABLE"
+
+    def test_connection_error_free_tier_denied(self, counter, mock_client):
+        """Connection error for free user → denied."""
+        mock_client.transact_write_items.side_effect = ConnectionError("timeout")
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+
+
+# --------------------------------------------------------------------------- #
+# T080b: DynamoDB timeout + subscriber tier → fail-open
+# --------------------------------------------------------------------------- #
+
+
+class TestFailOpenSubscriber:
+    """T080b: DynamoDB errors with subscriber tier → fail-open."""
+
+    def test_timeout_subscriber_allowed(self, counter, mock_client):
+        """DynamoDB timeout for subscriber → allowed (fail-open)."""
+        mock_client.transact_write_items.side_effect = _client_error(
+            "ProvisionedThroughputExceededException"
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, SUBSCRIBER_CONFIG)
+
+        assert result["allowed"] is True
+
+    def test_timeout_admin_allowed(self, counter, mock_client):
+        """DynamoDB timeout for admin → allowed (fail-open)."""
+        mock_client.transact_write_items.side_effect = _client_error(
+            "InternalServerError"
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, ADMIN_CONFIG)
+
+        assert result["allowed"] is True
+
+    def test_connection_error_subscriber_allowed(self, counter, mock_client):
+        """Connection error for subscriber → allowed (fail-open)."""
+        mock_client.transact_write_items.side_effect = ConnectionError("timeout")
+
+        result = counter.check_and_increment(TEST_USER_ID, SUBSCRIBER_CONFIG)
+
+        assert result["allowed"] is True
+
+
+# --------------------------------------------------------------------------- #
+# T090: Atomic transaction failure → no partial increments
+# --------------------------------------------------------------------------- #
+
+
+class TestAtomicTransaction:
+    """T090: Transaction ensures no partial increments."""
+
+    def test_single_transact_write_call(self, counter, mock_client):
+        """All three counters updated in a single transact_write_items call."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert mock_client.transact_write_items.call_count == 1
+
+    def test_all_counters_in_one_transaction(self, counter, mock_client):
+        """Transaction contains exactly 3 items for hourly/daily/monthly."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        items = call_kwargs["TransactItems"]
+        assert len(items) == 3
+
+        # Verify the SK prefixes
+        sks = [item["Update"]["Key"]["SK"]["S"] for item in items]
+        assert any("RATE#HOURLY#" in sk for sk in sks)
+        assert any("RATE#DAILY#" in sk for sk in sks)
+        assert any("RATE#MONTHLY#" in sk for sk in sks)
+
+
+# --------------------------------------------------------------------------- #
+# T100: Monthly anniversary reset with billing_anchor_day
+# --------------------------------------------------------------------------- #
+
+
+class TestMonthlyAnchor:
+    """T100: Monthly window respects billing_anchor_day."""
+
+    def test_before_anchor_uses_previous_month(self):
+        """Day 5 with anchor=15 → previous month window."""
+        now = datetime(2026, 2, 5, 10, 0, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(15, now)
+        assert m == "2026-01"
+
+    def test_on_anchor_uses_current_month(self):
+        """Day 15 with anchor=15 → current month window."""
+        now = datetime(2026, 2, 15, 10, 0, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(15, now)
+        assert m == "2026-02"
+
+    def test_after_anchor_uses_current_month(self):
+        """Day 20 with anchor=15 → current month window."""
+        now = datetime(2026, 2, 20, 10, 0, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(15, now)
+        assert m == "2026-02"
+
+    def test_anchor_clamped_to_short_month(self):
+        """Anchor day 31 in February clamped to 28/29."""
+        now = datetime(2026, 2, 28, 10, 0, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(31, now)
+        # Feb 28 >= min(31, 28) = 28, so current month
+        assert m == "2026-02"
+
+    def test_default_anchor_day_1(self):
+        """Default billing_anchor_day=1 uses calendar month."""
+        now = datetime(2026, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(1, now)
+        assert m == "2026-02"
+
+    def test_hourly_window_format(self):
+        """Hourly window is YYYY-MM-DDTHH."""
+        now = datetime(2026, 2, 16, 14, 30, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(1, now)
+        assert h == "2026-02-16T14"
+
+    def test_daily_window_format(self):
+        """Daily window is YYYY-MM-DD."""
+        now = datetime(2026, 2, 16, 14, 30, 0, tzinfo=timezone.utc)
+        h, d, m = MultiWindowCounter._get_current_windows(1, now)
+        assert d == "2026-02-16"
+
+
+# --------------------------------------------------------------------------- #
+# T110: TTL verification
+# --------------------------------------------------------------------------- #
+
+
+class TestTTLValues:
+    """T110: Counter TTLs match spec (2h/2d/35d)."""
+
+    def test_hourly_ttl_is_2_hours(self):
+        """Hourly TTL is 2 hours (7200 seconds)."""
+        assert _HOURLY_TTL_SECONDS == 2 * 3600
+
+    def test_daily_ttl_is_2_days(self):
+        """Daily TTL is 2 days (172800 seconds)."""
+        assert _DAILY_TTL_SECONDS == 2 * 86400
+
+    def test_monthly_ttl_is_35_days(self):
+        """Monthly TTL is 35 days (3024000 seconds)."""
+        assert _MONTHLY_TTL_SECONDS == 35 * 86400
+
+    def test_ttl_set_in_hourly_update(self, counter, mock_client):
+        """Hourly counter update includes TTL attribute."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        hourly_item = call_kwargs["TransactItems"][0]["Update"]
+        assert ":ttl_val" in hourly_item["ExpressionAttributeValues"]
+        ttl = int(hourly_item["ExpressionAttributeValues"][":ttl_val"]["N"])
+        assert ttl > 0
+
+    def test_ttl_set_in_daily_update(self, counter, mock_client):
+        """Daily counter update includes TTL attribute."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        daily_item = call_kwargs["TransactItems"][1]["Update"]
+        assert ":ttl_val" in daily_item["ExpressionAttributeValues"]
+
+    def test_ttl_set_in_monthly_update(self, counter, mock_client):
+        """Monthly counter update includes TTL attribute."""
+        mock_client.transact_write_items.return_value = {}
+
+        counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        call_kwargs = mock_client.transact_write_items.call_args[1]
+        monthly_item = call_kwargs["TransactItems"][2]["Update"]
+        assert ":ttl_val" in monthly_item["ExpressionAttributeValues"]
+
+
+# --------------------------------------------------------------------------- #
+# T160: Multiple windows exceeded → returns first (hourly priority)
+# --------------------------------------------------------------------------- #
+
+
+class TestMultipleWindowsExceeded:
+    """T160: When multiple windows exceeded, report hourly first."""
+
+    def test_hourly_and_daily_exceeded_returns_hourly(self, counter, mock_client):
+        """Both hourly and daily exceeded → reports hourly."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True, daily_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "hourly"
+
+    def test_all_three_exceeded_returns_hourly(self, counter, mock_client):
+        """All three windows exceeded → reports hourly."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            hourly_failed=True, daily_failed=True, monthly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "hourly"
+
+    def test_daily_and_monthly_exceeded_returns_daily(self, counter, mock_client):
+        """Daily and monthly exceeded (not hourly) → reports daily."""
+        mock_client.transact_write_items.side_effect = _transaction_canceled(
+            daily_failed=True, monthly_failed=True
+        )
+
+        result = counter.check_and_increment(TEST_USER_ID, FREE_CONFIG)
+
+        assert result["allowed"] is False
+        assert result["exceeded_window"] == "daily"
+
+
+# --------------------------------------------------------------------------- #
+# Reset time calculation
+# --------------------------------------------------------------------------- #
+
+
+class TestResetTimeCalculation:
+    """Test _calculate_reset_time produces correct reset times."""
+
+    def test_hourly_resets_at_next_hour(self):
+        """Hourly window resets at start of next hour."""
+        now = datetime(2026, 2, 16, 14, 30, 0, tzinfo=timezone.utc)
+        reset = MultiWindowCounter._calculate_reset_time(
+            WindowType.HOURLY, "2026-02-16T14", 1, now
+        )
+        assert reset.hour == 15
+        assert reset.minute == 0
+        assert reset.second == 0
+
+    def test_daily_resets_at_midnight(self):
+        """Daily window resets at midnight UTC tomorrow."""
+        now = datetime(2026, 2, 16, 14, 30, 0, tzinfo=timezone.utc)
+        reset = MultiWindowCounter._calculate_reset_time(
+            WindowType.DAILY, "2026-02-16", 1, now
+        )
+        assert reset.day == 17
+        assert reset.hour == 0
+
+    def test_monthly_resets_at_next_anchor(self):
+        """Monthly window resets at next billing anchor day."""
+        now = datetime(2026, 2, 16, 14, 30, 0, tzinfo=timezone.utc)
+        reset = MultiWindowCounter._calculate_reset_time(
+            WindowType.MONTHLY, "2026-02", 1, now
+        )
+        # Anchor day=1, current day=16, so resets March 1
+        assert reset.month == 3
+        assert reset.day == 1
+
+    def test_monthly_resets_this_month_if_before_anchor(self):
+        """Monthly resets later this month if before anchor day."""
+        now = datetime(2026, 2, 5, 14, 30, 0, tzinfo=timezone.utc)
+        reset = MultiWindowCounter._calculate_reset_time(
+            WindowType.MONTHLY, "2026-01", 15, now
+        )
+        # Before anchor 15, so resets Feb 15
+        assert reset.month == 2
+        assert reset.day == 15
+
+
+# --------------------------------------------------------------------------- #
+# get_counter_state
+# --------------------------------------------------------------------------- #
+
+
+class TestGetCounterState:
+    """Test read-only counter state retrieval."""
+
+    def test_returns_counter_state(self, counter, mock_client):
+        """get_counter_state returns CounterState with all fields."""
+        mock_client.get_item.return_value = {
+            "Item": {"count": {"N": "3"}}
+        }
+
+        state = counter.get_counter_state(TEST_USER_ID)
+
+        assert state["user_id"] == TEST_USER_ID
+        assert "hourly_count" in state
+        assert "daily_count" in state
+        assert "monthly_count" in state
+
+    def test_returns_zero_when_no_counters(self, counter, mock_client):
+        """Counter state returns 0 when no items exist."""
+        mock_client.get_item.return_value = {}
+
+        state = counter.get_counter_state(TEST_USER_ID)
+
+        assert state["hourly_count"] == 0
+        assert state["daily_count"] == 0
+        assert state["monthly_count"] == 0
+
+    def test_handles_dynamodb_error(self, counter, mock_client):
+        """Counter state returns 0s on DynamoDB error."""
+        mock_client.get_item.side_effect = _client_error("InternalServerError")
+
+        state = counter.get_counter_state(TEST_USER_ID)
+
+        assert state["hourly_count"] == 0
+        assert state["daily_count"] == 0
+        assert state["monthly_count"] == 0

--- a/tests/unit/test_tier_config_service.py
+++ b/tests/unit/test_tier_config_service.py
@@ -1,0 +1,333 @@
+"""Unit tests for TierConfigService.
+
+Issue: #364 - Tiered rate limiting with multi-window caps.
+
+Tests cover:
+- T130: Cache hit (second call within 5 min → no DynamoDB call)
+- T150: Config loaded from DynamoDB
+- T170: Tier config values match stored values
+- T180: Admin tier uses 50/500/10000 caps
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from auth.models.rate_limit import UserTier
+from auth.tier_config_service import TierConfigService, _CACHE_TTL, _DEFAULT_CONFIGS
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+TABLE_NAME = "test-token-cap-table"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _client_error(code: str, message: str = "test error") -> ClientError:
+    """Build a botocore ClientError for testing."""
+    return ClientError(
+        {"Error": {"Code": code, "Message": message}},
+        "TestOperation",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def mock_client():
+    """Provide a mock DynamoDB client."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def service(mock_client):
+    """Provide a TierConfigService with mock client."""
+    return TierConfigService(table_name=TABLE_NAME, dynamodb_client=mock_client)
+
+
+# --------------------------------------------------------------------------- #
+# Default configs
+# --------------------------------------------------------------------------- #
+
+
+class TestDefaultConfigs:
+    """Verify hardcoded default tier configurations."""
+
+    def test_free_defaults(self, service, mock_client):
+        """Free tier defaults: 5/15/100."""
+        mock_client.get_item.return_value = {}
+
+        config = service.get_tier_config(UserTier.FREE)
+
+        assert config["hourly_cap"] == 5
+        assert config["daily_cap"] == 15
+        assert config["monthly_cap"] == 100
+
+    def test_subscriber_defaults(self, service, mock_client):
+        """Subscriber tier defaults: 20/200/2000."""
+        mock_client.get_item.return_value = {}
+
+        config = service.get_tier_config(UserTier.SUBSCRIBER)
+
+        assert config["hourly_cap"] == 20
+        assert config["daily_cap"] == 200
+        assert config["monthly_cap"] == 2000
+
+    def test_admin_defaults(self, service, mock_client):
+        """T180: Admin tier defaults: 50/500/10000."""
+        mock_client.get_item.return_value = {}
+
+        config = service.get_tier_config(UserTier.ADMIN)
+
+        assert config["hourly_cap"] == 50
+        assert config["daily_cap"] == 500
+        assert config["monthly_cap"] == 10000
+
+    def test_unknown_tier_defaults_to_free(self, service, mock_client):
+        """Unknown tier string defaults to free tier limits."""
+        mock_client.get_item.return_value = {}
+
+        config = service.get_tier_config("enterprise")
+
+        assert config["hourly_cap"] == 5
+        assert config["daily_cap"] == 15
+        assert config["monthly_cap"] == 100
+
+
+# --------------------------------------------------------------------------- #
+# T130: Cache hit
+# --------------------------------------------------------------------------- #
+
+
+class TestCacheHit:
+    """T130: Second call within 5 min uses cache, no DynamoDB call."""
+
+    def test_cache_hit_no_second_dynamo_call(self, service, mock_client):
+        """Second get_tier_config call within TTL doesn't call DynamoDB."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+        service.get_tier_config(UserTier.FREE)
+
+        # Only one DynamoDB call (first cache miss)
+        assert mock_client.get_item.call_count == 1
+
+    def test_cache_returns_same_config(self, service, mock_client):
+        """Cached result returns identical config."""
+        mock_client.get_item.return_value = {}
+
+        config1 = service.get_tier_config(UserTier.FREE)
+        config2 = service.get_tier_config(UserTier.FREE)
+
+        assert config1 == config2
+
+    def test_cache_ttl_is_5_minutes(self):
+        """Cache TTL constant is 300 seconds (5 minutes)."""
+        assert _CACHE_TTL == 300
+
+    def test_different_tiers_cached_separately(self, service, mock_client):
+        """Different tier lookups each hit DynamoDB once."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+        service.get_tier_config(UserTier.SUBSCRIBER)
+
+        assert mock_client.get_item.call_count == 2
+
+    def test_cache_expired_refetches(self, service, mock_client):
+        """After cache TTL expires, DynamoDB is called again."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+
+        # Expire the cache by manipulating the cached timestamp
+        for tier_str in service._cache:
+            config, _ = service._cache[tier_str]
+            service._cache[tier_str] = (config, time.time() - _CACHE_TTL - 1)
+
+        service.get_tier_config(UserTier.FREE)
+
+        assert mock_client.get_item.call_count == 2
+
+    def test_invalidate_cache_clears_specific_tier(self, service, mock_client):
+        """invalidate_cache(tier) clears only that tier."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+        service.get_tier_config(UserTier.SUBSCRIBER)
+
+        service.invalidate_cache(UserTier.FREE)
+
+        service.get_tier_config(UserTier.FREE)
+        service.get_tier_config(UserTier.SUBSCRIBER)
+
+        # FREE re-fetched (2 calls), SUBSCRIBER cached (1 call) = 3 total
+        assert mock_client.get_item.call_count == 3
+
+    def test_invalidate_cache_all(self, service, mock_client):
+        """invalidate_cache() clears all tiers."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+        service.get_tier_config(UserTier.SUBSCRIBER)
+        service.invalidate_cache()
+        service.get_tier_config(UserTier.FREE)
+        service.get_tier_config(UserTier.SUBSCRIBER)
+
+        assert mock_client.get_item.call_count == 4
+
+
+# --------------------------------------------------------------------------- #
+# T150: Config loaded from DynamoDB
+# --------------------------------------------------------------------------- #
+
+
+class TestLoadFromDynamoDB:
+    """T150: Config loaded from DynamoDB overrides defaults."""
+
+    def test_dynamo_config_overrides_defaults(self, service, mock_client):
+        """Config from DynamoDB takes precedence over hardcoded defaults."""
+        mock_client.get_item.return_value = {
+            "Item": {
+                "PK": {"S": "CONFIG"},
+                "SK": {"S": "TIER#free"},
+                "hourly_cap": {"N": "10"},
+                "daily_cap": {"N": "50"},
+                "monthly_cap": {"N": "500"},
+            }
+        }
+
+        config = service.get_tier_config(UserTier.FREE)
+
+        assert config["hourly_cap"] == 10
+        assert config["daily_cap"] == 50
+        assert config["monthly_cap"] == 500
+
+    def test_dynamo_queries_correct_key(self, service, mock_client):
+        """DynamoDB query uses PK=CONFIG, SK=TIER#{tier}."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+
+        call_kwargs = mock_client.get_item.call_args[1]
+        assert call_kwargs["Key"]["PK"]["S"] == "CONFIG"
+        assert call_kwargs["Key"]["SK"]["S"] == "TIER#free"
+
+    def test_dynamo_error_falls_back_to_defaults(self, service, mock_client):
+        """DynamoDB error → falls back to hardcoded defaults."""
+        mock_client.get_item.side_effect = _client_error("InternalServerError")
+
+        config = service.get_tier_config(UserTier.FREE)
+
+        # Should still return valid config (defaults)
+        assert config["hourly_cap"] == 5
+        assert config["daily_cap"] == 15
+        assert config["monthly_cap"] == 100
+
+
+# --------------------------------------------------------------------------- #
+# T170: Tier config values match stored values
+# --------------------------------------------------------------------------- #
+
+
+class TestTierConfigValues:
+    """T170: Stored config values are returned accurately."""
+
+    def test_subscriber_config_from_dynamo(self, service, mock_client):
+        """Subscriber config read from DynamoDB matches stored values."""
+        mock_client.get_item.return_value = {
+            "Item": {
+                "PK": {"S": "CONFIG"},
+                "SK": {"S": "TIER#subscriber"},
+                "hourly_cap": {"N": "25"},
+                "daily_cap": {"N": "250"},
+                "monthly_cap": {"N": "2500"},
+            }
+        }
+
+        config = service.get_tier_config(UserTier.SUBSCRIBER)
+
+        assert config["tier"] == "subscriber"
+        assert config["hourly_cap"] == 25
+        assert config["daily_cap"] == 250
+        assert config["monthly_cap"] == 2500
+
+
+# --------------------------------------------------------------------------- #
+# set_tier_config
+# --------------------------------------------------------------------------- #
+
+
+class TestSetTierConfig:
+    """Writing tier config to DynamoDB."""
+
+    def test_set_config_writes_to_dynamo(self, service, mock_client):
+        """set_tier_config calls put_item on DynamoDB."""
+        result = service.set_tier_config(UserTier.FREE, 10, 50, 500)
+
+        assert result is True
+        mock_client.put_item.assert_called_once()
+
+    def test_set_config_writes_correct_values(self, service, mock_client):
+        """Written values match the provided caps."""
+        service.set_tier_config(UserTier.FREE, 10, 50, 500)
+
+        call_kwargs = mock_client.put_item.call_args[1]
+        item = call_kwargs["Item"]
+        assert item["PK"]["S"] == "CONFIG"
+        assert item["SK"]["S"] == "TIER#free"
+        assert item["hourly_cap"]["N"] == "10"
+        assert item["daily_cap"]["N"] == "50"
+        assert item["monthly_cap"]["N"] == "500"
+
+    def test_set_config_invalidates_cache(self, service, mock_client):
+        """After set_tier_config, cache for that tier is cleared."""
+        mock_client.get_item.return_value = {}
+
+        service.get_tier_config(UserTier.FREE)
+        service.set_tier_config(UserTier.FREE, 10, 50, 500)
+
+        assert "free" not in service._cache
+
+    def test_set_config_dynamo_error_raises(self, service, mock_client):
+        """DynamoDB error propagates from set_tier_config."""
+        mock_client.put_item.side_effect = _client_error("AccessDeniedException")
+
+        with pytest.raises(ClientError):
+            service.set_tier_config(UserTier.FREE, 10, 50, 500)
+
+    def test_accepts_string_tier(self, service, mock_client):
+        """set_tier_config accepts plain string tier."""
+        result = service.set_tier_config("subscriber", 20, 200, 2000)
+
+        assert result is True
+        call_kwargs = mock_client.put_item.call_args[1]
+        assert call_kwargs["Item"]["SK"]["S"] == "TIER#subscriber"
+
+
+# --------------------------------------------------------------------------- #
+# T180: Admin tier
+# --------------------------------------------------------------------------- #
+
+
+class TestAdminTier:
+    """T180: Admin tier has correct default caps."""
+
+    def test_admin_defaults_in_module(self):
+        """Module-level default for admin is 50/500/10000."""
+        admin_config = _DEFAULT_CONFIGS[UserTier.ADMIN]
+        assert admin_config["hourly_cap"] == 50
+        assert admin_config["daily_cap"] == 500
+        assert admin_config["monthly_cap"] == 10000


### PR DESCRIPTION
## Summary

- Add per-request rate limiting with three time windows (hourly/daily/monthly) and three user tiers (free/subscriber/admin)
- Uses DynamoDB `transact_write_items` for atomic 3-counter increments in `require_auth` middleware
- Hybrid fail mode: free tier fail-closed (503), subscriber/admin fail-open on DynamoDB errors
- Tier and billing_anchor_day embedded in JWT at token exchange

## Files Changed (16 files, +2405 lines)

**New:** `src/auth/models/` (rate_limit.py, user.py), `src/auth/tier_config_service.py`, 3 test files, fixture, 2 reports
**Modified:** `token_cap_service.py` (+MultiWindowCounter), `auth_middleware.py` (+rate limiting), `jwt_service.py` (+tier claims), `lambda_auth_function.py` (+get_user_tier), `__init__.py`

## Test Results

- **96 new tests** (47 MultiWindowCounter, 21 TierConfigService, 20 middleware, 8 JWT)
- **Full regression: 834 passed, 2 skipped, 0 failures**
- All 20 LLD test scenarios (T010-T220) covered

## Test plan

- [x] `poetry run pytest tests/unit/test_multi_window_counter.py -v` — 47 passed
- [x] `poetry run pytest tests/unit/test_tier_config_service.py -v` — 21 passed
- [x] `poetry run pytest tests/unit/test_auth_middleware.py -v` — 80 passed (20 new)
- [x] `poetry run pytest tests/unit/test_jwt_service.py -v` — 47 passed (8 new)
- [x] Full regression: `poetry run pytest --tb=short -q` — 834 passed, 0 failures
- [ ] Deploy + API smoke test (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)