### PR TITLE
fix: narrow Hate definition to prevent political vocab false positives

### DIFF
--- a/src/guardrails/resources/taxonomy.json
+++ b/src/guardrails/resources/taxonomy.json
@@ -2,7 +2,7 @@
   "taxonomy": {
     "Archaic": "Words that dropped out of common usage BEFORE 1950 (e.g., 'thou', 'forsooth', 'betwixt', 'prithee'). NOT formal/academic words still used in quality journalism—those are safe.",
     "Provocative": "Sexual slang or double entendres (e.g., 'swiving', 'tupping').",
-    "Hate": "Slurs or discriminatory language, even in compounds.",
+    "Hate": "Slurs that dehumanise a person or group based on identity (race, ethnicity, gender, sexuality, religion, disability). Political or ideological labels (e.g., 'technofascist', 'autocrat', 'ethnonationalist') are NOT hate—they describe systems or ideas, not people's identity.",
     "Neologism": "Newly coined words from the last 2 years (e.g., 'skibidi', 'fanum tax').",
     "None": "Standard, safe language. Includes rare but currently-used formal/academic terms (e.g., 'immiserate', 'ameliorate', 'efficacious')."
   },
@@ -59,6 +59,16 @@
     },
     {
       "text": "Critics called him a misandrist for his views",
+      "scores": {"Archaic": 0.0, "Provocative": 0.0, "Hate": 0.0, "Neologism": 0.0, "None": 1.0},
+      "category": "None"
+    },
+    {
+      "text": "The article warns of a technofascist state",
+      "scores": {"Archaic": 0.0, "Provocative": 0.0, "Hate": 0.0, "Neologism": 0.0, "None": 1.0},
+      "category": "None"
+    },
+    {
+      "text": "Ethnonationalist movements are gaining traction in Europe",
       "scores": {"Archaic": 0.0, "Provocative": 0.0, "Hate": 0.0, "Neologism": 0.0, "None": 1.0},
       "category": "None"
     }


### PR DESCRIPTION
## Summary

- Refined the semantic guardrail Hate category definition in `taxonomy.json` to target slurs that dehumanise people based on identity, not political/ideological vocabulary
- Removed the overly broad "even in compounds" clause that caused Haiku to hard-block terms like "technofascist"
- Added two few-shot examples (technofascist, ethnonationalist) to anchor the classifier

Closes #397

## Test plan

- [x] All 43 existing guardrail tests pass (`test_guardrails.py`, `test_denylist.py`, `test_semantic.py`)
- [ ] Deploy to Lambda and verify "technofascist" returns 200 (not 403)
- [ ] Verify actual slurs still get hard-blocked (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)