### PR TITLE
fix: set AUTH_ENABLED=true in provision.sh (close #499)

### DIFF
--- a/docs/reports/499/implementation-report.md
+++ b/docs/reports/499/implementation-report.md
@@ -1,0 +1,10 @@
+# Implementation Report: #499 Fix AUTH_ENABLED in provision.sh
+
+## Changes
+- `provision.sh` lines 446 and 465: `AUTH_ENABLED=false` → `AUTH_ENABLED=true`
+
+## Context
+AUTH_ENABLED was already set to `true` in production via manual `aws lambda update-function-configuration`, but provision.sh still had `false`. Next provision run would have reverted it.
+
+## Runtime Fix (Manual)
+CLOUDFLARE_ORIGIN_SECRET must be set via AWS CLI (contains secret, cannot be in code/transcript). Command provided to user separately.

--- a/docs/reports/499/test-report.md
+++ b/docs/reports/499/test-report.md
@@ -1,0 +1,6 @@
+# Test Report: #499 Fix AUTH_ENABLED in provision.sh
+
+## Verification
+- Config change only — no code logic changed
+- `grep AUTH_ENABLED provision.sh` confirms both occurrences now say `true`
+- Runtime fix verified via smoke test after user runs AWS CLI command

--- a/provision.sh
+++ b/provision.sh
@@ -443,7 +443,7 @@ if ! aws lambda get-function --function-name "$FUNC_NAME" --region "$REGION" >/d
         --timeout 60 \
         --memory-size 256 \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,AUTH_ENABLED=false}" \
+        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,AUTH_ENABLED=true}" \
         --tracing-config Mode=Active \
         --region "$REGION"
     echo -e "${GREEN}Created Agent Lambda (X-Ray enabled)${NC}"
@@ -462,7 +462,7 @@ else
         --function-name "$FUNC_NAME" \
         --handler src.lambda_function.lambda_handler \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,AUTH_ENABLED=false}" \
+        --environment "Variables={ALETHEIA_ENV=dev,DYNAMODB_TABLE=$TABLE_NAME,CLOUDFLARE_ORIGIN_SECRET=$ORIGIN_SECRET,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,AUTH_ENABLED=true}" \
         --tracing-config Mode=Active \
         --region "$REGION" >/dev/null
 


### PR DESCRIPTION
Closes #499

## Summary
- Fix `provision.sh` lines 446 and 465: `AUTH_ENABLED=false` → `AUTH_ENABLED=true`
- Production already had `true` (set manually), but next provision run would revert it
- CLOUDFLARE_ORIGIN_SECRET runtime fix requires manual AWS CLI command (secret handling)

## Test plan
- [x] `grep AUTH_ENABLED provision.sh` confirms both occurrences say `true`
- [ ] Smoke test after user runs CLOUDFLARE_ORIGIN_SECRET AWS CLI command

🤖 Generated with [Claude Code](https://claude.com/claude-code)