### PR TITLE
feat: add admin ID resolution CLI

### DIFF
--- a/docs/reports/376/implementation-report.md
+++ b/docs/reports/376/implementation-report.md
@@ -1,0 +1,22 @@
+# Implementation Report: #376 Admin ID Resolution CLI
+
+## Summary
+New CLI tool for mapping between real user IDs and their anonymized hashes from the CloudWatch Usage Dashboard (#369).
+
+## Files
+| File | Purpose |
+|------|---------|
+| `tools/admin_id_resolve.py` | CLI with `forward` and `reverse` subcommands |
+| `tests/unit/test_admin_id_resolve.py` | 8 unit tests with mocked DynamoDB |
+
+## Design
+- **Forward resolve**: Calls `anonymize_user_id()` to hash a known user_id
+- **Reverse resolve**: Brute-force scans users table, hashes each user_id, matches against target
+- **PII guard**: Reverse lookup requires `--confirm` flag (dry_run default)
+- **Pattern**: Follows `admin_subscriptions.py` (argparse, lazy DynamoDB client, env-var config)
+
+## Usage
+```bash
+poetry run python tools/admin_id_resolve.py forward USER_ID
+poetry run python tools/admin_id_resolve.py reverse HASH --confirm
+```

--- a/docs/reports/376/test-report.md
+++ b/docs/reports/376/test-report.md
@@ -1,0 +1,21 @@
+# Test Report: #376 Admin ID Resolution CLI
+
+## Results
+```
+8 passed in 0.36s
+975 passed, 2 skipped (full regression)
+mypy: Success, no issues found
+ruff: All checks passed
+```
+
+## Test Coverage
+| Test | What it verifies |
+|------|-----------------|
+| `test_returns_user_id_and_hash` | Forward resolve returns correct hash |
+| `test_hash_is_12_chars` | Hash length is 12 characters |
+| `test_deterministic` | Same input = same output |
+| `test_dry_run_refuses_without_confirm` | PII guard blocks without --confirm |
+| `test_finds_matching_user` | Reverse resolve finds correct user (mocked DynamoDB) |
+| `test_not_found` | Returns not_found when no match |
+| `test_empty_table` | Handles empty users table gracefully |
+| `test_dynamo_error` | Returns error status on DynamoDB failure |

--- a/tests/unit/test_admin_id_resolve.py
+++ b/tests/unit/test_admin_id_resolve.py
@@ -1,0 +1,122 @@
+"""Tests for admin ID resolution CLI.
+
+Issue #376: Admin ID Resolution CLI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+from src.auth.anonymize import anonymize_user_id
+from tools.admin_id_resolve import forward_resolve, reverse_resolve
+
+
+class TestForwardResolve:
+    """Forward resolution: user_id -> anonymized hash."""
+
+    def test_returns_user_id_and_hash(self):
+        """Forward resolve returns both the input and its hash."""
+        result = forward_resolve("user123")
+        assert result["user_id"] == "user123"
+        assert result["anonymized_hash"] == anonymize_user_id("user123")
+
+    def test_hash_is_12_chars(self):
+        """Hash output is 12 characters."""
+        result = forward_resolve("test@example.com")
+        assert len(result["anonymized_hash"]) == 12
+
+    def test_deterministic(self):
+        """Same input always produces same output."""
+        r1 = forward_resolve("user_abc")
+        r2 = forward_resolve("user_abc")
+        assert r1 == r2
+
+
+class TestReverseResolve:
+    """Reverse resolution: anonymized hash -> user_id (with PII guard)."""
+
+    def test_dry_run_refuses_without_confirm(self):
+        """Without --confirm, reverse lookup returns dry_run status."""
+        result = reverse_resolve("abcdef123456", dry_run=True)
+        assert result["status"] == "dry_run"
+        assert "PII" in result["message"]
+
+    @patch("tools.admin_id_resolve.get_dynamodb_client")
+    def test_finds_matching_user(self, mock_get_client):
+        """Reverse resolve finds the user whose hash matches."""
+        target_user = "linkedin|abc123"
+        target_hash = anonymize_user_id(target_user)
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Items": [
+                    {"user_id": {"S": "other_user"}},
+                    {"user_id": {"S": target_user}},
+                    {"user_id": {"S": "another_user"}},
+                ]
+            }
+        ]
+
+        result = reverse_resolve(target_hash, dry_run=False)
+        assert result["status"] == "found"
+        assert result["user_id"] == target_user
+        assert result["anonymized_hash"] == target_hash
+        assert result["users_scanned"] == 2
+
+    @patch("tools.admin_id_resolve.get_dynamodb_client")
+    def test_not_found(self, mock_get_client):
+        """Reverse resolve returns not_found when no user matches."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Items": [
+                    {"user_id": {"S": "user_a"}},
+                    {"user_id": {"S": "user_b"}},
+                ]
+            }
+        ]
+
+        result = reverse_resolve("000000000000", dry_run=False)
+        assert result["status"] == "not_found"
+        assert result["users_scanned"] == 2
+
+    @patch("tools.admin_id_resolve.get_dynamodb_client")
+    def test_empty_table(self, mock_get_client):
+        """Reverse resolve handles empty users table."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{"Items": []}]
+
+        result = reverse_resolve("abcdef123456", dry_run=False)
+        assert result["status"] == "not_found"
+        assert result["users_scanned"] == 0
+
+    @patch("tools.admin_id_resolve.get_dynamodb_client")
+    def test_dynamo_error(self, mock_get_client):
+        """Reverse resolve returns error on DynamoDB failure."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+            "Scan",
+        )
+
+        result = reverse_resolve("abcdef123456", dry_run=False)
+        assert result["status"] == "error"

--- a/tools/admin_id_resolve.py
+++ b/tools/admin_id_resolve.py
@@ -1,0 +1,144 @@
+"""Admin CLI for resolving anonymized user IDs.
+
+Issue #376: Admin ID Resolution CLI.
+
+The CloudWatch Usage Dashboard (#369) logs anonymized user hashes for privacy.
+This tool lets admins map between real user IDs and their anonymized hashes.
+
+Usage:
+    poetry run python tools/admin_id_resolve.py forward USER_ID
+    poetry run python tools/admin_id_resolve.py reverse HASH --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import boto3
+from botocore.exceptions import ClientError
+
+from src.auth.anonymize import anonymize_user_id
+
+USERS_TABLE = os.environ.get("USERS_TABLE", "aletheia-users")
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+
+def get_dynamodb_client():
+    """Get DynamoDB client."""
+    endpoint = os.environ.get("DYNAMODB_ENDPOINT")
+    if endpoint:
+        return boto3.client("dynamodb", endpoint_url=endpoint, region_name=AWS_REGION)
+    return boto3.client("dynamodb", region_name=AWS_REGION)
+
+
+def forward_resolve(user_id: str) -> dict:
+    """Hash a known user_id to its anonymized form.
+
+    Args:
+        user_id: The raw user ID (e.g., LinkedIn sub claim).
+
+    Returns:
+        Dict with user_id and its anonymized hash.
+    """
+    return {
+        "user_id": user_id,
+        "anonymized_hash": anonymize_user_id(user_id),
+    }
+
+
+def reverse_resolve(target_hash: str, dry_run: bool = True) -> dict:
+    """Scan users table and find which user_id maps to a given hash.
+
+    This is a brute-force scan that hashes every user_id in the table
+    and compares against the target. Requires --confirm flag because
+    it reveals PII (the real user_id behind an anonymized hash).
+
+    Args:
+        target_hash: The 12-character anonymized hash to resolve.
+        dry_run: If True, refuse to reveal PII (require --confirm).
+
+    Returns:
+        Dict with match result or dry_run notice.
+    """
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "message": "Reverse lookup reveals PII. Use --confirm to proceed.",
+            "target_hash": target_hash,
+        }
+
+    client = get_dynamodb_client()
+
+    try:
+        paginator = client.get_paginator("scan")
+        page_iterator = paginator.paginate(
+            TableName=USERS_TABLE,
+            ProjectionExpression="user_id",
+        )
+
+        scanned = 0
+        for page in page_iterator:
+            for item in page.get("Items", []):
+                uid = item.get("user_id", {}).get("S", "")
+                scanned += 1
+                if anonymize_user_id(uid) == target_hash:
+                    return {
+                        "status": "found",
+                        "user_id": uid,
+                        "anonymized_hash": target_hash,
+                        "users_scanned": scanned,
+                    }
+
+        return {
+            "status": "not_found",
+            "target_hash": target_hash,
+            "users_scanned": scanned,
+        }
+
+    except ClientError as e:
+        return {"status": "error", "message": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aletheia Admin ID Resolution CLI"
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Forward resolve
+    fwd = subparsers.add_parser(
+        "forward", help="Hash a user_id to its anonymized form"
+    )
+    fwd.add_argument("user_id", help="The raw user ID to hash")
+
+    # Reverse resolve
+    rev = subparsers.add_parser(
+        "reverse", help="Find which user_id maps to an anonymized hash"
+    )
+    rev.add_argument("hash", help="The 12-character anonymized hash to resolve")
+    rev.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Confirm PII reveal (required for reverse lookup)",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "forward":
+        result = forward_resolve(args.user_id)
+        print(json.dumps(result, indent=2))
+
+    elif args.command == "reverse":
+        result = reverse_resolve(args.hash, dry_run=not args.confirm)
+        print(json.dumps(result, indent=2))
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New CLI tool `tools/admin_id_resolve.py` for mapping between real user IDs and anonymized hashes from the CloudWatch Usage Dashboard (#369)
- **Forward resolve**: `poetry run python tools/admin_id_resolve.py forward USER_ID` — hashes a known user_id
- **Reverse resolve**: `poetry run python tools/admin_id_resolve.py reverse HASH --confirm` — brute-force scans users table, requires `--confirm` for PII reveal

## Test plan
- [x] 8 unit tests passing (mocked DynamoDB)
- [x] 975 passed full regression suite
- [x] mypy: no issues
- [x] ruff: all checks passed

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)