### PR TITLE
ci: add post-deploy smoke test after infrastructure deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,35 @@ jobs:
       - name: Deploy Infrastructure
         run: ./provision.sh
 
+  # Post-deploy smoke test - verify API health after infrastructure deployment
+  # Catches misconfigurations (e.g. AUTH_ENABLED=true before extension auth is ready)
+  post-deploy-smoke:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: deploy-infra
+    runs-on: ubuntu-latest
+    steps:
+      - name: Health check
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' https://api.aletheia.study/health)
+          echo "Health: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "FAIL: Health endpoint returned $HTTP_STATUS"
+            exit 1
+          fi
+
+      - name: Analysis endpoint (AUTH_ENABLED guard)
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            -X POST https://api.aletheia.study/ \
+            -H 'Content-Type: application/json' \
+            -H 'X-Aletheia-Client-Version: 1.0' \
+            -d '{"text":"smoke test"}')
+          echo "Analysis: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "401" ]; then
+            echo "FAIL: AUTH_ENABLED=true detected — extension auth not verified"
+            exit 1
+          fi
+
   # Compliance audit - runs on push to main AND nightly schedule
   # Requires AWS credentials to verify Bedrock configuration
   compliance-audit:

--- a/docs/reports/404/implementation-report.md
+++ b/docs/reports/404/implementation-report.md
@@ -1,0 +1,25 @@
+# Implementation Report — Issue #404: Post-Deploy Smoke Test
+
+## Summary
+
+Added `post-deploy-smoke` job to `.github/workflows/ci.yml` that runs after `deploy-infra` on pushes to main. The job performs two HTTP checks against the production API:
+
+1. **Health check** — `GET /health` must return 200
+2. **AUTH_ENABLED guard** — `POST /` must not return 401 (catches premature auth enablement)
+
+## Design Decisions
+
+- **Pure curl, no checkout** — the job needs no code, just HTTP access to the production API
+- **Only fails on 401** — 429 (rate limit) and 403 (blocked term) are acceptable; they indicate the API is functioning correctly
+- **Runs only on main push** — mirrors `deploy-infra` condition since it's verifying that deployment
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | Added `post-deploy-smoke` job between `deploy-infra` and `compliance-audit` |
+
+## Risk Assessment
+
+- **Blast radius:** CI only — no production changes
+- **Rollback:** Revert the commit

--- a/docs/reports/404/test-report.md
+++ b/docs/reports/404/test-report.md
@@ -1,0 +1,18 @@
+# Test Report — Issue #404: Post-Deploy Smoke Test
+
+## Test Strategy
+
+This is a CI workflow change (YAML only). No unit tests are applicable. Verification is:
+
+1. **YAML validity** — Parsed successfully with Python yaml.safe_load
+2. **Job structure** — `post-deploy-smoke` has correct `if`, `needs`, and `runs-on`
+3. **Integration** — Will run on next push to main; health check and analysis endpoint verified
+
+## Verification Checklist
+
+- [x] YAML syntax valid
+- [x] `post-deploy-smoke.needs: deploy-infra` — runs after deploy
+- [x] `post-deploy-smoke.if` — only on push to main
+- [x] Health check step curls `/health` and fails on non-200
+- [x] Analysis step curls `POST /` and fails on 401
+- [x] No existing tests broken (no code changes)


### PR DESCRIPTION
## Summary
- Adds `post-deploy-smoke` CI job that runs after `deploy-infra` on pushes to main
- Health check (`GET /health`) fails the pipeline if non-200
- AUTH_ENABLED guard (`POST /`) fails on 401 to catch premature auth enablement

Closes #404

## Test plan
- [x] YAML syntax validated
- [x] Job structure correct (`needs: deploy-infra`, main-only condition)
- [ ] Verify job appears in CI after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)