### PR TITLE
fix: feature-flag @require_auth to restore API (close #390)

### DIFF
--- a/docs/reports/390/implementation-report.md
+++ b/docs/reports/390/implementation-report.md
@@ -1,0 +1,30 @@
+# Implementation Report — Issue #390
+
+**Title:** fix: feature-flag @require_auth to restore API (401 regression)
+**Date:** 2026-02-19
+**Status:** Complete
+
+## Summary
+
+Added `AUTH_ENABLED` environment variable (default `false`) to control whether JWT authentication is required for HTTP requests. This restores API functionality while keeping auth code in place for future activation.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `src/lambda_function.py:652-662` | Conditional auth gate: checks `AUTH_ENABLED` env var before applying `@require_auth` |
+| `provision.sh:441` | Added `AUTH_ENABLED=false` to Lambda create env vars |
+| `provision.sh:460` | Added `AUTH_ENABLED=false` to Lambda update env vars |
+| `tests/unit/test_lambda_handler.py` | Added `TestAuthFeatureFlag` class with 3 tests |
+
+## Design Decisions
+
+- **Feature flag over removal:** Keeps auth code deployed and testable. Flip `AUTH_ENABLED=true` when auth infra (DynamoDB users table, auth Lambda) is deployed.
+- **Default false:** Fail-open for the auth gate since no client can provide JWTs yet.
+- **Env var naming:** `AUTH_ENABLED` is explicit and matches the pattern of other Lambda env vars.
+
+## Risk Assessment
+
+- **Low risk:** The change only affects the code path for HTTP requests with `requestContext`.
+- **Backward compatible:** Direct Lambda invocations (tests, SDK) are unaffected.
+- **Reversible:** Set `AUTH_ENABLED=true` to re-enable auth at any time.

--- a/docs/reports/390/test-report.md
+++ b/docs/reports/390/test-report.md
@@ -1,0 +1,30 @@
+# Test Report — Issue #390
+
+**Title:** fix: feature-flag @require_auth to restore API (401 regression)
+**Date:** 2026-02-19
+**Status:** All passing
+
+## Test Results
+
+```
+40 passed in 2.57s
+```
+
+## New Tests
+
+| Test | Description | Result |
+|------|-------------|--------|
+| `test_auth_disabled_bypasses_jwt` | HTTP request without JWT succeeds when AUTH_ENABLED=false | PASS |
+| `test_auth_enabled_requires_jwt` | HTTP request without JWT returns 401 when AUTH_ENABLED=true | PASS |
+| `test_direct_invocation_unaffected` | Direct invocation (no requestContext) works regardless of flag | PASS |
+
+## Existing Tests
+
+All 37 existing tests continue to pass. No regressions.
+
+## Coverage
+
+The three new tests cover:
+- The feature flag default (false) path
+- The feature flag enabled path (401 rejection)
+- The direct invocation path (flag irrelevant)

--- a/provision.sh
+++ b/provision.sh
@@ -438,7 +438,7 @@ if ! aws lambda get-function --function-name "$FUNC_NAME" --region "$REGION" >/d
         --timeout 60 \
         --memory-size 256 \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME}" \
+        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,AUTH_ENABLED=false}" \
         --tracing-config Mode=Active \
         --region "$REGION"
     echo -e "${GREEN}Created Agent Lambda (X-Ray enabled)${NC}"
@@ -457,7 +457,7 @@ else
         --function-name "$FUNC_NAME" \
         --handler src.lambda_function.lambda_handler \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME}" \
+        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,AUTH_ENABLED=false}" \
         --tracing-config Mode=Active \
         --region "$REGION" >/dev/null
 

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -649,14 +649,18 @@ def lambda_handler(
                 if not version.startswith("1."):
                     return {"statusCode": 403, "body": json.dumps({"error": "Missing or invalid client version"})}
 
-            # Issue #341: JWT authentication for HTTP requests
-            # Apply require_auth decorator logic inline for HTTP requests.
-            # The decorator wraps _analysis_handler, validating JWT and injecting auth_user_id.
-            @require_auth
-            def _authenticated_handler(auth_event: dict, auth_context: Any) -> dict:
-                return _analysis_handler(auth_event, auth_context, denylist)
+            # Issue #341/#390: JWT authentication for HTTP requests
+            # Feature-flagged: AUTH_ENABLED env var controls whether JWT is required.
+            # Default false — auth infra not yet deployed. Flip to true when ready.
+            auth_enabled = os.environ.get("AUTH_ENABLED", "false").lower() == "true"
+            if auth_enabled:
+                @require_auth
+                def _authenticated_handler(auth_event: dict, auth_context: Any) -> dict:
+                    return _analysis_handler(auth_event, auth_context, denylist)
 
-            return _authenticated_handler(event, context)
+                return _authenticated_handler(event, context)
+            else:
+                return _analysis_handler(event, context, denylist)
         else:
             # Direct Lambda invocation (tests, SDK calls) — no auth required
             return _analysis_handler(event, context, denylist)

--- a/tests/unit/test_lambda_handler.py
+++ b/tests/unit/test_lambda_handler.py
@@ -7,6 +7,7 @@ Tests use mocked AWS services and safe placeholder terms.
 No real slurs in test files (Willison Protocol).
 """
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 
@@ -499,3 +500,56 @@ class TestProcessScoresForDisplay:
         scores = {"Archaic": 0.05, "Provocative": 0.05, "None": 0.04}
         result = process_scores_for_display(scores)
         assert result == []
+
+
+class TestAuthFeatureFlag:
+    """Tests for Issue #390: AUTH_ENABLED feature flag.
+
+    The auth gate at lambda_handler:652 should be controlled by the
+    AUTH_ENABLED env var. When disabled (default), HTTP requests bypass
+    JWT authentication. When enabled, @require_auth is applied.
+    """
+
+    MOCK_HTTP_EVENT = {
+        "body": json.dumps({"text": "apple"}),
+        "headers": {
+            "x-aletheia-client-version": "1.0",
+        },
+        "requestContext": {
+            "http": {
+                "method": "POST",
+                "sourceIp": "10.0.0.1",
+                "path": "/",
+            }
+        },
+    }
+
+    def test_auth_disabled_bypasses_jwt(self):
+        """HTTP request without JWT succeeds when AUTH_ENABLED=false (default)."""
+        mock_response = {"statusCode": 200, "body": json.dumps({"status": "success"})}
+
+        with patch.dict(os.environ, {"AUTH_ENABLED": "false"}, clear=False), patch(
+            "src.lambda_function._analysis_handler", return_value=mock_response
+        ):
+            result = lambda_handler(self.MOCK_HTTP_EVENT, None, denylist=MOCK_DENYLIST)
+
+        assert result["statusCode"] == 200
+
+    def test_auth_enabled_requires_jwt(self):
+        """HTTP request without JWT returns 401 when AUTH_ENABLED=true."""
+        with patch.dict(os.environ, {"AUTH_ENABLED": "true"}, clear=False):
+            result = lambda_handler(self.MOCK_HTTP_EVENT, None, denylist=MOCK_DENYLIST)
+
+        assert result["statusCode"] == 401
+
+    def test_direct_invocation_unaffected(self):
+        """Direct Lambda invocation (no requestContext) works regardless of flag."""
+        event = {"text": "apple"}
+        mock_response = {"statusCode": 200, "body": json.dumps({"status": "success"})}
+
+        with patch.dict(os.environ, {"AUTH_ENABLED": "true"}, clear=False), patch(
+            "src.lambda_function._analysis_handler", return_value=mock_response
+        ):
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+        assert result["statusCode"] == 200


### PR DESCRIPTION
## Summary

- Add `AUTH_ENABLED` env var (default `false`) to conditionally apply `@require_auth` on HTTP requests
- Restores API functionality — the 401 regression (#389) is fixed
- Auth code remains deployed and ready to activate when infra is deployed

## Changes

| File | Change |
|------|--------|
| `src/lambda_function.py` | Conditional auth gate checks `AUTH_ENABLED` before applying `@require_auth` |
| `provision.sh` | Added `AUTH_ENABLED=false` to both create and update env var strings |
| `tests/unit/test_lambda_handler.py` | 3 new tests in `TestAuthFeatureFlag` class |

## Test plan

- [x] `test_auth_disabled_bypasses_jwt` — HTTP without JWT succeeds when flag off
- [x] `test_auth_enabled_requires_jwt` — HTTP without JWT returns 401 when flag on
- [x] `test_direct_invocation_unaffected` — Direct invocation works regardless
- [x] All 40 tests pass (37 existing + 3 new)
- [ ] Deploy via `provision.sh` and verify with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)