### PR TITLE
test(unit): add content-safety and content-check unit tests

### DIFF
--- a/tests/unit/chrome/content-check.test.js
+++ b/tests/unit/chrome/content-check.test.js
@@ -1,0 +1,101 @@
+/**
+ * Unit Tests for Chrome content-check.js
+ * Issue #104 - Age-Restricted Content Detection
+ * Issue #162 - NoArchive Transform Layer
+ *
+ * content-check.js is a content script injected into pages.
+ * It has no module.exports and depends on DOM APIs (document.querySelector).
+ * Tests use source-string verification since JSDOM lacks full innerText support.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const extensionDir = path.resolve(__dirname, '../../../extensions/chrome');
+
+const contentCheckSource = fs.readFileSync(path.join(extensionDir, 'content-check.js'), 'utf-8');
+
+describe('Content Check File (Chrome)', () => {
+  it('content-check.js file exists and is non-empty', () => {
+    expect(contentCheckSource.length).toBeGreaterThan(0);
+  });
+});
+
+describe('checkPageRating function (Chrome)', () => {
+  it('source contains checkPageRating function', () => {
+    expect(contentCheckSource).toContain('function checkPageRating()');
+  });
+
+  it('queries for rating meta tag', () => {
+    expect(contentCheckSource).toContain('meta[name="rating"]');
+  });
+
+  it('returns RATING_CHECK type', () => {
+    expect(contentCheckSource).toContain("type: 'RATING_CHECK'");
+  });
+
+  it('returns isRestricted and ratingValue fields', () => {
+    expect(contentCheckSource).toContain('isRestricted:');
+    expect(contentCheckSource).toContain('ratingValue:');
+  });
+});
+
+describe('isAgeRestrictedInline function (Chrome)', () => {
+  it('source contains inline age restriction check', () => {
+    expect(contentCheckSource).toContain('function isAgeRestrictedInline(ratingContent)');
+  });
+
+  it('checks for adult rating', () => {
+    expect(contentCheckSource).toContain("ADULT_RATING = 'adult'");
+  });
+
+  it('checks for RTA label pattern', () => {
+    expect(contentCheckSource).toContain("RTA_LABEL_PATTERN = 'rta-5042-1996-1400-1577-rta'");
+  });
+
+  it('normalizes input with toLowerCase and trim', () => {
+    expect(contentCheckSource).toContain('.toLowerCase()');
+    expect(contentCheckSource).toContain('.trim()');
+  });
+
+  it('validates string type before checking', () => {
+    expect(contentCheckSource).toContain("typeof ratingContent !== 'string'");
+  });
+});
+
+describe('checkNoArchive function (Chrome)', () => {
+  it('source contains checkNoArchive function', () => {
+    expect(contentCheckSource).toContain('function checkNoArchive()');
+  });
+
+  it('queries both robots and googlebot meta tags', () => {
+    expect(contentCheckSource).toContain('meta[name="robots"]');
+    expect(contentCheckSource).toContain('meta[name="googlebot"]');
+  });
+
+  it('checks for noarchive directive', () => {
+    expect(contentCheckSource).toContain("'noarchive'");
+  });
+});
+
+describe('checkPageSignals function (Chrome)', () => {
+  it('source contains checkPageSignals entry point', () => {
+    expect(contentCheckSource).toContain('function checkPageSignals()');
+  });
+
+  it('returns PAGE_SIGNALS type', () => {
+    expect(contentCheckSource).toContain("type: 'PAGE_SIGNALS'");
+  });
+
+  it('includes noarchive in result', () => {
+    expect(contentCheckSource).toContain('noarchive: checkNoArchive()');
+  });
+
+  it('script auto-executes at end for injection', () => {
+    expect(contentCheckSource).toContain('checkPageSignals();');
+  });
+});

--- a/tests/unit/chrome/content-safety.test.js
+++ b/tests/unit/chrome/content-safety.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit Tests for Chrome content-safety.js
+ * Issue #104 - Age-Restricted Content Detection
+ *
+ * Tests the pure isAgeRestricted function with no DOM dependencies.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const extensionDir = path.resolve(__dirname, '../../../extensions/chrome');
+
+// content-safety.js exports via module.exports
+const { isAgeRestricted, RTA_LABEL_PATTERN, ADULT_RATING } = await import(
+  `file://${path.join(extensionDir, 'content-safety.js')}`
+    .replace(/\\/g, '/')
+).catch(() => {
+  // Fallback: require() for CommonJS
+  return require(path.join(extensionDir, 'content-safety.js'));
+});
+
+describe('isAgeRestricted', () => {
+  it('returns false for null', () => {
+    expect(isAgeRestricted(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isAgeRestricted(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isAgeRestricted('')).toBe(false);
+  });
+
+  it('returns false for non-string input', () => {
+    expect(isAgeRestricted(42)).toBe(false);
+    expect(isAgeRestricted({})).toBe(false);
+  });
+
+  it('returns true for "adult" (exact match)', () => {
+    expect(isAgeRestricted('adult')).toBe(true);
+  });
+
+  it('returns true for "Adult" (case insensitive)', () => {
+    expect(isAgeRestricted('Adult')).toBe(true);
+    expect(isAgeRestricted('ADULT')).toBe(true);
+  });
+
+  it('returns true for " adult " (whitespace trimming)', () => {
+    expect(isAgeRestricted(' adult ')).toBe(true);
+  });
+
+  it('returns false for "mature" (fail open)', () => {
+    expect(isAgeRestricted('mature')).toBe(false);
+  });
+
+  it('returns false for "general"', () => {
+    expect(isAgeRestricted('general')).toBe(false);
+  });
+
+  it('returns true for string containing RTA pattern', () => {
+    expect(isAgeRestricted('rta-5042-1996-1400-1577-rta')).toBe(true);
+  });
+
+  it('returns true for RTA pattern with surrounding text', () => {
+    expect(isAgeRestricted('prefix rta-5042-1996-1400-1577-rta suffix')).toBe(true);
+  });
+
+  it('returns false for partial RTA pattern', () => {
+    expect(isAgeRestricted('rta-5042')).toBe(false);
+    expect(isAgeRestricted('rta-5042-1996')).toBe(false);
+  });
+});
+
+describe('Constants', () => {
+  it('exports RTA_LABEL_PATTERN', () => {
+    expect(RTA_LABEL_PATTERN).toBe('rta-5042-1996-1400-1577-rta');
+  });
+
+  it('exports ADULT_RATING', () => {
+    expect(ADULT_RATING).toBe('adult');
+  });
+});

--- a/tests/unit/firefox/content-check.test.js
+++ b/tests/unit/firefox/content-check.test.js
@@ -1,0 +1,100 @@
+/**
+ * Unit Tests for Firefox content-check.js
+ * Issue #104 - Age-Restricted Content Detection
+ * Issue #162 - NoArchive Transform Layer
+ *
+ * Firefox mirror of chrome/content-check.test.js.
+ * Source files are functionally identical across browsers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const extensionDir = path.resolve(__dirname, '../../../extensions/firefox');
+
+const contentCheckSource = fs.readFileSync(path.join(extensionDir, 'content-check.js'), 'utf-8');
+
+describe('Content Check File (Firefox)', () => {
+  it('content-check.js file exists and is non-empty', () => {
+    expect(contentCheckSource.length).toBeGreaterThan(0);
+  });
+});
+
+describe('checkPageRating function (Firefox)', () => {
+  it('source contains checkPageRating function', () => {
+    expect(contentCheckSource).toContain('function checkPageRating()');
+  });
+
+  it('queries for rating meta tag', () => {
+    expect(contentCheckSource).toContain('meta[name="rating"]');
+  });
+
+  it('returns RATING_CHECK type', () => {
+    expect(contentCheckSource).toContain("type: 'RATING_CHECK'");
+  });
+
+  it('returns isRestricted and ratingValue fields', () => {
+    expect(contentCheckSource).toContain('isRestricted:');
+    expect(contentCheckSource).toContain('ratingValue:');
+  });
+});
+
+describe('isAgeRestrictedInline function (Firefox)', () => {
+  it('source contains inline age restriction check', () => {
+    expect(contentCheckSource).toContain('function isAgeRestrictedInline(ratingContent)');
+  });
+
+  it('checks for adult rating', () => {
+    expect(contentCheckSource).toContain("ADULT_RATING = 'adult'");
+  });
+
+  it('checks for RTA label pattern', () => {
+    expect(contentCheckSource).toContain("RTA_LABEL_PATTERN = 'rta-5042-1996-1400-1577-rta'");
+  });
+
+  it('normalizes input with toLowerCase and trim', () => {
+    expect(contentCheckSource).toContain('.toLowerCase()');
+    expect(contentCheckSource).toContain('.trim()');
+  });
+
+  it('validates string type before checking', () => {
+    expect(contentCheckSource).toContain("typeof ratingContent !== 'string'");
+  });
+});
+
+describe('checkNoArchive function (Firefox)', () => {
+  it('source contains checkNoArchive function', () => {
+    expect(contentCheckSource).toContain('function checkNoArchive()');
+  });
+
+  it('queries both robots and googlebot meta tags', () => {
+    expect(contentCheckSource).toContain('meta[name="robots"]');
+    expect(contentCheckSource).toContain('meta[name="googlebot"]');
+  });
+
+  it('checks for noarchive directive', () => {
+    expect(contentCheckSource).toContain("'noarchive'");
+  });
+});
+
+describe('checkPageSignals function (Firefox)', () => {
+  it('source contains checkPageSignals entry point', () => {
+    expect(contentCheckSource).toContain('function checkPageSignals()');
+  });
+
+  it('returns PAGE_SIGNALS type', () => {
+    expect(contentCheckSource).toContain("type: 'PAGE_SIGNALS'");
+  });
+
+  it('includes noarchive in result', () => {
+    expect(contentCheckSource).toContain('noarchive: checkNoArchive()');
+  });
+
+  it('script auto-executes at end for injection', () => {
+    expect(contentCheckSource).toContain('checkPageSignals();');
+  });
+});

--- a/tests/unit/firefox/content-safety.test.js
+++ b/tests/unit/firefox/content-safety.test.js
@@ -1,0 +1,74 @@
+/**
+ * Unit Tests for Firefox content-safety.js
+ * Issue #104 - Age-Restricted Content Detection
+ *
+ * Firefox mirror of chrome/content-safety.test.js.
+ * Source files are identical across browsers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const extensionDir = path.resolve(__dirname, '../../../extensions/firefox');
+
+const { isAgeRestricted, RTA_LABEL_PATTERN, ADULT_RATING } = await import(
+  `file://${path.join(extensionDir, 'content-safety.js')}`
+    .replace(/\\/g, '/')
+).catch(() => {
+  return require(path.join(extensionDir, 'content-safety.js'));
+});
+
+describe('isAgeRestricted (Firefox)', () => {
+  it('returns false for null', () => {
+    expect(isAgeRestricted(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isAgeRestricted(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isAgeRestricted('')).toBe(false);
+  });
+
+  it('returns false for non-string input', () => {
+    expect(isAgeRestricted(42)).toBe(false);
+  });
+
+  it('returns true for "adult"', () => {
+    expect(isAgeRestricted('adult')).toBe(true);
+  });
+
+  it('returns true for "Adult" (case insensitive)', () => {
+    expect(isAgeRestricted('Adult')).toBe(true);
+  });
+
+  it('returns true for " adult " (whitespace trimming)', () => {
+    expect(isAgeRestricted(' adult ')).toBe(true);
+  });
+
+  it('returns false for "mature" (fail open)', () => {
+    expect(isAgeRestricted('mature')).toBe(false);
+  });
+
+  it('returns true for RTA pattern', () => {
+    expect(isAgeRestricted('rta-5042-1996-1400-1577-rta')).toBe(true);
+  });
+
+  it('returns false for partial RTA pattern', () => {
+    expect(isAgeRestricted('rta-5042')).toBe(false);
+  });
+});
+
+describe('Constants (Firefox)', () => {
+  it('exports RTA_LABEL_PATTERN', () => {
+    expect(RTA_LABEL_PATTERN).toBe('rta-5042-1996-1400-1577-rta');
+  });
+
+  it('exports ADULT_RATING', () => {
+    expect(ADULT_RATING).toBe('adult');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `content-safety.js` (Chrome + Firefox) — tests `isAgeRestricted` pure function
- Adds unit tests for `content-check.js` (Chrome + Firefox) — source-string verification of DOM-dependent content script

## Test plan
- [ ] `npx vitest run tests/unit/chrome/content-safety.test.js` passes
- [ ] `npx vitest run tests/unit/firefox/content-safety.test.js` passes
- [ ] `npx vitest run tests/unit/chrome/content-check.test.js` passes
- [ ] `npx vitest run tests/unit/firefox/content-check.test.js` passes

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)