### PR TITLE
chore(ci): add issue ref to Edge continue-on-error

### DIFF
--- a/.github/workflows/e2e-edge.yml
+++ b/.github/workflows/e2e-edge.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Prevent stalled browser hangs
     # Warn-only initially - remove after baseline established
-    continue-on-error: true
+    continue-on-error: true  # ref #455 — remove after exit criteria met
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Adds `ref #455` comment to `continue-on-error: true` in Edge E2E workflow
- Documents exit criteria: remove after Edge tests pass 10 consecutive runs

## Test plan
- [ ] YAML is valid (pre-commit hook passes)
- [ ] Edge E2E workflow still runs with continue-on-error

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)