### PR TITLE
docs: document Edge visual baseline exclusion

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -96,6 +96,8 @@ module.exports = defineConfig({
         },
         {
             // Issue #263: Edge E2E test matrix
+            // Visual baselines: Edge shares Chromium rendering engine;
+            // separate baselines not needed (ref #458)
             name: 'edge',
             use: {
                 channel: 'msedge',


### PR DESCRIPTION
## Summary
- Adds comment in `playwright.config.js` documenting why Edge does not need separate visual baselines
- Edge shares Chromium rendering engine, so baselines would be duplicates

## Test plan
- [ ] Playwright config still loads correctly

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)