### PR TITLE
security: rotate Agent Lambda URL, remove exposed URL (close #494)

### DIFF
--- a/extensions/chrome/service-worker.js
+++ b/extensions/chrome/service-worker.js
@@ -2,7 +2,6 @@
 // Chrome Manifest V3 version
 
 // [CV-7] CONSTANTS - WIRED TO CLOUDFLARE (Worker-proxied, rate-limited)
-// Direct Lambda URL: https://sqrqfnypgswudwtcheeasq5xri0aryfx.lambda-url.us-east-1.on.aws/
 const API_ENDPOINT = "https://api.aletheia.study/";
 
 // [#95] Client version for Lambda header validation (Issue #349: moved from WAF to Lambda)

--- a/extensions/firefox/service-worker.js
+++ b/extensions/firefox/service-worker.js
@@ -2,7 +2,6 @@
 // Firefox Manifest V3 version
 
 // [CV-7] CONSTANTS - WIRED TO CLOUDFLARE (Worker-proxied, rate-limited)
-// Direct Lambda URL: https://sqrqfnypgswudwtcheeasq5xri0aryfx.lambda-url.us-east-1.on.aws/
 const API_ENDPOINT = "https://api.aletheia.study/";
 
 // [#95] Client version for Lambda header validation (Issue #349: moved from WAF to Lambda)

--- a/workers/aletheia-api/worker.js
+++ b/workers/aletheia-api/worker.js
@@ -8,7 +8,7 @@
 //
 // Issue #433: Added /admin/* and /auth/github/* routing to Auth Lambda.
 
-const AGENT_LAMBDA = "sqrqfnypgswudwtcheeasq5xri0aryfx.lambda-url.us-east-1.on.aws";
+const AGENT_LAMBDA = "vq2uf4fnxgpqpmhqsmsqe5osma0htrgs.lambda-url.us-east-1.on.aws";
 const AUTH_LAMBDA = "sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws";
 
 const AUTH_PREFIXES = ["/auth/", "/admin/", "/metrics", "/my-data", "/redeem-coupon",


### PR DESCRIPTION
Closes #494

## Summary
- Removed hardcoded AletheiaAgent Lambda Function URL from service-worker.js comments (both Chrome and Firefox)
- Rotated the Lambda Function URL — old `sqrqfn...` URL is permanently dead
- Updated CloudFlare Worker (`aletheia-api`) with the new URL
- Worker deployed and verified: `api.aletheia.study/health` returns OK

## Verification
- Old URL returns `{"Message":null}` (dead)
- `api.aletheia.study/health` returns `{"status": "ok", "version": "1.0"}`
- Analysis through CloudFlare returns 401 (AUTH_ENABLED=true, expected without JWT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)