### PR TITLE
test: complete AUTH_ENABLED readiness checklist items 5-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,49 @@ jobs:
       - name: Deploy Infrastructure
         run: ./provision.sh
 
+  # Post-deploy smoke test - verifies production API after deploy (Issue #404)
+  post-deploy-smoke:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: deploy-infra
+    runs-on: ubuntu-latest
+    steps:
+      - name: Health check
+        run: |
+          echo "=== Production Health Check ==="
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://api.aletheia.study/health)
+          echo "Health endpoint returned: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -ne 200 ]; then
+            echo "✗ FAIL: Health check returned $HTTP_STATUS (expected 200)"
+            exit 1
+          fi
+          echo "✓ Health check passed"
+
+      - name: Analysis smoke test
+        run: |
+          echo "=== Production Analysis Smoke Test ==="
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://api.aletheia.study/ \
+            -H "Content-Type: application/json" \
+            -H "X-Aletheia-Client-Version: 1.0" \
+            -d '{"text":"smoke test"}')
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+          echo "Analysis endpoint returned: $HTTP_STATUS"
+          # 200 = AUTH_ENABLED=false (normal response)
+          # 401 = AUTH_ENABLED=true (expected when auth is on)
+          # 5xx = server error (FAIL)
+          if [ "$HTTP_STATUS" -ge 500 ]; then
+            echo "✗ FAIL: Server error $HTTP_STATUS"
+            echo "Response: $BODY"
+            exit 1
+          fi
+          if [ "$HTTP_STATUS" -eq 200 ] || [ "$HTTP_STATUS" -eq 401 ]; then
+            echo "✓ Analysis smoke test passed (status: $HTTP_STATUS)"
+          else
+            echo "⚠ Unexpected status $HTTP_STATUS — investigate"
+            echo "Response: $BODY"
+            exit 1
+          fi
+
   # Compliance audit - runs on push to main AND nightly schedule
   # Requires AWS credentials to verify Bedrock configuration
   compliance-audit:

--- a/docs/reports/405/implementation-report.md
+++ b/docs/reports/405/implementation-report.md
@@ -1,0 +1,70 @@
+# Implementation Report — #405 Auth Readiness Checklist (Items 5-9)
+
+**Date:** 2026-02-24
+**Branch:** `405-auth-readiness`
+**Issues:** #405 (parent), #442, #443, #444, #404
+
+---
+
+## Changes Made
+
+### 1. E2E Test 060 — Authenticated Analysis Network Verification (#442)
+
+**File:** `tests/e2e/auth-flow.spec.js`
+
+Added test 060 that verifies the complete auth chain at the network level:
+- Performs `mockLogin()` via popup page to store JWT in session storage
+- Uses `context.route('**/api.aletheia.study/**')` to intercept service worker requests
+- Captures the `Authorization` header from the intercepted request
+- Asserts the header is `Bearer mock-jwt-for-testing`
+- Fulfills with mock JSON response to avoid hitting production
+
+This covers checklist items 5 (E2E authenticated analysis) and 6 (network-level verification).
+
+### 2. Firefox SW Namespace Fix + START_OAUTH Tests (#444)
+
+**File:** `tests/unit/firefox/service-worker.test.js`
+
+**Namespace fix:** Added `global.chrome = browserMock` in `createServiceWorkerEnvironment()`. The Firefox `service-worker.js` uses `chrome.*` namespace (identical source to Chrome). Without this alias, the source evaluation failed silently during tests, resulting in zero coverage of the START_OAUTH handler.
+
+**START_OAUTH test suite:** Added 7 tests covering the complete OAuth flow:
+1. Returns true for async response
+2. Opens auth tab with correct URL
+3. Stores tokens on successful callback (session + local storage)
+4. Responds with user info on success
+5. Rejects on CSRF state mismatch
+6. Handles tab closure (OAuth cancelled)
+7. Times out after 5 minutes (fake timers)
+
+### 3. Post-Deploy Smoke Test CI Job (#404)
+
+**File:** `.github/workflows/ci.yml`
+
+Added `post-deploy-smoke` job that runs after `deploy-infra` on pushes to main:
+- Health check: `curl` to `/health`, expects 200
+- Analysis smoke: `POST` to `/`, accepts 200 (auth off) or 401 (auth on), fails on 5xx
+- No checkout or AWS credentials needed (public API only)
+
+### 4. LinkedIn OAuth Manual Testbook (#443)
+
+**File:** `docs/testbooks/10905-testbook-linkedin-oauth.md`
+
+Manual test procedure covering:
+- Prerequisites
+- Chrome 5-step test procedure
+- Firefox 5-step test procedure (with #396 popup-close behavior noted)
+- Pass/fail criteria tables per browser
+- Evidence recording table
+
+---
+
+## Files Modified
+
+| File | Action |
+|------|--------|
+| `tests/e2e/auth-flow.spec.js` | Edit — added test 060 |
+| `tests/unit/firefox/service-worker.test.js` | Edit — namespace fix + 7 START_OAUTH tests |
+| `.github/workflows/ci.yml` | Edit — added post-deploy-smoke job |
+| `docs/testbooks/10905-testbook-linkedin-oauth.md` | Create — manual testbook |
+| `docs/reports/405/implementation-report.md` | Create — this file |
+| `docs/reports/405/test-report.md` | Create — test results |

--- a/docs/reports/405/test-report.md
+++ b/docs/reports/405/test-report.md
@@ -1,0 +1,67 @@
+# Test Report — #405 Auth Readiness Checklist (Items 5-9)
+
+**Date:** 2026-02-24
+**Branch:** `405-auth-readiness`
+
+---
+
+## Firefox Service Worker Unit Tests
+
+**Command:** `npx vitest run tests/unit/firefox/service-worker.test.js`
+**Result:** 33 passed (0 failed)
+
+| Suite | Tests | Status |
+|-------|-------|--------|
+| Service Worker File (Firefox) | 4 | Pass |
+| Installation Events (Firefox) | 3 | Pass |
+| Message Handlers (Firefox) | 4 | Pass |
+| Security - Sender Validation (Firefox) | 3 | Pass |
+| Age Gate - Tab State Management (Firefox) | 2 | Pass |
+| Context Menu Click Handler (Firefox) | 3 | Pass |
+| Badge State (Firefox) | 1 | Pass |
+| API Integration (Firefox) | 2 | Pass |
+| Helper Functions (Firefox) | 2 | Pass |
+| Error Handling (Firefox) | 2 | Pass |
+| **START_OAUTH Handler (Issue #396)** | **7** | **Pass** |
+
+### START_OAUTH Tests Detail
+
+| Test | Result |
+|------|--------|
+| Returns true for async response | Pass |
+| Opens auth tab with correct URL | Pass |
+| Stores tokens on successful callback | Pass |
+| Responds with user info on success | Pass |
+| Rejects on CSRF state mismatch | Pass |
+| Handles tab closure (OAuth cancelled) | Pass |
+| Times out after 5 minutes | Pass |
+
+---
+
+## Full Vitest Suite
+
+**Command:** `npx vitest run`
+**Result:** 267 passed, 3 failed (pre-existing), 2 skipped
+
+Pre-existing failures (confirmed on `main`):
+- `extension-files.test.js` — popup.css parity (cosmetic)
+- `article-extractor.test.js` — 2 phone scrubbing regex tests
+
+**Zero regressions introduced.**
+
+---
+
+## CI YAML Validation
+
+**Check:** `grep "post-deploy-smoke" .github/workflows/ci.yml`
+**Result:** Found — job defined correctly with `needs: deploy-infra` dependency.
+
+---
+
+## E2E Auth Flow Tests
+
+**Note:** Test 060 requires a headed Chromium instance with the extension loaded. It was verified structurally (correct fixture usage, route interception pattern matches tests 010-050). Full E2E execution requires:
+```
+npx playwright test tests/e2e/auth-flow.spec.js --project=chromium --headed
+```
+This runs in CI via the `e2e-chrome` job with `xvfb-run`.

--- a/docs/testbooks/10905-testbook-linkedin-oauth.md
+++ b/docs/testbooks/10905-testbook-linkedin-oauth.md
@@ -1,0 +1,138 @@
+# 10905 — LinkedIn OAuth Manual Testbook
+
+**Issue:** #443 | **Parent:** #405 | **Auth System:** AletheiaAuth Lambda
+**Last Updated:** 2026-02-24
+
+---
+
+## 1. Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| LinkedIn account | Any valid LinkedIn account (personal or test) |
+| Chrome | Latest stable, extension loaded unpacked from `extensions/chrome/` |
+| Firefox | v140.0+, extension loaded temporarily from `extensions/firefox/manifest.json` |
+| AUTH_ENABLED | Must be `true` on the Lambda (`AletheiaAgent`) |
+| Auth Lambda | `AletheiaAuth` deployed and reachable |
+| Network | Internet access to LinkedIn OAuth and `api.aletheia.study` |
+
+---
+
+## 2. Chrome Test Procedure
+
+### Step 1: Load Extension
+1. Navigate to `chrome://extensions`
+2. Enable Developer Mode
+3. Load unpacked from `extensions/chrome/`
+4. Verify extension icon appears in toolbar
+
+### Step 2: Login
+1. Click the Aletheia extension icon to open popup
+2. Click "Sign in with LinkedIn"
+3. LinkedIn OAuth page opens in a new tab
+4. Authorize the application
+5. Tab closes automatically after authorization
+6. Popup shows logged-in state with user name
+
+**Expected:** Popup displays user name and "Sign out" button.
+
+### Step 3: Verify Tokens
+1. Open DevTools on any page
+2. Run in console: `chrome.runtime.sendMessage({ type: 'AUTH_STATUS' }, r => console.log(r))`
+3. Verify response contains `{ authenticated: true }` (or check via popup UI)
+4. In DevTools Application tab > Extension Storage, verify `jwt` exists in session storage
+
+**Expected:** JWT is present in session storage, refresh token in local storage.
+
+### Step 4: Analyze with Auth
+1. Navigate to an allowlisted site
+2. Select text, right-click, choose "Explain with AI"
+3. Open DevTools Network tab, find the POST to `api.aletheia.study`
+4. Inspect request headers
+
+**Expected:** `Authorization: Bearer <jwt>` header is present in the request.
+
+### Step 5: Logout
+1. Click the Aletheia extension icon
+2. Click "Sign out"
+3. Verify popup returns to "Sign in" state
+4. Repeat Step 4 — analyze text again
+
+**Expected:** After logout, the POST request has no `Authorization` header.
+
+---
+
+## 3. Firefox Test Procedure
+
+### Step 1: Load Extension
+1. Navigate to `about:debugging#/runtime/this-firefox`
+2. Click "Load Temporary Add-on"
+3. Select `extensions/firefox/manifest.json`
+4. Verify extension icon appears in toolbar
+
+### Step 2: Login
+1. Click the Aletheia extension icon to open popup
+2. Click "Sign in with LinkedIn"
+3. LinkedIn OAuth page opens in a new tab
+
+> **Known Issue (#396):** The popup may close when the auth tab opens. This is expected behavior in Firefox — the service worker continues the OAuth flow independently. Wait for the auth tab to close automatically after authorization.
+
+4. Authorize the application on LinkedIn
+5. Auth tab closes automatically
+6. Re-open popup — should show logged-in state
+
+**Expected:** After re-opening popup, user name and "Sign out" button are displayed.
+
+### Step 3: Verify Tokens
+1. Open DevTools (F12) on the extension's background page (via `about:debugging`)
+2. Check storage via the Storage tab or console
+3. Verify JWT exists in session storage
+
+**Expected:** JWT is present in session storage, refresh token in local storage.
+
+### Step 4: Analyze with Auth
+1. Navigate to an allowlisted site
+2. Select text, right-click, choose "Explain with AI"
+3. Open DevTools Network tab, find the POST to `api.aletheia.study`
+4. Inspect request headers
+
+**Expected:** `Authorization: Bearer <jwt>` header is present in the request.
+
+### Step 5: Logout
+1. Click the Aletheia extension icon
+2. Click "Sign out"
+3. Verify popup returns to "Sign in" state
+4. Repeat Step 4 — analyze text again
+
+**Expected:** After logout, the POST request has no `Authorization` header.
+
+---
+
+## 4. Pass/Fail Criteria
+
+### Chrome
+
+| Step | Criterion | Pass | Fail |
+|------|-----------|------|------|
+| 2 | OAuth completes, popup shows user name | User visible | Error or blank |
+| 3 | JWT in session storage | Present | Missing |
+| 4 | Authorization header in network request | `Bearer <jwt>` | Missing header |
+| 5 | Tokens cleared after logout | No Authorization header | Header still present |
+
+### Firefox
+
+| Step | Criterion | Pass | Fail |
+|------|-----------|------|------|
+| 2 | OAuth completes (popup may close — #396) | User visible on re-open | Error or stuck |
+| 3 | JWT in session storage | Present | Missing |
+| 4 | Authorization header in network request | `Bearer <jwt>` | Missing header |
+| 5 | Tokens cleared after logout | No Authorization header | Header still present |
+
+---
+
+## 5. Evidence Recording
+
+| Date | Browser | Version | Tester | Steps Passed | Overall | Notes |
+|------|---------|---------|--------|--------------|---------|-------|
+| | Chrome | | | /5 | | |
+| | Firefox | | | /5 | | |

--- a/tests/e2e/auth-flow.spec.js
+++ b/tests/e2e/auth-flow.spec.js
@@ -166,4 +166,51 @@ test.describe('E2E Auth Flow (#403)', () => {
         await page.close();
     });
 
+    test('060: authenticated fetch includes Authorization header at network level', async ({ context, extensionId, serviceWorker }) => {
+        // Step 1: mockLogin via popup to store JWT in session storage
+        const popupUrl = `chrome-extension://${extensionId}/popup.html`;
+        const page = await context.newPage();
+        await page.goto(popupUrl);
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(500);
+
+        await page.evaluate(async () => {
+            return await window.AletheiaAuth.mockLogin();
+        });
+
+        // Step 2: Intercept requests to api.aletheia.study and capture Authorization header
+        let capturedAuthHeader = null;
+        await context.route('**/api.aletheia.study/**', async (route) => {
+            capturedAuthHeader = route.request().headers()['authorization'];
+            // Fulfill with mock response to avoid hitting production
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    signal: 'Verified',
+                    gem: 'Mock authenticated response',
+                    context: 'Test context'
+                })
+            });
+        });
+
+        // Step 3: Trigger a fetch from the service worker using getAuthHeaders()
+        await serviceWorker.evaluate(async () => {
+            // eslint-disable-next-line no-undef
+            const headers = await getAuthHeaders();
+            // eslint-disable-next-line no-undef
+            await fetch(API_ENDPOINT, {
+                method: 'POST',
+                headers: headers,
+                body: JSON.stringify({ text: 'test auth header' })
+            });
+        });
+
+        // Step 4: Verify the Authorization header was present at network level
+        // Playwright lowercases header names in route.request().headers()
+        expect(capturedAuthHeader).toBe('Bearer mock-jwt-for-testing');
+
+        await page.close();
+    });
+
 });

--- a/tests/unit/firefox/service-worker.test.js
+++ b/tests/unit/firefox/service-worker.test.js
@@ -58,6 +58,10 @@ function createServiceWorkerEnvironment(options = {}) {
   // Set up global browser object (canonical Firefox namespace)
   global.browser = browserMock;
 
+  // Firefox service-worker.js uses chrome.* namespace (same source as Chrome).
+  // Without this alias, the source fails silently and no handlers register.
+  global.chrome = browserMock;
+
   // Mock console to suppress logging during tests (save original first)
   const originalConsole = global.console;
   global.console = {
@@ -613,5 +617,254 @@ describe('Error Handling (Firefox)', () => {
 
     // The age gate should fail open (allow the tab)
     // This is tested via checkTabForAgeRestriction behavior
+  });
+});
+
+// ============================================================================
+// START_OAUTH HANDLER TESTS (Issue #396)
+// ============================================================================
+
+describe('START_OAUTH Handler (Issue #396)', () => {
+  let env;
+  let messageListener;
+
+  const MOCK_AUTH_URL = 'https://www.linkedin.com/oauth/v2/authorization?client_id=test';
+  const MOCK_CALLBACK_URL = 'https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws/auth/callback';
+  const MOCK_LAMBDA_AUTH_URL = 'https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws';
+  const MOCK_STATE = 'csrf-state-abc123';
+
+  function createOAuthMessage(overrides = {}) {
+    return {
+      type: 'START_OAUTH',
+      authUrl: MOCK_AUTH_URL,
+      callbackUrl: MOCK_CALLBACK_URL,
+      lambdaAuthUrl: MOCK_LAMBDA_AUTH_URL,
+      state: MOCK_STATE,
+      ...overrides
+    };
+  }
+
+  beforeEach(() => {
+    env = createServiceWorkerEnvironment();
+    // Get the registered onMessage listener directly for precise control
+    const { browserMock } = env;
+    const calls = browserMock.runtime.onMessage.addListener.mock.calls;
+    messageListener = calls[calls.length - 1][0];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanupEnvironment();
+  });
+
+  it('returns true for async response', () => {
+    const sendResponse = vi.fn();
+    const result = messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+    expect(result).toBe(true);
+  });
+
+  it('opens auth tab with correct URL', async () => {
+    const { browserMock } = env;
+    const sendResponse = vi.fn();
+
+    messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+
+    // Wait for tabs.create to be called
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(browserMock.tabs.create).toHaveBeenCalledWith({ url: MOCK_AUTH_URL });
+  });
+
+  it('stores tokens on successful callback', async () => {
+    const { browserMock } = env;
+    const sendResponse = vi.fn();
+
+    // Mock token exchange response
+    const mockTokenData = {
+      accessToken: 'linkedin-access-token',
+      expiresIn: 3600,
+      jwt: 'signed-jwt-token',
+      refreshToken: 'linkedin-refresh-token',
+      user: { id: 'user-123', name: 'Test LinkedIn User' }
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockTokenData)
+    });
+
+    messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+
+    // Wait for tabs.create to resolve
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Get the tab ID that was created
+    const createdTab = await browserMock.tabs.create.mock.results[0].value;
+
+    // Simulate LinkedIn redirecting to callback URL with code and state
+    const callbackUrlWithParams = `${MOCK_CALLBACK_URL}?code=auth-code-xyz&state=${MOCK_STATE}`;
+    browserMock.__simulateTabUpdate(createdTab.id, callbackUrlWithParams, 'complete');
+
+    // Wait for token exchange and storage
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Verify session storage was updated
+    expect(browserMock.storage.session.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: 'linkedin-access-token',
+        jwt: 'signed-jwt-token'
+      })
+    );
+
+    // Verify local storage was updated
+    expect(browserMock.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refreshToken: 'linkedin-refresh-token',
+        userId: 'user-123',
+        displayName: 'Test LinkedIn User'
+      })
+    );
+  });
+
+  it('responds with user info on success', async () => {
+    const { browserMock } = env;
+    const sendResponse = vi.fn();
+
+    const mockTokenData = {
+      accessToken: 'at',
+      expiresIn: 3600,
+      jwt: 'jwt',
+      refreshToken: 'rt',
+      user: { id: 'u1', name: 'Alice' }
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockTokenData)
+    });
+
+    messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const createdTab = await browserMock.tabs.create.mock.results[0].value;
+
+    const callbackUrl = `${MOCK_CALLBACK_URL}?code=code&state=${MOCK_STATE}`;
+    browserMock.__simulateTabUpdate(createdTab.id, callbackUrl, 'complete');
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      user: { id: 'u1', name: 'Alice' }
+    });
+  });
+
+  it('rejects on CSRF state mismatch', async () => {
+    const { browserMock } = env;
+    const sendResponse = vi.fn();
+
+    // We still need fetch mock for the flow but CSRF check happens before token exchange
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        accessToken: 'at', expiresIn: 3600, jwt: 'j',
+        refreshToken: 'rt', user: { id: 'u', name: 'N' }
+      })
+    });
+
+    messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const createdTab = await browserMock.tabs.create.mock.results[0].value;
+
+    // Return a DIFFERENT state than what was sent (CSRF attack)
+    const callbackUrl = `${MOCK_CALLBACK_URL}?code=code&state=WRONG-STATE`;
+    browserMock.__simulateTabUpdate(createdTab.id, callbackUrl, 'complete');
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringContaining('CSRF')
+      })
+    );
+  });
+
+  it('handles tab closure (OAuth cancelled)', async () => {
+    const { browserMock } = env;
+    const sendResponse = vi.fn();
+
+    messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const createdTab = await browserMock.tabs.create.mock.results[0].value;
+
+    // User closes the OAuth tab before completing auth
+    browserMock.__triggerTabRemoved(createdTab.id);
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringContaining('cancelled')
+      })
+    );
+  });
+
+  it('times out after 5 minutes', async () => {
+    vi.useFakeTimers();
+    const sendResponse = vi.fn();
+
+    messageListener(
+      createOAuthMessage(),
+      { id: 'extension@aletheia.study' },
+      sendResponse
+    );
+
+    // Advance past the 5-minute timeout
+    // tabs.create returns a promise — need to flush microtasks first
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Now advance past the 5-minute timeout
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
+
+    // Flush any remaining microtasks
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringContaining('timeout')
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

Completes the remaining 5 items on the AUTH_ENABLED readiness checklist (#405):

- **Item 5+6 (#442):** E2E test 060 — authenticated analysis with network-level Authorization header verification via `context.route()`
- **Item 7 (#443):** Manual LinkedIn OAuth testbook (`docs/testbooks/10905-testbook-linkedin-oauth.md`)
- **Item 8 (#404):** Post-deploy smoke test CI job — health check + analysis smoke after `deploy-infra`
- **Item 9 (#444):** Firefox SW namespace fix (`global.chrome = browserMock`) + 7 START_OAUTH unit tests covering CSRF, timeout, tab close, and token storage

## Key Finding

The Firefox `service-worker.js` uses `chrome.*` namespace but the unit test mock only provided `global.browser`. This caused the source evaluation to fail silently — meaning the START_OAUTH handler had **zero unit test coverage**. Fixed by aliasing `global.chrome = browserMock`.

## Test plan

- [x] `npx vitest run tests/unit/firefox/service-worker.test.js` — 33/33 pass (including 7 new START_OAUTH tests)
- [x] `npx vitest run` — 267 passed, 3 pre-existing failures (confirmed on main), 0 regressions
- [x] CI YAML validates (`check yaml` pre-commit hook passed)
- [ ] `npx playwright test tests/e2e/auth-flow.spec.js --project=chromium --headed` — test 060 (runs in CI via `e2e-chrome` job)

Closes #442, closes #443, closes #444, closes #404
Ref #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)