### PR TITLE
fix: resolve 5 CI failures + denylist false positive

### DIFF
--- a/docs/runbooks/provision-cloudwatch.sh
+++ b/docs/runbooks/provision-cloudwatch.sh
@@ -11,7 +11,6 @@ set -e
 # =============================================================================
 
 REGION="us-east-1"
-ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 GREEN='\033[0;32m'

--- a/extensions/chrome/popup.html
+++ b/extensions/chrome/popup.html
@@ -87,9 +87,11 @@
         <div id="coupon-form" class="coupon-form" style="display: none;">
           <input type="text" id="coupon-input" class="coupon-input"
                  placeholder="Enter 16-character code" maxlength="16"
-                 autocomplete="off" spellcheck="false">
+                 autocomplete="off" spellcheck="false"
+                 aria-label="Coupon code">
           <input type="email" id="coupon-email" class="coupon-email-input"
-                 placeholder="Email (optional)" autocomplete="email">
+                 placeholder="Email (optional)" autocomplete="email"
+                 aria-label="Email address">
           <button id="coupon-submit" class="coupon-submit-button" disabled>
             Redeem Coupon
           </button>

--- a/src/guardrails/resources/denylist.json
+++ b/src/guardrails/resources/denylist.json
@@ -14,7 +14,7 @@
     "profanity": 35
   },
   "updated": "2026-01-01",
-  "term_count": 803,
+  "term_count": 802,
   "terms": [
     "\"white-acting\" black women",
     "\"yo mama\" joke",
@@ -798,7 +798,6 @@
     "western and central asians",
     "westerners",
     "whale tail",
-    "white",
     "white ape",
     "white chimpanzee",
     "white ears",

--- a/tests/e2e/waf-integration.spec.js
+++ b/tests/e2e/waf-integration.spec.js
@@ -1,18 +1,19 @@
 // tests/e2e/waf-integration.spec.js
-// API tests for WAF integration (#95)
+// API tests for header enforcement (#95, updated for CloudFlare Worker #349)
 // Uses Playwright's request API (Node.js, no CORS issues)
-//
-// LLD: docs/1095-security-hardening.md
 
 const { test, expect } = require('@playwright/test');
 
-// CloudFront URL
-const CLOUDFRONT_URL = 'https://d1fkpkls2wesse.cloudfront.net/';
+// CloudFlare Worker URL (CloudFront deleted in #349)
+const API_URL = 'https://api.aletheia.study/';
 
-test.describe('WAF Integration (#95)', () => {
+test.describe('Header Enforcement (#95, #349)', () => {
 
-    test('020: CloudFront accepts request with valid header', async ({ request }) => {
-        const response = await request.post(CLOUDFRONT_URL, {
+    // CloudFlare rate limit: 3 req/10s/IP — run serial with delay to avoid 429
+    test.describe.configure({ mode: 'serial' });
+
+    test('020: API accepts request with valid header', async ({ request }) => {
+        const response = await request.post(API_URL, {
             headers: {
                 'Content-Type': 'application/json',
                 'X-Aletheia-Client-Version': '1.0'
@@ -29,8 +30,8 @@ test.describe('WAF Integration (#95)', () => {
         expect(response.ok()).toBe(true);
     });
 
-    test('030: WAF blocks request without header', async ({ request }) => {
-        const response = await request.post(CLOUDFRONT_URL, {
+    test('030: Worker blocks request without header', async ({ request }) => {
+        const response = await request.post(API_URL, {
             headers: {
                 'Content-Type': 'application/json'
                 // Missing X-Aletheia-Client-Version
@@ -41,8 +42,8 @@ test.describe('WAF Integration (#95)', () => {
         expect(response.status()).toBe(403);
     });
 
-    test('040: WAF blocks invalid version', async ({ request }) => {
-        const response = await request.post(CLOUDFRONT_URL, {
+    test('040: Worker blocks invalid version', async ({ request }) => {
+        const response = await request.post(API_URL, {
             headers: {
                 'Content-Type': 'application/json',
                 'X-Aletheia-Client-Version': '0.9' // Invalid
@@ -54,7 +55,9 @@ test.describe('WAF Integration (#95)', () => {
     });
 
     test('050: Future version accepted', async ({ request }) => {
-        const response = await request.post(CLOUDFRONT_URL, {
+        // Wait for CloudFlare rate-limit window to reset (3 req/10s)
+        await new Promise(r => setTimeout(r, 11_000));
+        const response = await request.post(API_URL, {
             headers: {
                 'Content-Type': 'application/json',
                 'X-Aletheia-Client-Version': '1.99'

--- a/tests/fixtures/html/test-article-semantic.html
+++ b/tests/fixtures/html/test-article-semantic.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Article Semantic Test Page</title>
+</head>
+<body>
+    <article>
+        <h1>Article Semantic Test</h1>
+        <p>This page uses the semantic article tag for content extraction testing.</p>
+    </article>
+</body>
+</html>

--- a/tests/fixtures/html/test-googlebot-noarchive.html
+++ b/tests/fixtures/html/test-googlebot-noarchive.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Googlebot NoArchive Test Page</title>
+    <meta name="googlebot" content="noarchive">
+</head>
+<body>
+    <h1>Googlebot NoArchive Test Page</h1>
+    <p>This page has a googlebot-specific noarchive directive.</p>
+</body>
+</html>

--- a/tests/fixtures/html/test-main-semantic.html
+++ b/tests/fixtures/html/test-main-semantic.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Main Semantic Test Page</title>
+</head>
+<body>
+    <main>
+        <h1>Main Semantic Test</h1>
+        <p>This page uses the semantic main tag but has no article tag.</p>
+    </main>
+</body>
+</html>

--- a/tests/fixtures/html/test-normal.html
+++ b/tests/fixtures/html/test-normal.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Normal Test Page</title>
+</head>
+<body>
+    <h1>Normal Test Page</h1>
+    <p>This page has no noarchive restrictions. It is a clean test page.</p>
+</body>
+</html>

--- a/tests/fixtures/html/test-pii-content.html
+++ b/tests/fixtures/html/test-pii-content.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PII Content Test Page</title>
+</head>
+<body>
+    <h1>Contact Us</h1>
+    <p>Contact our team for more information.</p>
+    <p>Email: test@example.com</p>
+    <p>Phone: (555) 123-4567</p>
+</body>
+</html>

--- a/tests/unit/test_denylist.py
+++ b/tests/unit/test_denylist.py
@@ -176,6 +176,26 @@ class TestCheckDenylist:
             assert result["blocked"] is True
 
 
+class TestFalsePositiveRegression:
+    """Regression tests for denylist false positives (#413)."""
+
+    def test_pan_white_tribalism_not_blocked(self):
+        """'pan-white tribalism' must NOT be blocked (Issue #413)."""
+        denylist = load_denylist()
+        result = check_denylist("pan-white tribalism", denylist)
+        assert result["blocked"] is False, (
+            "Bare 'white' should not be in the denylist — "
+            "it blocks legitimate analytical text"
+        )
+
+    def test_white_not_in_production_denylist(self):
+        """Bare 'white' must not appear in the production denylist."""
+        denylist = load_denylist()
+        assert "white" not in denylist, (
+            "Bare 'white' found in denylist — too broad, blocks legitimate text"
+        )
+
+
 class TestIntegration:
     """Integration tests using file-based denylist."""
 

--- a/tools/audit_schedule_check.py
+++ b/tools/audit_schedule_check.py
@@ -172,6 +172,33 @@ def check_audit_schedule(audit_num: str, file_path: Path, today: datetime) -> di
         }
 
 
+def _find_audit_file(audit_num: str, search_dirs: list[Path]) -> Path | None:
+    """
+    Find audit file across search directories with prefix mapping.
+
+    Handles both AssemblyZero (08xx) and Aletheia (108xx) numbering.
+    """
+    # Prefixes to try: original 08xx and Aletheia 108xx (replace leading 0 with 10)
+    prefixes = [audit_num]
+    if audit_num.startswith("0"):
+        prefixes.append(f"1{audit_num}")
+
+    for search_dir in search_dirs:
+        if not search_dir.exists():
+            continue
+        for prefix in prefixes:
+            # Standard pattern: {prefix}-audit-*.md
+            matches = list(search_dir.glob(f"{prefix}-audit-*.md"))
+            if matches:
+                return matches[0]
+            # Alternate pattern (e.g., horizon scanning, meta-audit)
+            matches = list(search_dir.glob(f"{prefix}-*.md"))
+            if matches:
+                return matches[0]
+
+    return None
+
+
 def main() -> int:
     """Run audit schedule compliance check."""
     print("=== Audit Schedule Compliance Check ===")
@@ -181,22 +208,19 @@ def main() -> int:
         print("  No docs/ directory found, skipping...")
         return 0
 
+    # Search both docs/ (AssemblyZero) and docs/audits/ (Aletheia)
+    search_dirs = [docs_dir, docs_dir / "audits"]
+
     today = datetime.now()
     blocks = []
     warns = []
     oks = []
 
     for audit_num, frequency in sorted(AUDIT_FREQUENCY.items()):
-        # Find the audit file
-        pattern = f"{audit_num}-audit-*.md"
-        matches = list(docs_dir.glob(pattern))
+        file_path = _find_audit_file(audit_num, search_dirs)
 
-        if not matches:
-            # Try alternate patterns (e.g., 0898 horizon scanning, 0899 meta-audit)
-            alt_pattern = f"{audit_num}-*.md"
-            matches = list(docs_dir.glob(alt_pattern))
-
-        if not matches:
+        if not file_path:
+            pattern = f"{audit_num}-audit-*.md"
             blocks.append({
                 "audit": audit_num,
                 "status": "block",
@@ -204,7 +228,6 @@ def main() -> int:
             })
             continue
 
-        file_path = matches[0]
         result = check_audit_schedule(audit_num, file_path, today)
         result["audit"] = audit_num
         result["file"] = file_path.name


### PR DESCRIPTION
## Summary

- **infra-lint (#408):** Remove unused `ACCOUNT_ID` variable (ShellCheck SC2034)
- **e2e-chrome/test-edge (#409):** Create 5 missing HTML fixtures for `full-article.spec.js`
- **e2e-chrome (#410):** Update dead CloudFront URL to `api.aletheia.study` in `waf-integration.spec.js`
- **audit-schedule (#411):** Fix `08xx` → `108xx` prefix mapping so script finds Aletheia audit files
- **accessibility (#412):** Add `aria-label` to `coupon-input` and `coupon-email` in Chrome popup
- **denylist (#413):** Remove overbroad bare `"white"` entry + add regression test for "pan-white tribalism"

## Test plan

- [x] 922 unit tests pass (0 failures)
- [x] pa11y reports 0 issues on both Chrome and Firefox popups
- [x] audit-schedule finds 10/17 audits OK (5 legitimately overdue monthly/weekly, 2 new)
- [x] All pre-commit hooks pass (ruff, mypy, ESLint, secrets, policy)
- [ ] CI: infra-lint (ShellCheck) passes
- [ ] CI: e2e-chrome passes (fixtures + WAF URL)
- [ ] CI: test-edge passes (same fixtures)
- [ ] CI: accessibility passes (aria-labels)
- [ ] CI: audit-schedule passes (prefix mapping)

Closes #408, closes #409, closes #410, closes #411, closes #412, closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)