### PR TITLE
feat: web presence updates — README rewrite, wiki overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,137 @@
 # Aletheia: AI-Powered Context Analysis Engine
 
-# Add after the first heading in README.md
-# You'll need to enable Codecov integration at codecov.io first
-
-BADGES='
 ![CI](https://github.com/martymcenroe/Aletheia/actions/workflows/ci.yml/badge.svg)
-[![codecov](https://codecov.io/gh/martymcenroe/Aletheia/branch/main/graph/badge.svg)](https://codecov.io/gh/martymcenroe/Aletheia)
 ![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-'
-echo "$BADGES"
 
-**Aletheia** (Greek for *Truth/Unconcealment*) is a serverless, event-driven architecture that bridges the gap between static content and semantic understanding. It allows users to extract context-aware insights from any webpage using a custom Chrome Extension and an Agentic AI backend.
+**Aletheia** (Greek: *truth, unconcealment*) is a privacy-first browser extension that helps users understand the historical context and etymology of words and phrases. Select text on any webpage, right-click "Explain with AI", and get an etymology-rich analysis powered by a serverless AI backend.
 
-### 🏆 Engineering Highlights
-* **Serverless Architecture:** Built on **AWS Lambda** and **DynamoDB** with "Scale-to-Zero" economics.
-* **AI Agent Orchestration:** Implements **LangGraph** for stateful, multi-turn reasoning (not just stateless API calls).
-* **Infrastructure as Code:** "Bare metal" provisioning scripts (Bash/AWS CLI) demonstrating deep understanding of cloud primitives without abstraction layers.
-* **Event-Driven Harvesting:** Custom-built data pipeline to harvest, sanitize, and checkpoint training data from live browsing sessions.
-* **Security First:** Strict IAM scoping and manifest permission gating.
-
-### 🛠 Tech Stack
-* **Language:** Python 3.12 (Backend), JavaScript (Frontend)
-* **Cloud:** AWS (Lambda, DynamoDB, S3, IAM)
-* **AI/ML:** LangChain, LangGraph, OpenAI/Bedrock
-* **Tooling:** Poetry, GitHub Actions, Custom Bash Automation
-
-### 🚀 Quick Start (Development)
-1.  **Clone:** `git clone ...`
-2.  **Provision:** `./provision.sh` (Sets up AWS resources)
-3.  **Deploy:** `./deploy.sh` (Builds & pushes Lambda artifact)
-4.  **Install:** Load `extension/` directory into Chrome Developer Mode.
+**[aletheia.study](https://aletheia.study)** | **[Wiki](https://github.com/martymcenroe/Aletheia/wiki)** | **[Privacy Policy](https://github.com/martymcenroe/Aletheia/wiki/Privacy)**
 
 ---
-*Created by [Marty McEnroe]. This project demonstrates strict engineering hygiene, architectural documentation, and the "AI-as-Workforce" development paradigm.*
+
+## Features
+
+- **Etymology Analysis** — Understand the origins and evolution of words and phrases
+- **Context-Aware** — Considers surrounding text for disambiguation
+- **Privacy-First** — Minimal permissions, anonymized logging, no browsing history access
+- **Multi-Browser** — Chrome (Manifest V3) and Firefox (Manifest V2)
+- **Tiered Subscriptions** — Free tier with generous limits, premium tier for heavy users
+- **JWT Authentication** — LinkedIn OAuth sign-in with local token validation (<1ms)
+- **Rate Limiting** — Per-user multi-window caps (hourly/daily/monthly) with DynamoDB atomic counters
+
+## Architecture
+
+```
+Browser Extension → CloudFlare Worker → Lambda Function URL → Lambda (Python 3.12)
+                                              ↓
+                                     AWS Bedrock (Claude) + DynamoDB
+```
+
+| Layer | Technology |
+|-------|------------|
+| **Frontend** | Browser extension (JavaScript, Manifest V3) |
+| **Edge** | CloudFlare Workers (rate limiting, DDoS, shared secret) |
+| **Compute** | AWS Lambda (Python 3.12) — Agent + Auth |
+| **AI** | AWS Bedrock (Anthropic Claude) |
+| **State** | DynamoDB (agent state, users, token cap, coupons) |
+| **Auth** | LinkedIn OAuth → JWT (HS256) → Secrets Manager |
+| **Billing** | Stripe (subscriptions, webhooks, checkout) |
+| **Observability** | CloudWatch (EMF metrics, X-Ray tracing, 14-day retention) |
+
+## Tech Stack
+
+| Category | Tools |
+|----------|-------|
+| **Language** | Python 3.12 (backend), JavaScript (extension) |
+| **Cloud** | AWS Lambda, DynamoDB, Secrets Manager, CloudWatch, Bedrock |
+| **Edge** | CloudFlare Workers, CloudFlare DNS |
+| **Auth** | LinkedIn OAuth, JWT (PyJWT), dual-secret rotation |
+| **Billing** | Stripe SDK (subscriptions, webhooks, checkout sessions) |
+| **AI** | LangGraph (agent orchestration), AWS Bedrock (Anthropic Claude) |
+| **Testing** | pytest (975+ tests), mypy, ruff, gitleaks |
+| **CI/CD** | GitHub Actions, pre-commit hooks (12 checks) |
+| **IaC** | Bash/AWS CLI provisioning (`provision.sh`) |
+
+## Quick Start (Development)
+
+```bash
+# Clone
+git clone https://github.com/martymcenroe/Aletheia.git
+cd Aletheia
+
+# Install dependencies
+poetry install
+
+# Run tests
+poetry run pytest tests/ --ignore=tests/integration -q
+
+# Provision AWS infrastructure (requires configured AWS CLI)
+./provision.sh
+
+# Load extension in Chrome
+# 1. Navigate to chrome://extensions/
+# 2. Enable Developer mode
+# 3. Click "Load unpacked" → select extensions/chrome/
+```
+
+## Project Structure
+
+```
+Aletheia/
+├── extensions/chrome/       # Chrome Manifest V3 extension
+├── extensions/firefox/      # Firefox Manifest V2 extension
+├── src/                     # Python backend
+│   ├── auth/                # JWT, middleware, OAuth, rate limiting, Stripe
+│   ├── guardrails/          # Content safety filtering
+│   ├── signal_inspector/    # Signal analysis logic
+│   └── lambda_function.py   # Agent Lambda handler
+├── tests/                   # 975+ unit tests
+├── tools/                   # Admin CLIs (subscriptions, coupons, token cap, ID resolve)
+├── docs/                    # ADRs, LLDs, audits, runbooks, reports
+└── provision.sh             # AWS infrastructure provisioning
+```
+
+## Admin Tools
+
+```bash
+# Subscription management
+poetry run python tools/admin_subscriptions.py view --user-id USER_ID
+
+# Coupon management
+poetry run python tools/admin_coupons.py create --tier premium --duration 30
+
+# Token cap management
+poetry run python tools/admin_token_cap.py --new-cap 50 --admin-id admin@example.com
+
+# ID resolution (anonymized hash ↔ user ID)
+poetry run python tools/admin_id_resolve.py forward USER_ID
+poetry run python tools/admin_id_resolve.py reverse HASH --confirm
+```
+
+## Security
+
+- **Defense in depth**: CloudFlare DDoS → rate limiting → shared secret → JWT validation → input validation → AI guardrails
+- **Minimal permissions**: Extension requests only `contextMenus`, `activeTab`, `storage`
+- **Privacy-preserving logs**: User IDs anonymized via SHA-256 truncation before logging
+- **Secret management**: All secrets in AWS Secrets Manager, never in code or env vars
+- **Pre-commit hooks**: gitleaks, ruff, mypy, ESLint security rules
+
+See [Security Policy](https://github.com/martymcenroe/Aletheia/wiki/Security) and [16 ADRs](https://github.com/martymcenroe/Aletheia/tree/main/docs/adrs) documenting architectural decisions.
+
+## Documentation
+
+| Resource | Description |
+|----------|-------------|
+| [Wiki](https://github.com/martymcenroe/Aletheia/wiki) | User guide, architecture, API reference |
+| [ADRs](docs/adrs/) | 19 architecture decision records |
+| [Privacy Policy](https://github.com/martymcenroe/Aletheia/wiki/Privacy) | Data handling and retention |
+| [aletheia.study](https://aletheia.study) | Product landing page |
+
+## License
+
+[MIT](LICENSE)
+
+---
+
+*Built by [Marty McEnroe](https://github.com/martymcenroe) using the AI-as-Workforce development paradigm.*

--- a/docs/reports/371/implementation-report.md
+++ b/docs/reports/371/implementation-report.md
@@ -1,0 +1,39 @@
+# Implementation Report: #371 Web Presence Updates
+
+## Summary
+Full rewrite of README.md and 7 wiki pages, plus marketing copy and LinkedIn launch post in dispatch repo.
+
+## Changes
+
+### README.md (Full Rewrite)
+- Fixed broken badge syntax (was raw shell commands in markdown)
+- Updated tech stack: CloudFlare Workers (not CloudFront+WAF), Bedrock Claude (not OpenAI)
+- Added features: JWT auth, LinkedIn OAuth, Stripe billing, tiered rate limiting, admin tools
+- Fixed Quick Start paths: `extensions/chrome/` (was `extension/`)
+- Added architecture diagram, project structure, admin tools section, security highlights
+- Added links to aletheia.study, wiki, privacy policy
+
+### Wiki Pages Updated (7 of 13)
+| Page | Key Changes |
+|------|-------------|
+| `Home.md` | Tech stack (CloudFlare, Stripe, Bedrock Claude), features (auth, billing, rate limiting), milestones updated |
+| `Architecture.md` | New Mermaid diagram (CloudFlare Worker + Auth Lambda), 4 DynamoDB tables, ADR references 10217-10219, 7-layer security |
+| `API-Reference.md` | Base URL → api.aletheia.study, JWT auth docs, billing/admin/GDPR endpoints, per-tier rate limits |
+| `User-Guide.md` | Authentication section, subscription tiers, upgrade flow |
+| `Developer-Guide.md` | Repo structure (auth package, admin tools), workflow (worktrees, pre-merge gate), 12 pre-commit hooks |
+| `Getting-Started.md` | Sign-in step added, JWT troubleshooting |
+| `_Sidebar.md` | aletheia.study link added |
+
+### NOT Modified
+- `Privacy.md` — Chrome Web Store submission, frozen
+
+### Dispatch Repo (Marketing Copy)
+| File | Purpose |
+|------|---------|
+| `drafts/2026-02-19-aletheia-launch-linkedin.md` | LinkedIn launch post (short + long versions) |
+| `drafts/2026-02-19-aletheia-product-copy.md` | Core messaging, feature list, tier comparison, Chrome Web Store listing |
+
+## Constraints
+- Privacy.md preserved unchanged (Chrome Web Store requirement)
+- Wiki changes pushed directly (no PR process for wiki)
+- ADRs 10217-10219 referenced by Architecture page (must merge #370 first)

--- a/docs/reports/371/test-report.md
+++ b/docs/reports/371/test-report.md
@@ -1,0 +1,20 @@
+# Test Report: #371 Web Presence Updates
+
+## Verification
+- README.md badges render as proper markdown (not shell commands)
+- README.md links: aletheia.study, wiki, privacy policy, ADRs, LICENSE all correct
+- Wiki pages: no references to CloudFront or WAF remain in updated pages
+- Wiki Privacy.md: NOT modified (verified via git diff exclusion)
+- All wiki pages have updated timestamps (2026-02-19)
+- Dispatch drafts have valid YAML frontmatter
+- No unit tests required (documentation/content-only change)
+
+## Wiki Changes Verification
+- [x] Home.md — Tech stack shows CloudFlare, Bedrock Claude (not CloudFront, OpenAI)
+- [x] Architecture.md — Mermaid diagram shows CloudFlare Worker → Lambda Function URL
+- [x] API-Reference.md — Base URL is api.aletheia.study, JWT auth documented
+- [x] User-Guide.md — Authentication and subscription sections added
+- [x] Developer-Guide.md — Repo structure includes auth package
+- [x] Getting-Started.md — Sign-in step and JWT troubleshooting added
+- [x] _Sidebar.md — aletheia.study link present
+- [x] Privacy.md — Unchanged


### PR DESCRIPTION
## Summary
- **README.md**: Full rewrite — fixed broken badge syntax, replaced OpenAI with Bedrock Claude, replaced CloudFront+WAF with CloudFlare Workers, added all Feb 2026 features (JWT auth, LinkedIn OAuth, Stripe billing, tiered rate limiting, admin tools, 975+ tests)
- **Wiki** (7 pages updated via direct push): Home, Architecture, API Reference, User Guide, Developer Guide, Getting Started, Sidebar
- **Privacy.md**: NOT modified (Chrome Web Store submission — frozen)
- **Dispatch repo**: LinkedIn launch post draft + core product copy/messaging

## Key Changes
- Architecture diagram now shows CloudFlare Worker → Lambda Function URL (not CloudFront → WAF → Lambda)
- API Reference documents all endpoints: analysis, auth, billing, admin, GDPR
- User Guide adds authentication flow, subscription tiers, upgrade path
- Developer Guide reflects current repo structure (auth package, 12 pre-commit hooks, worktree workflow)

## Test plan
- [x] README badges render as markdown (not raw shell)
- [x] No CloudFront/WAF references in updated wiki pages
- [x] Privacy.md unchanged (verified)
- [x] Pre-commit hooks pass

**Note:** Merge #370 (PR #387) first — wiki Architecture page references ADRs 10217-10219 created there.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)