### PR TITLE
chore: update firefox-api.mock.js with notifications API

### DIFF
--- a/tests/mocks/firefox-api.mock.js
+++ b/tests/mocks/firefox-api.mock.js
@@ -211,6 +211,13 @@ export function createFirefoxMock(options = {}) {
       })
     },
 
+    // Issue #391: Notifications API mock
+    notifications: {
+      create: vi.fn().mockImplementation(() => {
+        return Promise.resolve('mock-notification-id');
+      })
+    },
+
     // Storage API
     storage: {
       // Local storage (persists)


### PR DESCRIPTION
## Summary
- Adds `browser.notifications.create` mock to `firefox-api.mock.js`
- Matches the API used by service-worker.js for error notifications

## Test plan
- [ ] Existing Firefox unit tests still pass
- [ ] Mock is available via `browser.notifications.create`

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)