### PR TITLE
feat: infra batch — coupon TTL, Stripe layer, tier GSI, IAM fixes

### DIFF
--- a/docs/reports/378/implementation-report.md
+++ b/docs/reports/378/implementation-report.md
@@ -1,0 +1,19 @@
+# Implementation Report: #378 DynamoDB GSI on Tier for Users Table
+
+## Summary
+Added `tier-index` GSI to `aletheia-users` table and fixed IAM permissions for index queries.
+
+## Changes
+| File | Change |
+|------|--------|
+| `provision.sh` | Added tier-index GSI creation block (pattern from user_id-index) |
+| `provision.sh` | Added `/index/*` suffix to users table IAM resource ARN |
+| `provision.sh` | Updated summary to show `(tier-index GSI)` |
+
+## IAM Bug Fix
+Without the `/index/*` resource suffix on the users table ARN, any DynamoDB `Query` operation against the GSI would fail with `AccessDeniedException`. The agent state table already had this suffix; the users table was missing it.
+
+## Design Notes
+- `KEYS_ONLY` projection minimizes GSI storage cost
+- `PAY_PER_REQUEST` billing inherited from table
+- `metrics_handler.py` update deferred (Scan with 5-min cache is fine at current scale)

--- a/docs/reports/378/test-report.md
+++ b/docs/reports/378/test-report.md
@@ -1,0 +1,7 @@
+# Test Report: #378 DynamoDB GSI on Tier for Users Table
+
+## Verification
+- `bash -n provision.sh` — syntax check PASSED
+- Manual diff review — GSI block follows user_id-index pattern exactly
+- IAM resource ARN includes `/index/*` suffix
+- No unit tests required (infrastructure-only change)

--- a/docs/reports/381/implementation-report.md
+++ b/docs/reports/381/implementation-report.md
@@ -1,0 +1,15 @@
+# Implementation Report: #381 DynamoDB TTL on Coupon Expiry
+
+## Summary
+Added TTL enablement block for `aletheia-coupons` table in `provision.sh`, using the `expiry` attribute (unix timestamp already present on coupon items).
+
+## Changes
+| File | Change |
+|------|--------|
+| `provision.sh` | Added TTL block after coupons table creation (pattern from token-cap TTL) |
+| `provision.sh` | Updated summary output to show `(TTL enabled)` for coupons table |
+
+## Design Notes
+- Coupons with `expiry = 0` are unaffected (DynamoDB ignores epoch-0 TTL values)
+- Follows exact pattern of token-cap TTL block (lines 175-192 of original)
+- Idempotent: checks `TimeToLiveStatus` before enabling

--- a/docs/reports/381/test-report.md
+++ b/docs/reports/381/test-report.md
@@ -1,0 +1,6 @@
+# Test Report: #381 DynamoDB TTL on Coupon Expiry
+
+## Verification
+- `bash -n provision.sh` — syntax check PASSED
+- Manual diff review — TTL block follows token-cap pattern exactly
+- No unit tests required (infrastructure-only change)

--- a/docs/reports/383/implementation-report.md
+++ b/docs/reports/383/implementation-report.md
@@ -1,0 +1,16 @@
+# Implementation Report: #383 Lambda Layer Rebuild for Stripe SDK
+
+## Summary
+Added `stripe` to the Lambda dependency layer and fixed IAM permissions for Stripe secrets access.
+
+## Changes
+| File | Change |
+|------|--------|
+| `provision.sh` | Added `stripe` to pip install and layer description |
+| `provision.sh` | Added `STRIPE_SECRET_NAME`, `STRIPE_WEBHOOK_SECRET_NAME` variables |
+| `provision.sh` | Added `STRIPE_PRICE_ID` env var (defaults empty, set after #366) |
+| `provision.sh` | Added Stripe secret ARNs to Secrets Manager IAM permissions |
+| `provision.sh` | Added Stripe env vars to Auth Lambda create + update config |
+
+## IAM Bug Fix
+Without the Secrets Manager permissions for `aletheia/stripe-secret-key-test` and `aletheia/stripe-webhook-secret-test`, the Stripe endpoints would return 500 at runtime when `stripe_handler.py` calls `get_secret_value()`.

--- a/docs/reports/383/test-report.md
+++ b/docs/reports/383/test-report.md
@@ -1,0 +1,6 @@
+# Test Report: #383 Lambda Layer Rebuild for Stripe SDK
+
+## Verification
+- `bash -n provision.sh` — syntax check PASSED
+- Manual diff review — pip install, layer description, IAM, env vars all correct
+- No unit tests required (infrastructure-only change)

--- a/provision.sh
+++ b/provision.sh
@@ -30,6 +30,9 @@ FUNC_NAME="${APP_NAME}Agent"
 AUTH_FUNC_NAME="${APP_NAME}Auth"
 LINKEDIN_SECRET_NAME="aletheia/linkedin-oauth"
 JWT_SECRET_NAME="aletheia/jwt-signing-key"
+STRIPE_SECRET_NAME="aletheia/stripe-secret-key-test"
+STRIPE_WEBHOOK_SECRET_NAME="aletheia/stripe-webhook-secret-test"
+STRIPE_PRICE_ID="${STRIPE_PRICE_ID:-}"  # Set after Stripe price creation (#366)
 LAYER_NAME="${APP_NAME}Dependencies"
 
 # Issue #351: Read CloudFlare origin secret from SSM Parameter Store (never in git)
@@ -153,6 +156,34 @@ else
     echo "Users table already exists: $USERS_TABLE"
 fi
 
+# Issue #378: Add GSI on tier for admin metrics queries
+echo "Checking GSI on tier..."
+TIER_GSI_EXISTS=$(aws dynamodb describe-table \
+    --table-name "$USERS_TABLE" \
+    --region "$REGION" \
+    --query "Table.GlobalSecondaryIndexes[?IndexName=='tier-index'].IndexName" \
+    --output text 2>/dev/null || echo "")
+
+if [ -z "$TIER_GSI_EXISTS" ]; then
+    echo "Creating GSI on tier for admin metrics queries..."
+    aws dynamodb update-table \
+        --table-name "$USERS_TABLE" \
+        --region "$REGION" \
+        --attribute-definitions AttributeName=tier,AttributeType=S \
+        --global-secondary-index-updates '[{
+            "Create": {
+                "IndexName": "tier-index",
+                "KeySchema": [{"AttributeName": "tier", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "KEYS_ONLY"}
+            }
+        }]'
+    echo "Waiting for GSI to become active..."
+    aws dynamodb wait table-exists --table-name "$USERS_TABLE" --region "$REGION"
+    echo -e "${GREEN}GSI tier-index created${NC}"
+else
+    echo "GSI tier-index already exists"
+fi
+
 # =============================================================================
 # Step 3: DynamoDB Token Cap Table (Issue #341: JWT Auth + Daily Cap)
 # =============================================================================
@@ -210,6 +241,25 @@ else
     echo "Coupons table already exists: $COUPONS_TABLE"
 fi
 
+# Issue #381: Enable TTL for coupon auto-expiry
+echo "Checking Coupons TTL..."
+COUPONS_TTL=$(aws dynamodb describe-time-to-live \
+    --table-name "$COUPONS_TABLE" \
+    --region "$REGION" \
+    --query 'TimeToLiveDescription.TimeToLiveStatus' \
+    --output text 2>/dev/null || echo "DISABLED")
+
+if [ "$COUPONS_TTL" != "ENABLED" ]; then
+    echo "Enabling TTL on $COUPONS_TABLE..."
+    aws dynamodb update-time-to-live \
+        --table-name "$COUPONS_TABLE" \
+        --region "$REGION" \
+        --time-to-live-specification "Enabled=true,AttributeName=expiry"
+    echo -e "${GREEN}TTL enabled on coupons table${NC}"
+else
+    echo "TTL already enabled on coupons table"
+fi
+
 # =============================================================================
 # Step 4: IAM Role with All Required Permissions
 # =============================================================================
@@ -259,6 +309,7 @@ aws iam put-role-policy \
                 "arn:aws:dynamodb:*:*:table/'"$TABLE_NAME"'",
                 "arn:aws:dynamodb:*:*:table/'"$TABLE_NAME"'/index/*",
                 "arn:aws:dynamodb:*:*:table/'"$USERS_TABLE"'",
+                "arn:aws:dynamodb:*:*:table/'"$USERS_TABLE"'/index/*",
                 "arn:aws:dynamodb:*:*:table/'"$TOKEN_CAP_TABLE"'",
                 "arn:aws:dynamodb:*:*:table/'"$COUPONS_TABLE"'"
             ]
@@ -278,7 +329,9 @@ aws iam put-role-policy \
             ],
             "Resource": [
                 "arn:aws:secretsmanager:'"$REGION"':'"$ACCOUNT_ID"':secret:'"$LINKEDIN_SECRET_NAME"'*",
-                "arn:aws:secretsmanager:'"$REGION"':'"$ACCOUNT_ID"':secret:'"$JWT_SECRET_NAME"'*"
+                "arn:aws:secretsmanager:'"$REGION"':'"$ACCOUNT_ID"':secret:'"$JWT_SECRET_NAME"'*",
+                "arn:aws:secretsmanager:'"$REGION"':'"$ACCOUNT_ID"':secret:'"$STRIPE_SECRET_NAME"'*",
+                "arn:aws:secretsmanager:'"$REGION"':'"$ACCOUNT_ID"':secret:'"$STRIPE_WEBHOOK_SECRET_NAME"'*"
             ]
         },
         {
@@ -327,8 +380,8 @@ mkdir -p build/python
 # Install ONLY the required runtime dependencies (cherry-pick, not full poetry export)
 # Issue #7: aws-xray-sdk for observability tracing
 # Issue #341: PyJWT for JWT authentication
-echo "Installing runtime dependencies: requests, python-jose, aws-xray-sdk, PyJWT..."
-pip install requests python-jose aws-xray-sdk PyJWT -t build/python --no-cache-dir --quiet
+echo "Installing runtime dependencies: requests, python-jose, aws-xray-sdk, PyJWT, stripe..."
+pip install requests python-jose aws-xray-sdk PyJWT stripe -t build/python --no-cache-dir --quiet
 
 # Remove unnecessary files to reduce layer size
 echo "Cleaning up unnecessary files..."
@@ -350,7 +403,7 @@ echo "Layer size: $LAYER_SIZE"
 echo "Publishing Lambda Layer: $LAYER_NAME..."
 LAYER_VERSION_ARN=$(aws lambda publish-layer-version \
     --layer-name "$LAYER_NAME" \
-    --description "Runtime dependencies for Aletheia Lambdas (requests, python-jose, aws-xray-sdk, PyJWT)" \
+    --description "Runtime dependencies for Aletheia Lambdas (requests, python-jose, aws-xray-sdk, PyJWT, stripe)" \
     --zip-file fileb://dependencies.zip \
     --compatible-runtimes python3.12 python3.11 python3.10 \
     --compatible-architectures x86_64 \
@@ -436,7 +489,7 @@ if ! aws lambda get-function --function-name "$AUTH_FUNC_NAME" --region "$REGION
         --timeout 30 \
         --memory-size 256 \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE}" \
+        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE,STRIPE_SECRET_NAME=$STRIPE_SECRET_NAME,STRIPE_WEBHOOK_SECRET_NAME=$STRIPE_WEBHOOK_SECRET_NAME,STRIPE_PRICE_ID=$STRIPE_PRICE_ID}" \
         --tracing-config Mode=Active \
         --region "$REGION"
     echo -e "${GREEN}Created Auth Lambda (X-Ray enabled)${NC}"
@@ -454,7 +507,7 @@ else
         --function-name "$AUTH_FUNC_NAME" \
         --handler src.lambda_auth_function.lambda_handler \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE}" \
+        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE,STRIPE_SECRET_NAME=$STRIPE_SECRET_NAME,STRIPE_WEBHOOK_SECRET_NAME=$STRIPE_WEBHOOK_SECRET_NAME,STRIPE_PRICE_ID=$STRIPE_PRICE_ID}" \
         --tracing-config Mode=Active \
         --region "$REGION" >/dev/null
 
@@ -627,9 +680,9 @@ echo ""
 echo "Resources:"
 echo "  DynamoDB Tables:"
 echo "    - $TABLE_NAME (TTL enabled)"
-echo "    - $USERS_TABLE"
+echo "    - $USERS_TABLE (tier-index GSI)"
 echo "    - $TOKEN_CAP_TABLE (TTL enabled)"
-echo "    - $COUPONS_TABLE"
+echo "    - $COUPONS_TABLE (TTL enabled)"
 echo "  IAM Role: $ROLE_NAME"
 echo "  Lambda Layer: $LAYER_NAME"
 echo ""


### PR DESCRIPTION
## Summary
- **#381**: Enable DynamoDB TTL on `aletheia-coupons` table using the `expiry` attribute for automatic coupon cleanup
- **#383**: Add `stripe` SDK to Lambda dependency layer, add Stripe secrets to IAM permissions, add Stripe env vars (`STRIPE_SECRET_NAME`, `STRIPE_WEBHOOK_SECRET_NAME`, `STRIPE_PRICE_ID`) to Auth Lambda
- **#378**: Add `tier-index` GSI on `aletheia-users` table for admin metrics queries, fix missing `/index/*` IAM resource suffix

## IAM Bug Fixes
- Users table was missing `/index/*` resource suffix — any GSI Query would get `AccessDeniedException`
- Stripe secrets were not in Secrets Manager IAM permissions — Stripe endpoints would return 500 at runtime

## Test plan
- [x] `bash -n provision.sh` — syntax check passed
- [x] Diff review of all changes (TTL, GSI, IAM, layer, env vars)
- [ ] Deploy with `bash provision.sh` to verify end-to-end

Closes #381, closes #383, closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)