### PR TITLE
chore(ci): add Codecov coverage threshold enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   extension-lint:
     needs: policy-check  # Only run if policy check passes

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+# Codecov configuration — ref #459
+# See: https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 5%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Sets `fail_ci_if_error: true` on Codecov upload step in `ci.yml`
- Adds `codecov.yml` with 70% project target and 80% patch target

## Test plan
- [ ] CI workflow still runs correctly
- [ ] Codecov enforces thresholds on new PRs

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)