### PR TITLE
docs: session log cleanup 2026-03-04 (#480)

### DIFF
--- a/docs/session-logs/2026-03-03.md
+++ b/docs/session-logs/2026-03-03.md
@@ -131,3 +131,35 @@ Session ended (auto-logged by stop hook)
 - Branch: main @ de1f004
 - Open PRs: 0
 - Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-03-04 01:18 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: main @ 55af037
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-03-04 01:19 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: main @ 55af037
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary

--- a/docs/session-logs/2026-03-04.md
+++ b/docs/session-logs/2026-03-04.md
@@ -4,3 +4,8 @@
 - **Mode:** full cleanup
 - **Summary:** Fixed Chrome OAuth popup death bug (delegated launchWebAuthFlow to SW), added HTTP error handling to Firefox SW, fixed 401→"Sign In Required" mapping for both browsers. PR #487 merged. All unit tests pass (367/367). E2E proof: overlay renders correctly for both auth and unauth states.
 - **Next:** Per user direction
+
+## Session: 480-oauth-fix-and-cleanup
+- **Mode:** full cleanup
+- **Summary:** Continued from previous session. Merged PR #487 (Chrome OAuth SW delegation + Firefox HTTP error handling). Cleaned up stale worktree Aletheia-480 and branches. Deleted temporary debug-*.js test files and screenshots. API health verified.
+- **Next:** Per user direction


### PR DESCRIPTION
## Summary
- Appended session 480-oauth-fix-and-cleanup entry to 2026-03-04 session log
- Stop-hook auto-appended entries to 2026-03-03 session log
- No code changes

No-Issue: batch documentation cleanup, no feature issue applies

## Test plan
- [ ] Doc-only change — no tests required