### PR TITLE
feat: store LinkedIn profile data on registration (close #498)

### DIFF
--- a/docs/reports/498/implementation-report.md
+++ b/docs/reports/498/implementation-report.md
@@ -1,0 +1,14 @@
+# Implementation Report: #498 Store LinkedIn Profile Data
+
+## Changes
+- `src/lambda_auth_function.py`: `get_or_create_user()` now stores `email` and `picture` from LinkedIn OIDC userinfo response
+  - On CREATE: adds email/picture to DynamoDB Item if present
+  - On UPDATE: updates email/picture on each login (profile data may change)
+  - Gracefully handles missing fields (no error if LinkedIn doesn't return them)
+
+## Tests Added
+- `test_get_or_create_user_stores_email_and_picture_on_create`
+- `test_get_or_create_user_updates_email_and_picture_on_login`
+- `test_get_or_create_user_no_email_picture_no_error`
+
+All 7 TestUserManagement tests pass.

--- a/docs/reports/498/test-report.md
+++ b/docs/reports/498/test-report.md
@@ -1,0 +1,16 @@
+# Test Report: #498 Store LinkedIn Profile Data
+
+## Results
+- 7/7 TestUserManagement tests pass (4 existing + 3 new)
+- No regressions
+
+## Test Cases
+| Test | Result |
+|------|--------|
+| test_get_or_create_user_new | PASS |
+| test_get_or_create_user_existing | PASS |
+| test_get_or_create_user_stores_email_and_picture_on_create | PASS |
+| test_get_or_create_user_updates_email_and_picture_on_login | PASS |
+| test_get_or_create_user_no_email_picture_no_error | PASS |
+| test_get_user_tier_missing | PASS |
+| test_get_user_tier_existing | PASS |

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -351,12 +351,24 @@ def get_or_create_user(user_info: dict) -> dict:
             Key={"user_id": {"S": user_id}},
         )
         if "Item" in response:
-            # Update last_login
+            # Update last_login and profile fields (Issue #498)
+            update_expr = "SET last_login = :now"
+            expr_values = {":now": {"S": now}}
+
+            email = user_info.get("email")
+            if email:
+                update_expr += ", email = :email"
+                expr_values[":email"] = {"S": email}
+            picture = user_info.get("picture")
+            if picture:
+                update_expr += ", picture = :picture"
+                expr_values[":picture"] = {"S": picture}
+
             client.update_item(
                 TableName=USERS_TABLE,
                 Key={"user_id": {"S": user_id}},
-                UpdateExpression="SET last_login = :now",
-                ExpressionAttributeValues={":now": {"S": now}},
+                UpdateExpression=update_expr,
+                ExpressionAttributeValues=expr_values,
             )
             return {
                 "user_id": user_id,
@@ -368,16 +380,24 @@ def get_or_create_user(user_info: dict) -> dict:
         logger.error(f"DynamoDB get_item error: {e}")
         raise
 
-    # Create new user
+    # Create new user (Issue #498: store profile fields)
     try:
+        item = {
+            "user_id": {"S": user_id},
+            "display_name": {"S": display_name},
+            "created_at": {"S": now},
+            "last_login": {"S": now},
+        }
+        email = user_info.get("email")
+        if email:
+            item["email"] = {"S": email}
+        picture = user_info.get("picture")
+        if picture:
+            item["picture"] = {"S": picture}
+
         client.put_item(
             TableName=USERS_TABLE,
-            Item={
-                "user_id": {"S": user_id},
-                "display_name": {"S": display_name},
-                "created_at": {"S": now},
-                "last_login": {"S": now},
-            },
+            Item=item,
         )
         logger.info(f"Created new user: {user_id}")
         return {

--- a/tests/unit/test_lambda_auth.py
+++ b/tests/unit/test_lambda_auth.py
@@ -197,6 +197,52 @@ class TestUserManagement:
         assert user["user_id"] == TEST_USER_ID
         assert user["display_name"] == "Old Name"  # Display name is not updated on login currently
 
+    def test_get_or_create_user_stores_email_and_picture_on_create(self, aws_env):
+        user_info = {
+            "sub": TEST_USER_ID, "name": TEST_USER_NAME,
+            "email": "test@example.com", "picture": "https://example.com/photo.jpg",
+        }
+        auth_func.get_or_create_user(user_info)
+        db_user = aws_env["dynamodb"].get_item(
+            TableName=auth_func.USERS_TABLE,
+            Key={"user_id": {"S": TEST_USER_ID}}
+        )["Item"]
+        assert db_user["email"]["S"] == "test@example.com"
+        assert db_user["picture"]["S"] == "https://example.com/photo.jpg"
+
+    def test_get_or_create_user_updates_email_and_picture_on_login(self, aws_env):
+        aws_env["dynamodb"].put_item(
+            TableName=auth_func.USERS_TABLE,
+            Item={
+                "user_id": {"S": TEST_USER_ID},
+                "display_name": {"S": "Old Name"},
+                "created_at": {"S": "2020-01-01T00:00:00Z"},
+                "last_login": {"S": "2020-01-01T00:00:00Z"},
+            }
+        )
+        user_info = {
+            "sub": TEST_USER_ID, "name": "Old Name",
+            "email": "new@example.com", "picture": "https://example.com/new.jpg",
+        }
+        auth_func.get_or_create_user(user_info)
+        db_user = aws_env["dynamodb"].get_item(
+            TableName=auth_func.USERS_TABLE,
+            Key={"user_id": {"S": TEST_USER_ID}}
+        )["Item"]
+        assert db_user["email"]["S"] == "new@example.com"
+        assert db_user["picture"]["S"] == "https://example.com/new.jpg"
+
+    def test_get_or_create_user_no_email_picture_no_error(self, aws_env):
+        user_info = {"sub": TEST_USER_ID, "name": TEST_USER_NAME}
+        user = auth_func.get_or_create_user(user_info)
+        assert user["user_id"] == TEST_USER_ID
+        db_user = aws_env["dynamodb"].get_item(
+            TableName=auth_func.USERS_TABLE,
+            Key={"user_id": {"S": TEST_USER_ID}}
+        )["Item"]
+        assert "email" not in db_user
+        assert "picture" not in db_user
+
     def test_get_user_tier_missing(self, aws_env):
         tier, day = auth_func.get_user_tier("missing-user")
         assert tier == "free"


### PR DESCRIPTION
Closes #498

## Summary
- `get_or_create_user()` now stores `email` and `picture` from LinkedIn OIDC userinfo
- On CREATE: adds fields to DynamoDB Item if present in userinfo
- On UPDATE: refreshes email/picture on each login
- Gracefully handles missing fields (no error if LinkedIn doesn't return them)

## Test plan
- [x] 3 new tests added to TestUserManagement
- [x] 7/7 TestUserManagement tests pass
- [x] ruff + mypy pass
- [ ] Verify fields appear in DynamoDB after next real login