### PR TITLE
fix: store JWT and send Authorization headers in extension API calls

### DIFF
--- a/docs/reports/402/implementation-report.md
+++ b/docs/reports/402/implementation-report.md
@@ -1,0 +1,21 @@
+# Implementation Report — Issue #402
+
+## Summary
+Fixed missing JWT storage and Authorization headers in extension API calls.
+
+## Root Cause
+Two bugs: `storeTokens()` discarded the `jwt` field from token exchange response, and all fetch calls sent no Authorization header.
+
+## Changes (6 files)
+
+| File | Change |
+|------|--------|
+| `extensions/chrome/auth.js` | `storeTokens()` +jwt param, `getJwt()`, `clearTokens()` +jwt, export, call site |
+| `extensions/firefox/auth.js` | Same (browser.* API) |
+| `extensions/chrome/service-worker.js` | `getAuthHeaders()` helper, 2 fetch calls |
+| `extensions/firefox/service-worker.js` | `getAuthHeaders()` helper, 2 fetch calls, jwt in OAuth flow |
+| `extensions/chrome/popup.js` | JWT in full-page, coupon, subscription, upgrade fetches |
+| `extensions/firefox/popup.js` | JWT in full-page fetch |
+
+## Graceful Degradation
+When no JWT exists (not logged in), requests go without Authorization header. AUTH_ENABLED=false works as before; AUTH_ENABLED=true returns 401 for unauthenticated requests (correct behavior).

--- a/docs/reports/402/test-report.md
+++ b/docs/reports/402/test-report.md
@@ -1,0 +1,14 @@
+# Test Report — Issue #402
+
+## Unit Tests
+```
+tests/unit/test_stripe_handler.py — 15 passed
+tests/unit/test_lambda_auth.py   — 16 passed
+Total: 31 passed, 0 failed
+```
+
+## Manual Verification Checklist
+- [ ] Load Chrome extension locally, sign in, verify `chrome.storage.session` contains `jwt` key
+- [ ] Select text, analyze, check DevTools Network tab for `Authorization: Bearer ...` header
+- [ ] Test without signing in — verify requests still work (no header sent, AUTH_ENABLED=false)
+- [ ] Firefox: same checks with browser.storage.session

--- a/extensions/chrome/auth.js
+++ b/extensions/chrome/auth.js
@@ -52,11 +52,12 @@ function generateState() {
  * @param {number} expiresIn - Seconds until access token expires
  * @param {object} user - User info {id, name}
  */
-async function storeTokens(accessToken, refreshToken, expiresIn, user) {
-    // Access token - session only (memory, cleared on browser close)
+async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt) {
+    // Access token + JWT - session only (memory, cleared on browser close)
     await chrome.storage.session.set({
         accessToken,
-        expiresAt: Date.now() + (expiresIn * 1000)
+        expiresAt: Date.now() + (expiresIn * 1000),
+        jwt: jwt || null
     });
 
     // Refresh token + profile - local persistence
@@ -73,9 +74,18 @@ async function storeTokens(accessToken, refreshToken, expiresIn, user) {
  * Clear all auth data (logout).
  */
 async function clearTokens() {
-    await chrome.storage.session.remove(['accessToken', 'expiresAt']);
+    await chrome.storage.session.remove(['accessToken', 'expiresAt', 'jwt']);
     await chrome.storage.local.remove(['refreshToken', 'userId', 'displayName']);
     console.log('[Aletheia Auth] Tokens cleared');
+}
+
+/**
+ * Get JWT from session storage.
+ * @returns {Promise<string | null>} JWT or null if not authenticated
+ */
+async function getJwt() {
+    const session = await chrome.storage.session.get(['jwt']);
+    return session.jwt || null;
 }
 
 /**
@@ -313,7 +323,8 @@ async function initiateLogin() {
             tokenData.accessToken,
             tokenData.refreshToken,
             tokenData.expiresIn,
-            tokenData.user
+            tokenData.user,
+            tokenData.jwt
         );
 
         console.log('[Aletheia Auth] Login successful:', tokenData.user.name);
@@ -344,6 +355,7 @@ window.AletheiaAuth = {
     isAuthenticated,
     getAuthState,
     getAccessToken,
+    getJwt,
     clearTokens,
     // Config for debugging
     getConfig: () => ({ ...AUTH_CONFIG, CLIENT_ID: '***' })  // Hide client ID in logs

--- a/extensions/chrome/popup.js
+++ b/extensions/chrome/popup.js
@@ -577,13 +577,17 @@ async function handleFullPageClick() {
       }
     };
 
-    // Send to Lambda
+    // Send to Lambda (Issue #402: include JWT if authenticated)
+    const jwt = await window.AletheiaAuth.getJwt();
+    const fullPageHeaders = {
+      'Content-Type': 'application/json',
+      'X-Aletheia-Client-Version': CLIENT_VERSION
+    };
+    if (jwt) fullPageHeaders['Authorization'] = `Bearer ${jwt}`;
+
     const response = await fetch(API_ENDPOINT, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Aletheia-Client-Version': CLIENT_VERSION
-      },
+      headers: fullPageHeaders,
       body: JSON.stringify(payload)
     });
 
@@ -686,9 +690,9 @@ async function handleCouponSubmit() {
   showCouponStatus('Validating coupon...', 'info');
 
   try {
-    // Get JWT from auth state
-    const authState = await window.AletheiaAuth.getAuthState();
-    if (!authState || !authState.jwt) {
+    // Get JWT from session storage (Issue #402)
+    const jwt = await window.AletheiaAuth.getJwt();
+    if (!jwt) {
       showCouponStatus('Please sign in first', 'error');
       return;
     }
@@ -702,7 +706,7 @@ async function handleCouponSubmit() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${authState.jwt}`
+        'Authorization': `Bearer ${jwt}`
       },
       body: JSON.stringify(payload)
     });
@@ -764,12 +768,13 @@ async function checkSubscriptionStatus() {
 
   try {
     const authState = await window.AletheiaAuth.getAuthState();
-    if (!authState || !authState.jwt) return;
+    const jwt = await window.AletheiaAuth.getJwt();
+    if (!authState || !jwt) return;
 
     const response = await fetch(SUBSCRIPTION_STATUS_URL, {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${authState.jwt}`
+        'Authorization': `Bearer ${jwt}`
       }
     });
 
@@ -814,7 +819,8 @@ async function handleUpgradeClick() {
 
   try {
     const authState = await window.AletheiaAuth.getAuthState();
-    if (!authState || !authState.jwt) {
+    const jwt = await window.AletheiaAuth.getJwt();
+    if (!authState || !jwt) {
       upgradeButton.textContent = 'Please sign in first';
       return;
     }
@@ -823,7 +829,7 @@ async function handleUpgradeClick() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${authState.jwt}`
+        'Authorization': `Bearer ${jwt}`
       }
     });
 

--- a/extensions/chrome/service-worker.js
+++ b/extensions/chrome/service-worker.js
@@ -8,6 +8,17 @@ const API_ENDPOINT = "https://api.aletheia.study/";
 // [#95] Client version for Lambda header validation (Issue #349: moved from WAF to Lambda)
 const CLIENT_VERSION = "1.0";
 
+// Issue #402: Auth header injection
+async function getAuthHeaders() {
+    const session = await chrome.storage.session.get(['jwt']);
+    const headers = {
+        'Content-Type': 'application/json',
+        'X-Aletheia-Client-Version': CLIENT_VERSION
+    };
+    if (session.jwt) headers['Authorization'] = `Bearer ${session.jwt}`;
+    return headers;
+}
+
 // =============================================================================
 // Issue #391 Phase 2: Error Handling Helpers
 // =============================================================================
@@ -249,10 +260,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
                 const response = await fetch(API_ENDPOINT, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Aletheia-Client-Version': CLIENT_VERSION
-                    },
+                    headers: await getAuthHeaders(),
                     body: JSON.stringify(payload)
                 });
 
@@ -459,10 +467,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
         const response = await fetch(API_ENDPOINT, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Aletheia-Client-Version': CLIENT_VERSION  // [#95] WAF header validation
-            },
+            headers: await getAuthHeaders(),
             body: JSON.stringify(payload),
             signal: controller.signal
         });

--- a/extensions/firefox/auth.js
+++ b/extensions/firefox/auth.js
@@ -63,11 +63,12 @@ function generateState() {
  * @param {number} expiresIn - Seconds until access token expires
  * @param {object} user - User info {id, name}
  */
-async function storeTokens(accessToken, refreshToken, expiresIn, user) {
-    // Access token - session only (memory, cleared on browser close)
+async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt) {
+    // Access token + JWT - session only (memory, cleared on browser close)
     await browser.storage.session.set({
         accessToken,
-        expiresAt: Date.now() + (expiresIn * 1000)
+        expiresAt: Date.now() + (expiresIn * 1000),
+        jwt: jwt || null
     });
 
     // Refresh token + profile - local persistence
@@ -84,9 +85,18 @@ async function storeTokens(accessToken, refreshToken, expiresIn, user) {
  * Clear all auth data (logout).
  */
 async function clearTokens() {
-    await browser.storage.session.remove(['accessToken', 'expiresAt']);
+    await browser.storage.session.remove(['accessToken', 'expiresAt', 'jwt']);
     await browser.storage.local.remove(['refreshToken', 'userId', 'displayName']);
     console.log('[Aletheia Auth] Tokens cleared');
+}
+
+/**
+ * Get JWT from session storage.
+ * @returns {Promise<string | null>} JWT or null if not authenticated
+ */
+async function getJwt() {
+    const session = await browser.storage.session.get(['jwt']);
+    return session.jwt || null;
 }
 
 /**
@@ -312,6 +322,7 @@ window.AletheiaAuth = {
     isAuthenticated,
     getAuthState,
     getAccessToken,
+    getJwt,
     clearTokens,
     // Exposed for testing
     generateState,

--- a/extensions/firefox/popup.js
+++ b/extensions/firefox/popup.js
@@ -500,13 +500,17 @@ async function handleFullPageClick() {
       }
     };
 
-    // Send to Lambda
+    // Send to Lambda (Issue #402: include JWT if authenticated)
+    const jwt = await window.AletheiaAuth.getJwt();
+    const fullPageHeaders = {
+      'Content-Type': 'application/json',
+      'X-Aletheia-Client-Version': CLIENT_VERSION
+    };
+    if (jwt) fullPageHeaders['Authorization'] = `Bearer ${jwt}`;
+
     const response = await fetch(API_ENDPOINT, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Aletheia-Client-Version': CLIENT_VERSION
-      },
+      headers: fullPageHeaders,
       body: JSON.stringify(payload)
     });
 

--- a/extensions/firefox/service-worker.js
+++ b/extensions/firefox/service-worker.js
@@ -8,6 +8,17 @@ const API_ENDPOINT = "https://api.aletheia.study/";
 // [#95] Client version for Lambda header validation (Issue #349: moved from WAF to Lambda)
 const CLIENT_VERSION = "1.0";
 
+// Issue #402: Auth header injection
+async function getAuthHeaders() {
+    const session = await chrome.storage.session.get(['jwt']);
+    const headers = {
+        'Content-Type': 'application/json',
+        'X-Aletheia-Client-Version': CLIENT_VERSION
+    };
+    if (session.jwt) headers['Authorization'] = `Bearer ${session.jwt}`;
+    return headers;
+}
+
 // =============================================================================
 // AGE GATE - Tab State Management (Issue #104)
 // =============================================================================
@@ -185,10 +196,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
                 const response = await fetch(API_ENDPOINT, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Aletheia-Client-Version': CLIENT_VERSION
-                    },
+                    headers: await getAuthHeaders(),
                     body: JSON.stringify(payload)
                 });
 
@@ -312,7 +320,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 // 5. Store tokens (service worker has access to storage APIs)
                 await chrome.storage.session.set({
                     accessToken: tokenData.accessToken,
-                    expiresAt: Date.now() + (tokenData.expiresIn * 1000)
+                    expiresAt: Date.now() + (tokenData.expiresIn * 1000),
+                    jwt: tokenData.jwt || null
                 });
 
                 await chrome.storage.local.set({
@@ -502,10 +511,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
         const response = await fetch(API_ENDPOINT, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Aletheia-Client-Version': CLIENT_VERSION  // [#95] WAF header validation
-            },
+            headers: await getAuthHeaders(),
             body: JSON.stringify(payload)
         });
 


### PR DESCRIPTION
## Summary
- Store `jwt` from token exchange in session storage (was silently discarded)
- Add `getJwt()` to auth.js and `getAuthHeaders()` to service workers
- Wire Authorization header into all 6 analysis/coupon/subscription fetch calls
- Fix coupon redemption using nonexistent `authState.jwt` (now uses `getJwt()`)

Closes #402

## Test plan
- [x] 31 unit tests pass (test_stripe_handler + test_lambda_auth)
- [ ] Load Chrome extension, sign in, verify `chrome.storage.session` contains `jwt`
- [ ] Analyze text, check Network tab for `Authorization: Bearer ...` header
- [ ] Test without signing in — requests still work (AUTH_ENABLED=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)