### PR TITLE
feat: route auth through custom domain (close #496)

### DIFF
--- a/docs/reports/496/implementation-report.md
+++ b/docs/reports/496/implementation-report.md
@@ -1,0 +1,15 @@
+# Implementation Report: #496 Route Auth Through Custom Domain
+
+## Changes
+- `extensions/chrome/auth.js`: LAMBDA_AUTH_URL → `https://api.aletheia.study`
+- `extensions/firefox/auth.js`: LAMBDA_AUTH_URL → `https://api.aletheia.study`
+- `extensions/chrome/manifest.json`: removed raw Lambda URL from host_permissions
+- `extensions/firefox/manifest.json`: removed raw Lambda URL from host_permissions
+
+## How It Works
+The CloudFlare Worker (`workers/aletheia-api/worker.js`) already routes `/auth/*` paths to the Auth Lambda. The extension now uses the clean custom domain URL instead of the raw Lambda Function URL.
+
+## Manual Steps Required
+1. **LinkedIn OAuth App:** Update redirect URI from `https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws/auth/callback` to `https://api.aletheia.study/auth/callback`
+2. **Chrome identity redirect:** Already uses `chrome.identity.getRedirectURL()` — no change needed
+3. **Firefox AMO:** Resubmit extension with updated manifest

--- a/docs/reports/496/test-report.md
+++ b/docs/reports/496/test-report.md
@@ -1,0 +1,8 @@
+# Test Report: #496 Route Auth Through Custom Domain
+
+## Verification
+- `grep -r 'sk33bz56yi5qlbrrwzqnprmeuy0xwhzn' extensions/` returns no matches
+- Both auth.js files point to `https://api.aletheia.study`
+- Both manifest.json files have single clean host_permission
+- CloudFlare Worker already routes `/auth/*` to Auth Lambda (verified in worker.js)
+- Full OAuth flow requires manual LinkedIn redirect URI update before testing

--- a/extensions/chrome/auth.js
+++ b/extensions/chrome/auth.js
@@ -13,8 +13,8 @@ const AUTH_CONFIG = {
     // LinkedIn OAuth endpoints
     AUTH_URL: 'https://www.linkedin.com/oauth/v2/authorization',
 
-    // Lambda Auth endpoint (UPDATE after provisioning)
-    LAMBDA_AUTH_URL: 'https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws',
+    // Auth endpoint (routed through CloudFlare Worker to Auth Lambda)
+    LAMBDA_AUTH_URL: 'https://api.aletheia.study',
 
     // LinkedIn OAuth scopes (minimal - r_liteprofile only)
     SCOPES: 'openid profile',

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -14,8 +14,7 @@
     "notifications"
   ],
   "host_permissions": [
-    "https://api.aletheia.study/*",
-    "https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws/*"
+    "https://api.aletheia.study/*"
   ],
   "background": {
     "service_worker": "service-worker.js"

--- a/extensions/firefox/auth.js
+++ b/extensions/firefox/auth.js
@@ -24,8 +24,8 @@ const AUTH_CONFIG = {
     // LinkedIn OAuth endpoints
     AUTH_URL: 'https://www.linkedin.com/oauth/v2/authorization',
 
-    // Lambda Auth endpoint (shared with Chrome extension)
-    LAMBDA_AUTH_URL: 'https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws',
+    // Auth endpoint (routed through CloudFlare Worker to Auth Lambda)
+    LAMBDA_AUTH_URL: 'https://api.aletheia.study',
 
     // LinkedIn OAuth scopes (minimal - r_liteprofile only)
     SCOPES: 'openid profile',

--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -11,8 +11,7 @@
     "storage"
   ],
   "host_permissions": [
-    "https://api.aletheia.study/*",
-    "https://sk33bz56yi5qlbrrwzqnprmeuy0xwhzn.lambda-url.us-east-1.on.aws/*"
+    "https://api.aletheia.study/*"
   ],
   "background": {
     "scripts": ["service-worker.js"]


### PR DESCRIPTION
Closes #496

## Summary
- Change `LAMBDA_AUTH_URL` from raw Lambda Function URL to `https://api.aletheia.study` in both Chrome and Firefox `auth.js`
- Remove raw Lambda URL from `host_permissions` in both manifests
- CloudFlare Worker already routes `/auth/*` to Auth Lambda — no backend changes needed

**Manual steps after merge:**
1. Update LinkedIn OAuth app redirect URI to `https://api.aletheia.study/auth/callback`
2. Resubmit Firefox extension to AMO with updated manifest

## Test plan
- [x] `grep -r 'sk33bz56yi5qlbrrwzqnprmeuy0xwhzn' extensions/` returns no matches
- [x] Both auth.js files point to `https://api.aletheia.study`
- [x] Both manifests have clean `host_permissions`
- [x] ESLint passes
- [ ] Manual OAuth flow test after LinkedIn redirect URI update