### PR TITLE
fix: Firefox OAuth persistent state survives SW restart

### DIFF
--- a/docs/reports/396/implementation-report.md
+++ b/docs/reports/396/implementation-report.md
@@ -1,0 +1,49 @@
+# Implementation Report — Issue #396: Firefox OAuth Persistent State Fix
+
+## Summary
+
+Replaced closure-based OAuth tab listeners in Firefox service-worker.js with a persistent state pattern using `chrome.storage.session` and top-level event listeners. This fixes the bug where Firefox background script suspension kills dynamic listeners, causing token storage to silently fail after long OAuth flows.
+
+## Root Cause
+
+The START_OAUTH handler registered `chrome.tabs.onUpdated` and `chrome.tabs.onRemoved` listeners **inside** an async closure. These dynamic listeners:
+1. Captured `tab.id`, `state`, `callbackUrl`, `sendResponse` in closures
+2. Did not survive Firefox background script suspension/restart
+3. Silently failed if the user took >30s on the LinkedIn auth page
+
+## Fix: Persistent State Pattern
+
+### Architecture Change
+
+**Before:** Message handler → open tab → register dynamic listeners → wait for callback → exchange tokens → sendResponse
+**After:** Message handler → open tab → store `pendingOAuth` in session storage → sendResponse immediately. Top-level `onUpdated` listener → read `pendingOAuth` → detect callback → exchange tokens → store tokens → clear `pendingOAuth`
+
+### Why This Works
+
+- **Top-level listeners** are re-registered every time the SW starts
+- **`pendingOAuth`** state persists in `chrome.storage.session` across SW restarts
+- **Popup already handles disconnected errors** (`popup.js:346-349`) — user reopens popup to see auth status
+- **5-minute stale check** prevents zombie OAuth flows from processing old callbacks
+- **`chrome.*` namespace** works identically in Firefox MV3 140+ (returns Promises)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `extensions/firefox/service-worker.js` | Fixed header comments; added top-level `onUpdated`/`onRemoved` OAuth listeners; rewrote START_OAUTH handler to use persistent state |
+| `tests/unit/firefox/service-worker.test.js` | Rewrote 8 START_OAUTH tests for persistent state pattern |
+
+## Files NOT Changed
+
+| File | Why |
+|------|-----|
+| `extensions/firefox/auth.js` | Already delegates correctly via `browser.runtime.sendMessage` |
+| `extensions/firefox/popup.js` | Already handles `disconnected` error and checks `isAuthenticated()` on reopen |
+| `extensions/chrome/service-worker.js` | Chrome uses `chrome.identity.launchWebAuthFlow` — no popup closure issue |
+| `tests/mocks/firefox-api.mock.js` | Existing mock supports all needed APIs |
+
+## Risk Assessment
+
+- **Blast radius:** Firefox extension only — Chrome unaffected
+- **Rollback:** Revert the commit
+- **Manual verification:** Requires AUTH_ENABLED=true (deferred to #405)

--- a/docs/reports/396/test-report.md
+++ b/docs/reports/396/test-report.md
@@ -1,0 +1,35 @@
+# Test Report — Issue #396: Firefox OAuth Persistent State Fix
+
+## Test Results
+
+### Firefox Service Worker Tests
+```
+35 passed | 0 failed
+```
+
+### Full Unit Suite
+```
+15 test files | 368 passed | 4 skipped | 0 failed
+```
+
+## START_OAUTH Test Coverage (8 tests)
+
+| Test | Verifies |
+|------|----------|
+| opens auth tab with correct URL | `chrome.tabs.create` called with authUrl |
+| stores pendingOAuth in session storage | `chrome.storage.session.set` called with `{ pendingOAuth: { tabId, state, callbackUrl, lambdaAuthUrl, startedAt } }` |
+| top-level listener detects callback and stores tokens | Simulate tab update → fetch token exchange → session/local storage set → pendingOAuth cleared |
+| validates CSRF state | Mismatched state → no fetch, pendingOAuth cleared |
+| clears pendingOAuth when tab closed | Simulate tab removed → `storage.session.remove('pendingOAuth')` called |
+| detects stale OAuth (>5 min) | Old `startedAt` → no fetch, pendingOAuth cleared |
+| handles token exchange failure | Mock fetch 500 → pendingOAuth cleared, no tokens stored |
+| ignores tab updates with no pendingOAuth | Tab update without START_OAUTH → no errors, no fetch |
+| stale check uses 5-minute threshold from source | Source code contains timeout constant |
+
+## Verification Checklist
+
+- [x] Firefox SW tests: 35/35 pass
+- [x] Full unit suite: 368 pass, 0 fail
+- [x] No mock changes needed
+- [x] Chrome tests unaffected
+- [ ] Manual Firefox testbook TC-05 (requires AUTH_ENABLED=true, deferred to #405)

--- a/extensions/firefox/service-worker.js
+++ b/extensions/firefox/service-worker.js
@@ -1,5 +1,5 @@
-// extensions/chrome/service-worker.js
-// Chrome Manifest V3 version
+// extensions/firefox/service-worker.js
+// Firefox Manifest V3 version
 
 // [CV-7] CONSTANTS - WIRED TO CLOUDFLARE (Worker-proxied, rate-limited)
 // Direct Lambda URL: https://sqrqfnypgswudwtcheeasq5xri0aryfx.lambda-url.us-east-1.on.aws/
@@ -144,6 +144,125 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 });
 
 // =============================================================================
+// OAUTH TAB LISTENERS (Issue #396 - Persistent State)
+// Top-level listeners survive Firefox background script suspension/restart.
+// State is stored in chrome.storage.session as `pendingOAuth`.
+// =============================================================================
+
+// Issue #396: Detect OAuth callback in auth tab
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    // Only process 'complete' status changes
+    if (changeInfo.status !== 'complete') return;
+
+    (async () => {
+        try {
+            const { pendingOAuth } = await chrome.storage.session.get('pendingOAuth');
+            if (!pendingOAuth) return;
+            if (tabId !== pendingOAuth.tabId) return;
+
+            // Stale check: ignore if older than 5 minutes
+            if (Date.now() - pendingOAuth.startedAt > 5 * 60 * 1000) {
+                console.log('[Aletheia Auth SW] Stale OAuth detected, clearing');
+                await chrome.storage.session.remove('pendingOAuth');
+                chrome.tabs.remove(tabId).catch(() => {});
+                return;
+            }
+
+            // Check if this tab navigated to the callback URL
+            if (!tab.url || !tab.url.startsWith(pendingOAuth.callbackUrl)) return;
+
+            // Parse the callback URL
+            const url = new URL(tab.url);
+            const code = url.searchParams.get('code');
+            const returnedState = url.searchParams.get('state');
+            const error = url.searchParams.get('error');
+            const errorDesc = url.searchParams.get('error_description');
+
+            // Close the auth tab
+            chrome.tabs.remove(tabId).catch(() => {});
+
+            if (error) {
+                console.error('[Aletheia Auth SW] OAuth error:', errorDesc || error);
+                await chrome.storage.session.remove('pendingOAuth');
+                return;
+            }
+
+            if (!code) {
+                console.error('[Aletheia Auth SW] No authorization code received');
+                await chrome.storage.session.remove('pendingOAuth');
+                return;
+            }
+
+            // Validate CSRF state
+            if (returnedState !== pendingOAuth.state) {
+                console.error('[Aletheia Auth SW] CSRF detected: state mismatch');
+                await chrome.storage.session.remove('pendingOAuth');
+                return;
+            }
+
+            // Exchange code for tokens
+            console.log('[Aletheia Auth SW] Exchanging code for tokens...');
+            const tokenResponse = await fetch(
+                `${pendingOAuth.lambdaAuthUrl}/auth/token`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        code: code,
+                        redirectUri: pendingOAuth.callbackUrl
+                    })
+                }
+            );
+
+            if (!tokenResponse.ok) {
+                const errorData = await tokenResponse.json().catch(() => ({}));
+                console.error('[Aletheia Auth SW] Token exchange failed:', errorData.error || tokenResponse.status);
+                await chrome.storage.session.remove('pendingOAuth');
+                return;
+            }
+
+            const tokenData = await tokenResponse.json();
+
+            // Store tokens
+            await chrome.storage.session.set({
+                accessToken: tokenData.accessToken,
+                expiresAt: Date.now() + (tokenData.expiresIn * 1000),
+                jwt: tokenData.jwt || null
+            });
+
+            await chrome.storage.local.set({
+                refreshToken: tokenData.refreshToken,
+                userId: tokenData.user.id,
+                displayName: tokenData.user.name
+            });
+
+            // Clear pending state
+            await chrome.storage.session.remove('pendingOAuth');
+
+            console.log('[Aletheia Auth SW] Login successful:', tokenData.user.name);
+        } catch (error) {
+            console.error('[Aletheia Auth SW] OAuth callback error:', error);
+            await chrome.storage.session.remove('pendingOAuth').catch(() => {});
+        }
+    })();
+});
+
+// Issue #396: Clean up pendingOAuth when auth tab is closed by user
+chrome.tabs.onRemoved.addListener((tabId) => {
+    (async () => {
+        try {
+            const { pendingOAuth } = await chrome.storage.session.get('pendingOAuth');
+            if (pendingOAuth && pendingOAuth.tabId === tabId) {
+                console.log('[Aletheia Auth SW] Auth tab closed, clearing pendingOAuth');
+                await chrome.storage.session.remove('pendingOAuth');
+            }
+        } catch (_e) {
+            // Ignore - tab may have been removed during shutdown
+        }
+    })();
+});
+
+// =============================================================================
 // MESSAGE HANDLERS (Issue #104 - Popup Communication)
 // Security: ADR 0213 - Validate sender.id to prevent message spoofing
 // =============================================================================
@@ -228,114 +347,41 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true; // Will respond asynchronously
     }
 
-    // Issue #396: OAuth flow — run in service worker so popup can close safely
+    // Issue #396: OAuth flow — open auth tab and store persistent state
+    // Top-level onUpdated listener handles callback detection (survives SW restart)
     if (message.type === 'START_OAUTH') {
         (async () => {
             try {
-                const { authUrl, callbackUrl, state } = message;
+                const { authUrl, callbackUrl, state, lambdaAuthUrl } = message;
 
                 // 1. Open LinkedIn auth tab
                 const tab = await chrome.tabs.create({ url: authUrl });
                 console.log('[Aletheia Auth SW] Opened auth tab:', tab.id);
 
-                // 2. Wait for callback URL via tab listener (persists in service worker)
-                const result = await new Promise((resolve, reject) => {
-                    const timeout = setTimeout(() => {
-                        chrome.tabs.onUpdated.removeListener(listener);
-                        chrome.tabs.onRemoved.removeListener(removedListener);
-                        reject(new Error('OAuth timeout: 5 minutes'));
-                    }, 5 * 60 * 1000);
-
-                    const removedListener = (removedTabId) => {
-                        if (removedTabId === tab.id) {
-                            clearTimeout(timeout);
-                            chrome.tabs.onUpdated.removeListener(listener);
-                            chrome.tabs.onRemoved.removeListener(removedListener);
-                            reject(new Error('OAuth cancelled: tab closed'));
-                        }
-                    };
-
-                    const listener = (updatedTabId, changeInfo, updatedTab) => {
-                        if (updatedTabId !== tab.id) return;
-                        if (changeInfo.status !== 'complete') return;
-                        if (!updatedTab.url || !updatedTab.url.startsWith(callbackUrl)) return;
-
-                        clearTimeout(timeout);
-                        chrome.tabs.onUpdated.removeListener(listener);
-                        chrome.tabs.onRemoved.removeListener(removedListener);
-
-                        try {
-                            const url = new URL(updatedTab.url);
-                            const code = url.searchParams.get('code');
-                            const returnedState = url.searchParams.get('state');
-                            const error = url.searchParams.get('error');
-                            const errorDesc = url.searchParams.get('error_description');
-
-                            chrome.tabs.remove(tab.id).catch(() => {});
-
-                            if (error) {
-                                reject(new Error(errorDesc || error));
-                            } else if (!code) {
-                                reject(new Error('No authorization code received'));
-                            } else {
-                                resolve({ code, returnedState });
-                            }
-                        } catch (_e) {
-                            reject(new Error('Failed to parse callback URL'));
-                        }
-                    };
-
-                    chrome.tabs.onUpdated.addListener(listener);
-                    chrome.tabs.onRemoved.addListener(removedListener);
-                });
-
-                // 3. Validate CSRF state
-                if (result.returnedState !== state) {
-                    sendResponse({ success: false, error: 'CSRF detected: state mismatch' });
-                    return;
-                }
-
-                // 4. Exchange code for tokens
-                console.log('[Aletheia Auth SW] Exchanging code for tokens...');
-                const tokenResponse = await fetch(
-                    `${message.lambdaAuthUrl}/auth/token`,
-                    {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            code: result.code,
-                            redirectUri: callbackUrl
-                        })
-                    }
-                );
-
-                if (!tokenResponse.ok) {
-                    const errorData = await tokenResponse.json().catch(() => ({}));
-                    sendResponse({ success: false, error: errorData.error || `Token exchange failed: ${tokenResponse.status}` });
-                    return;
-                }
-
-                const tokenData = await tokenResponse.json();
-
-                // 5. Store tokens (service worker has access to storage APIs)
+                // 2. Store pending OAuth state (survives SW suspension/restart)
                 await chrome.storage.session.set({
-                    accessToken: tokenData.accessToken,
-                    expiresAt: Date.now() + (tokenData.expiresIn * 1000),
-                    jwt: tokenData.jwt || null
+                    pendingOAuth: {
+                        tabId: tab.id,
+                        state,
+                        callbackUrl,
+                        lambdaAuthUrl,
+                        startedAt: Date.now()
+                    }
                 });
 
-                await chrome.storage.local.set({
-                    refreshToken: tokenData.refreshToken,
-                    userId: tokenData.user.id,
-                    displayName: tokenData.user.name
-                });
-
-                console.log('[Aletheia Auth SW] Login successful:', tokenData.user.name);
-                sendResponse({ success: true, user: tokenData.user });
-
+                // 3. Respond immediately — popup may close, tokens arrive via top-level listener
+                try {
+                    sendResponse({ success: true, pending: true });
+                } catch (_e) {
+                    // Popup already closed — expected behavior
+                }
             } catch (error) {
-                console.error('[Aletheia Auth SW] OAuth failed:', error);
-                sendResponse({ success: false, error: error.message });
+                console.error('[Aletheia Auth SW] OAuth start failed:', error);
+                try {
+                    sendResponse({ success: false, error: error.message });
+                } catch (_e) {
+                    // Popup already closed
+                }
             }
         })();
         return true; // Will respond asynchronously

--- a/tests/unit/firefox/service-worker.test.js
+++ b/tests/unit/firefox/service-worker.test.js
@@ -621,7 +621,7 @@ describe('Error Handling (Firefox)', () => {
 });
 
 // ============================================================================
-// START_OAUTH HANDLER TESTS (Issue #396)
+// START_OAUTH HANDLER TESTS (Issue #396 — Persistent State Pattern)
 // ============================================================================
 
 describe('START_OAUTH Handler (Issue #396)', () => {
@@ -639,25 +639,6 @@ describe('START_OAUTH Handler (Issue #396)', () => {
     cleanupEnvironment();
   });
 
-  it('returns true for async response', async () => {
-    const { browserMock } = env;
-
-    const sendResponse = vi.fn();
-
-    // Get the actual registered listener
-    const listener = browserMock.runtime.onMessage.addListener.mock.calls
-      .map(call => call[0])
-      .find(fn => typeof fn === 'function');
-
-    const result = listener(
-      { type: 'START_OAUTH', authUrl: AUTH_URL, callbackUrl: CALLBACK_URL, state: CSRF_STATE, lambdaAuthUrl: LAMBDA_AUTH_URL },
-      { id: 'extension@aletheia.study' },
-      sendResponse
-    );
-
-    expect(result).toBe(true);
-  });
-
   it('opens auth tab with correct URL', async () => {
     const { browserMock } = env;
 
@@ -669,13 +650,41 @@ describe('START_OAUTH Handler (Issue #396)', () => {
       lambdaAuthUrl: LAMBDA_AUTH_URL
     });
 
-    // Wait for async tab creation
     await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(browserMock.tabs.create).toHaveBeenCalledWith({ url: AUTH_URL });
   });
 
-  it('stores tokens on successful callback', async () => {
+  it('stores pendingOAuth in session storage', async () => {
+    const { browserMock } = env;
+
+    browserMock.__simulateMessage({
+      type: 'START_OAUTH',
+      authUrl: AUTH_URL,
+      callbackUrl: CALLBACK_URL,
+      state: CSRF_STATE,
+      lambdaAuthUrl: LAMBDA_AUTH_URL
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const createdTab = await browserMock.tabs.create.mock.results[0].value;
+
+    // Verify pendingOAuth was stored with correct fields
+    expect(browserMock.storage.session.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pendingOAuth: expect.objectContaining({
+          tabId: createdTab.id,
+          state: CSRF_STATE,
+          callbackUrl: CALLBACK_URL,
+          lambdaAuthUrl: LAMBDA_AUTH_URL,
+          startedAt: expect.any(Number)
+        })
+      })
+    );
+  });
+
+  it('top-level listener detects callback and stores tokens', async () => {
     const { browserMock } = env;
 
     // Mock the token exchange endpoint
@@ -691,6 +700,7 @@ describe('START_OAUTH Handler (Issue #396)', () => {
       })
     });
 
+    // Send START_OAUTH to set up pendingOAuth state
     browserMock.__simulateMessage({
       type: 'START_OAUTH',
       authUrl: AUTH_URL,
@@ -699,10 +709,9 @@ describe('START_OAUTH Handler (Issue #396)', () => {
       lambdaAuthUrl: LAMBDA_AUTH_URL
     });
 
-    // Wait for tab creation
     await new Promise(resolve => setTimeout(resolve, 50));
 
-    // Simulate the OAuth callback - tab navigates to callback URL with code
+    // Simulate the OAuth callback via top-level tab listener
     const createdTab = await browserMock.tabs.create.mock.results[0].value;
     browserMock.__simulateTabUpdate(
       createdTab.id,
@@ -710,7 +719,7 @@ describe('START_OAUTH Handler (Issue #396)', () => {
       'complete'
     );
 
-    // Wait for token exchange
+    // Wait for async token exchange
     await new Promise(resolve => setTimeout(resolve, 200));
 
     // Verify tokens stored in session storage
@@ -729,66 +738,15 @@ describe('START_OAUTH Handler (Issue #396)', () => {
         displayName: 'Test User'
       })
     );
+
+    // Verify pendingOAuth was cleaned up
+    expect(browserMock.storage.session.remove).toHaveBeenCalledWith('pendingOAuth');
   });
 
-  it('responds with user info on success', async () => {
+  it('validates CSRF state', async () => {
     const { browserMock } = env;
 
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({
-        accessToken: 'token',
-        refreshToken: 'refresh',
-        expiresIn: 3600,
-        jwt: 'jwt',
-        user: { id: 'user-456', name: 'Jane Doe' }
-      })
-    });
-
-    browserMock.__simulateMessage({
-      type: 'START_OAUTH',
-      authUrl: AUTH_URL,
-      callbackUrl: CALLBACK_URL,
-      state: CSRF_STATE,
-      lambdaAuthUrl: LAMBDA_AUTH_URL
-    });
-
-    await new Promise(resolve => setTimeout(resolve, 50));
-
-    const createdTab = await browserMock.tabs.create.mock.results[0].value;
-    browserMock.__simulateTabUpdate(
-      createdTab.id,
-      `${CALLBACK_URL}?code=code&state=${CSRF_STATE}`,
-      'complete'
-    );
-
-    // Wait for the full async chain
-    await new Promise(resolve => setTimeout(resolve, 200));
-
-    // Verify user info was stored (indicates successful flow)
-    expect(browserMock.storage.local.set).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: 'user-456',
-        displayName: 'Jane Doe'
-      })
-    );
-  });
-
-  it('rejects on CSRF state mismatch', async () => {
-    const { browserMock } = env;
-
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({
-        accessToken: 'token',
-        refreshToken: 'refresh',
-        expiresIn: 3600,
-        jwt: 'jwt',
-        user: { id: 'user', name: 'User' }
-      })
-    });
+    global.fetch = vi.fn();
 
     browserMock.__simulateMessage({
       type: 'START_OAUTH',
@@ -809,11 +767,15 @@ describe('START_OAUTH Handler (Issue #396)', () => {
       'complete'
     );
 
-    // Wait for async processing
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    // Token exchange should not store tokens since state mismatches
-    // The handler sends error response with 'CSRF detected'
+    // Token exchange should NOT have been called
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // pendingOAuth should be cleared
+    expect(browserMock.storage.session.remove).toHaveBeenCalledWith('pendingOAuth');
+
+    // No access tokens stored
     const sessionSetCalls = browserMock.storage.session.set.mock.calls;
     const hasAccessToken = sessionSetCalls.some(call =>
       call[0] && call[0].accessToken !== undefined
@@ -821,7 +783,7 @@ describe('START_OAUTH Handler (Issue #396)', () => {
     expect(hasAccessToken).toBe(false);
   });
 
-  it('handles tab closure (OAuth cancelled)', async () => {
+  it('clears pendingOAuth when tab closed', async () => {
     const { browserMock } = env;
 
     browserMock.__simulateMessage({
@@ -836,13 +798,15 @@ describe('START_OAUTH Handler (Issue #396)', () => {
 
     const createdTab = await browserMock.tabs.create.mock.results[0].value;
 
-    // Simulate tab being closed by user (OAuth cancelled)
+    // Simulate tab being closed by user
     browserMock.__triggerTabRemoved(createdTab.id);
 
-    // Wait for error handling
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    // Should not have stored any tokens
+    // pendingOAuth should be cleared
+    expect(browserMock.storage.session.remove).toHaveBeenCalledWith('pendingOAuth');
+
+    // No tokens stored
     const sessionSetCalls = browserMock.storage.session.set.mock.calls;
     const hasAccessToken = sessionSetCalls.some(call =>
       call[0] && call[0].accessToken !== undefined
@@ -850,9 +814,98 @@ describe('START_OAUTH Handler (Issue #396)', () => {
     expect(hasAccessToken).toBe(false);
   });
 
-  it('times out after 5 minutes', () => {
-    // Verify the source code contains the 5-minute timeout
+  it('detects stale OAuth (>5 min)', async () => {
+    const { browserMock } = env;
+
+    global.fetch = vi.fn();
+
+    // Manually set pendingOAuth with old startedAt (6 minutes ago)
+    browserMock.__setSessionStorageData({
+      pendingOAuth: {
+        tabId: 100,
+        state: CSRF_STATE,
+        callbackUrl: CALLBACK_URL,
+        lambdaAuthUrl: LAMBDA_AUTH_URL,
+        startedAt: Date.now() - (6 * 60 * 1000)
+      }
+    });
+
+    // Simulate tab update matching the callback URL
+    browserMock.__simulateTabUpdate(
+      100,
+      `${CALLBACK_URL}?code=code&state=${CSRF_STATE}`,
+      'complete'
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Token exchange should NOT have been called (stale)
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // pendingOAuth should be cleared
+    expect(browserMock.storage.session.remove).toHaveBeenCalledWith('pendingOAuth');
+  });
+
+  it('handles token exchange failure', async () => {
+    const { browserMock } = env;
+
+    // Mock failed token exchange
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Internal server error' })
+    });
+
+    browserMock.__simulateMessage({
+      type: 'START_OAUTH',
+      authUrl: AUTH_URL,
+      callbackUrl: CALLBACK_URL,
+      state: CSRF_STATE,
+      lambdaAuthUrl: LAMBDA_AUTH_URL
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const createdTab = await browserMock.tabs.create.mock.results[0].value;
+    browserMock.__simulateTabUpdate(
+      createdTab.id,
+      `${CALLBACK_URL}?code=code&state=${CSRF_STATE}`,
+      'complete'
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // pendingOAuth should be cleared even on failure
+    expect(browserMock.storage.session.remove).toHaveBeenCalledWith('pendingOAuth');
+
+    // No access tokens stored
+    const sessionSetCalls = browserMock.storage.session.set.mock.calls;
+    const hasAccessToken = sessionSetCalls.some(call =>
+      call[0] && call[0].accessToken !== undefined
+    );
+    expect(hasAccessToken).toBe(false);
+  });
+
+  it('ignores tab updates with no pendingOAuth', async () => {
+    const { browserMock } = env;
+
+    global.fetch = vi.fn();
+
+    // Simulate a tab update without any START_OAUTH — no pendingOAuth in storage
+    browserMock.__simulateTabUpdate(
+      1,
+      `${CALLBACK_URL}?code=code&state=${CSRF_STATE}`,
+      'complete'
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // No fetch calls, no errors, no token storage
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('stale check uses 5-minute threshold from source', () => {
     expect(serviceWorkerSource).toContain('5 * 60 * 1000');
-    expect(serviceWorkerSource).toContain('OAuth timeout');
+    expect(serviceWorkerSource).toContain('Stale OAuth');
   });
 });


### PR DESCRIPTION
## Summary
- Replaces closure-based dynamic `onUpdated`/`onRemoved` listeners with storage-backed `pendingOAuth` state and top-level listeners
- Top-level listeners survive Firefox background script suspension/restart
- 5-minute stale check prevents zombie OAuth flows
- Popup already handles disconnected errors — user reopens to see auth status

Closes #396

## Test plan
- [x] Firefox SW unit tests: 35/35 pass
- [x] Full unit suite: 368 pass, 0 fail, no regressions
- [x] Chrome tests unaffected (separate `chrome.identity` flow)
- [ ] Manual Firefox testbook TC-05 (requires AUTH_ENABLED=true, deferred to #405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)