### PR TITLE
feat: write EULA and terms of service (close #500)

### DIFF
--- a/docs/legal/eula.html
+++ b/docs/legal/eula.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service - Aletheia</title>
+  <meta name="description" content="End User License Agreement and Terms of Service for Aletheia browser extension.">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://aletheia.study/eula.html">
+  <meta property="og:title" content="Terms of Service - Aletheia">
+  <meta property="og:description" content="End User License Agreement and Terms of Service for Aletheia browser extension.">
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <a href="/" class="logo"><img src="assets/lambda-web-32.png" alt="&lambda;" class="logo-lambda">Aletheia</a>
+      <nav>
+        <a href="/" class="nav-link">Home</a>
+        <div class="nav-dropdown">
+          <button class="nav-dropdown-trigger" tabindex="0">Engineering <span class="nav-dropdown-arrow">&#9660;</span></button>
+          <div class="nav-dropdown-menu">
+            <a href="architecture.html">Architecture</a>
+            <a href="observability.html">Observability</a>
+            <a href="operations.html">Operations</a>
+            <a href="safety.html">Safety</a>
+          </div>
+        </div>
+        <a href="privacy.html" class="nav-link">Privacy</a>
+        <a href="eula.html" class="nav-link">Terms</a>
+        <a href="https://github.com/martymcenroe/Aletheia" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <h1>End User License Agreement &amp; Terms of Service</h1>
+      <p class="last-updated">Last updated: March 2026</p>
+
+      <div class="highlight-box">
+        <strong>Summary:</strong> Use Aletheia lawfully, don't circumvent safety features, AI output is informational only. We can terminate accounts for violations.
+      </div>
+
+      <p>This End User License Agreement ("Agreement") is between you ("User") and ThriveTech AI ("Company", "we", "us"), an Australian company, for the Aletheia browser extension ("Extension") and related services ("Service").</p>
+      <p>By installing or using the Extension, you agree to this Agreement. If you do not agree, do not install or use the Extension.</p>
+
+      <h2>1. License Grant</h2>
+      <p>We grant you a limited, non-exclusive, non-transferable, revocable license to use the Extension for personal, non-commercial purposes under the <strong>PolyForm Noncommercial License 1.0.0</strong>.</p>
+      <p>Commercial use requires a separate license. Contact <a href="mailto:cto@thrivetech.ai">cto@thrivetech.ai</a>.</p>
+
+      <h2>2. Acceptable Use</h2>
+      <p>You agree NOT to:</p>
+      <ul>
+        <li>Use the Extension on websites containing illegal content</li>
+        <li>Circumvent content safety features (age gate, content filters)</li>
+        <li>Reverse engineer the Service's backend components</li>
+        <li>Use automated tools, scripts, or bots to interact with the Service</li>
+        <li>Resell, redistribute, or sublicense access</li>
+        <li>Generate harmful, abusive, or threatening content</li>
+        <li>Access Service APIs directly, bypassing the Extension</li>
+        <li>Interfere with infrastructure or other users' access</li>
+      </ul>
+
+      <h2>3. Content Restrictions</h2>
+      <p>The Extension blocks operation on adult and age-restricted websites. This is a core safety feature. Attempting to circumvent these restrictions is a violation of this Agreement and grounds for account termination.</p>
+
+      <h2>4. Account &amp; Authentication</h2>
+      <p>Authentication via LinkedIn OAuth is required. By authenticating, you agree to provide accurate information, maintain account security, and accept responsibility for all activity under your account.</p>
+      <p>We store your LinkedIn user ID, display name, email, and profile picture as described in our <a href="privacy.html">Privacy Policy</a>.</p>
+
+      <h2>5. Subscription Tiers &amp; Payments</h2>
+      <ul>
+        <li><strong>Free Tier:</strong> Available to all authenticated users with usage caps</li>
+        <li><strong>Subscriber Tier:</strong> Higher caps via Stripe subscription or promotional coupon</li>
+      </ul>
+      <p><strong>Refund Policy:</strong> Cancel anytime. Full refunds within 30 days of charge. After 30 days, refunds at our discretion. Contact <a href="mailto:cto@thrivetech.ai">cto@thrivetech.ai</a>.</p>
+      <p><strong>Coupons:</strong> Subject to expiration and usage limits. No cash value, non-transferable.</p>
+
+      <h2>6. Account Termination</h2>
+      <p>We may suspend or terminate your account at any time, with or without notice, for:</p>
+      <ul>
+        <li>Violation of this Agreement</li>
+        <li>Abuse of the Service</li>
+        <li>Fraud or misrepresentation</li>
+        <li>Non-payment</li>
+        <li>Any reason at our sole discretion</li>
+      </ul>
+      <p>Upon termination, your right to use the Extension ceases immediately. You may request data deletion per our Privacy Policy.</p>
+
+      <h2>7. Data Handling</h2>
+      <p>Governed by our <a href="privacy.html">Privacy Policy</a>. We only process text you explicitly select. We do not track browsing history or sell data. Data retained for 30 days, then deleted.</p>
+
+      <h2>8. Intellectual Property</h2>
+      <p>The Extension is licensed under PolyForm Noncommercial 1.0.0. Source code: <a href="https://github.com/martymcenroe/Aletheia" target="_blank" rel="noopener">github.com/martymcenroe/Aletheia</a>.</p>
+      <p>We make no ownership claim over analysis output. You may use output for any non-commercial purpose.</p>
+
+      <h2>9. Disclaimers</h2>
+      <p>THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND.</p>
+      <ul>
+        <li><strong>Not Professional Advice:</strong> AI analysis is informational only &mdash; not legal, medical, financial, or professional advice</li>
+        <li><strong>Accuracy:</strong> AI can produce incorrect or misleading output. Always verify important information</li>
+        <li><strong>Availability:</strong> We do not guarantee uninterrupted access</li>
+      </ul>
+
+      <h2>10. Limitation of Liability</h2>
+      <p>To the maximum extent permitted by law, ThriveTech AI shall not be liable for any indirect, incidental, special, consequential, or punitive damages. Total liability shall not exceed the amount paid in the preceding 12 months, or AUD $50, whichever is greater.</p>
+
+      <h2>11. Changes</h2>
+      <p>We may update this Agreement. Material changes will be communicated via the Extension or this page. Continued use after changes constitutes acceptance.</p>
+
+      <h2>12. Governing Law</h2>
+      <p>This Agreement is governed by the laws of Australia. Disputes shall be resolved in Australian courts.</p>
+
+      <h2>13. Contact</h2>
+      <ul>
+        <li>Email: <a href="mailto:cto@thrivetech.ai">cto@thrivetech.ai</a></li>
+        <li>GitHub: <a href="https://github.com/martymcenroe/Aletheia/issues" target="_blank" rel="noopener">github.com/martymcenroe/Aletheia/issues</a></li>
+      </ul>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <span class="footer-logo"><img src="assets/lambda-web-16.png" alt="&lambda;" class="footer-lambda">Aletheia</span>
+      <nav class="footer-links">
+        <a href="/">Home</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="observability.html">Observability</a>
+        <a href="operations.html">Operations</a>
+        <a href="safety.html">Safety</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="eula.html">Terms</a>
+        <a href="https://github.com/martymcenroe/Aletheia" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/legal/eula.md
+++ b/docs/legal/eula.md
@@ -1,0 +1,136 @@
+# Aletheia - End User License Agreement (EULA) & Terms of Service
+
+**Effective Date:** March 2026
+**Last Updated:** March 2026
+
+This End User License Agreement ("Agreement") is a legal agreement between you ("User") and ThriveTech AI ("Company", "we", "us"), an Australian company, for the use of the Aletheia browser extension ("Extension") and related services ("Service").
+
+By installing, accessing, or using the Extension, you agree to be bound by this Agreement. If you do not agree, do not install or use the Extension.
+
+## 1. License Grant
+
+Subject to the terms of this Agreement, we grant you a limited, non-exclusive, non-transferable, revocable license to install and use the Extension for personal, non-commercial purposes in accordance with the PolyForm Noncommercial License 1.0.0.
+
+Commercial use of the Extension or its output requires a separate commercial license. Contact cto@thrivetech.ai for commercial licensing inquiries.
+
+## 2. Acceptable Use
+
+You agree to use the Extension only for lawful purposes and in accordance with this Agreement. You agree NOT to:
+
+- Use the Extension on websites containing illegal content
+- Attempt to circumvent the Extension's content safety features, including the age gate or content filters
+- Reverse engineer, decompile, disassemble, or attempt to derive the source code of the Service's backend components
+- Use automated tools, scripts, or bots to interact with the Extension or Service
+- Resell, redistribute, or sublicense access to the Extension or Service
+- Use the Extension to generate content that is harmful, abusive, threatening, or violates any applicable law
+- Attempt to access the Service's APIs directly, bypassing the Extension
+- Interfere with or disrupt the Service's infrastructure or other users' access
+
+## 3. Content Restrictions
+
+The Extension includes built-in content safety features that block operation on certain categories of websites, including but not limited to:
+
+- Adult/sexually explicit content
+- Content rated as restricted by industry-standard metadata (RTA, PICS)
+
+These restrictions are a core feature of the Extension, not a limitation. Attempting to circumvent these restrictions constitutes a violation of this Agreement and grounds for account termination.
+
+## 4. Account & Authentication
+
+Use of the Extension requires authentication via LinkedIn OAuth. By authenticating, you agree to:
+
+- Provide accurate information during the login process
+- Maintain the security of your account credentials
+- Notify us immediately of any unauthorized use of your account
+- Accept responsibility for all activity under your account
+
+We store your LinkedIn user ID, display name, email address, and profile picture URL as described in our [Privacy Policy](https://aletheia.study/privacy.html).
+
+## 5. Subscription Tiers & Payments
+
+The Extension operates on a tiered model:
+
+- **Free Tier:** Available to all authenticated users with usage caps (requests per hour, day, and month)
+- **Subscriber Tier:** Paid tier with higher usage caps, available via Stripe subscription or promotional coupon codes
+- **Admin Tier:** Reserved for authorized administrators
+
+### 5.1 Stripe Subscriptions
+Paid subscriptions are billed monthly via Stripe. By subscribing, you agree to Stripe's [Terms of Service](https://stripe.com/legal). Subscription fees are charged at the beginning of each billing period.
+
+### 5.2 Refund Policy
+You may cancel your subscription at any time. Refund requests within 30 days of a charge will be honored in full. After 30 days, refunds are at our discretion. Contact cto@thrivetech.ai for refund requests.
+
+### 5.3 Promotional Coupons
+Coupon codes grant tier upgrades and are subject to their own expiration dates and usage limits. Coupons have no cash value and cannot be transferred.
+
+## 6. Account Termination
+
+We reserve the right to suspend or terminate your account at any time, with or without notice, for any reason, including but not limited to:
+
+- Violation of this Agreement or Acceptable Use policy
+- Abuse of the Service (excessive automated requests, scraping, etc.)
+- Fraud or misrepresentation
+- Non-payment of subscription fees
+- At our sole discretion for any reason
+
+Upon termination, your right to use the Extension ceases immediately. You may request deletion of your data per our Privacy Policy.
+
+## 7. Data Handling & Privacy
+
+Your use of the Extension is also governed by our [Privacy Policy](https://aletheia.study/privacy.html). Key points:
+
+- We only process text you explicitly select and submit
+- We do not track your browsing history
+- We do not sell your data to third parties
+- Selected text is processed by AWS Bedrock (Amazon Nova AI), which does not train on your data
+- Data is retained for 30 days, then automatically deleted
+- You may request data deletion at any time
+
+## 8. Intellectual Property
+
+The Extension is licensed under the PolyForm Noncommercial License 1.0.0. The source code is available at [github.com/martymcenroe/Aletheia](https://github.com/martymcenroe/Aletheia).
+
+The AI-generated analysis output is provided for your personal use. We make no claim of ownership over the analysis results. You are free to use the output for any non-commercial purpose.
+
+## 9. Disclaimers
+
+THE EXTENSION AND SERVICE ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED.
+
+- **Not Professional Advice:** AI analysis is informational only. It does not constitute legal, medical, financial, or any other professional advice. Always verify important information from authoritative sources.
+- **Accuracy:** While we strive for accurate analysis, AI systems can produce incorrect, incomplete, or misleading output. We do not guarantee the accuracy, completeness, or reliability of any analysis.
+- **Availability:** We do not guarantee uninterrupted access to the Service. Maintenance, updates, or unforeseen issues may cause temporary unavailability.
+
+## 10. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THRIVETECH AI BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUE, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
+
+- Your use of or inability to use the Service
+- Any unauthorized access to or alteration of your data
+- Any third-party conduct on the Service
+- Any other matter relating to the Service
+
+Our total liability for all claims under this Agreement shall not exceed the amount you paid us in the 12 months preceding the claim, or AUD $50, whichever is greater.
+
+## 11. Changes to This Agreement
+
+We may update this Agreement from time to time. Material changes will be communicated via:
+
+- A notice in the Extension
+- An update to this page with a revised "Last Updated" date
+
+Continued use of the Extension after changes constitutes acceptance of the updated terms. If you do not agree with changes, you must stop using the Extension and uninstall it.
+
+## 12. Governing Law
+
+This Agreement is governed by and construed in accordance with the laws of Australia. Any disputes arising from this Agreement shall be resolved in the courts of Australia.
+
+## 13. Severability
+
+If any provision of this Agreement is found to be unenforceable, the remaining provisions shall continue in full force and effect.
+
+## 14. Contact
+
+For questions about this Agreement:
+
+- Email: [cto@thrivetech.ai](mailto:cto@thrivetech.ai)
+- GitHub: [github.com/martymcenroe/Aletheia/issues](https://github.com/martymcenroe/Aletheia/issues)

--- a/docs/reports/500/implementation-report.md
+++ b/docs/reports/500/implementation-report.md
@@ -1,0 +1,16 @@
+# Implementation Report: #500 Write EULA
+
+## Changes
+- Created `docs/legal/eula.md` — full EULA/Terms of Service in markdown
+- Created `docs/legal/eula.html` — HTML version matching site style, servable at aletheia.study/eula.html
+
+## Coverage
+- License grant (PolyForm Noncommercial 1.0.0)
+- Acceptable use policy
+- Content restrictions (age gate, circumvention = violation)
+- Account termination rights
+- Subscription tiers and refund policy (30-day)
+- Data handling (references privacy policy)
+- AI disclaimers (not professional advice, no accuracy guarantee)
+- Limitation of liability (AUD $50 or 12-month payments)
+- Governing law: Australia

--- a/docs/reports/500/test-report.md
+++ b/docs/reports/500/test-report.md
@@ -1,0 +1,7 @@
+# Test Report: #500 Write EULA
+
+## Verification
+- Document content reviewed for completeness
+- HTML validates against existing site style (same header, footer, nav as privacy.html)
+- All links are valid (privacy.html, GitHub, mailto)
+- No code changes — documentation only


### PR DESCRIPTION
Closes #500

## Summary
- `docs/legal/eula.md` — full EULA/Terms of Service in markdown
- `docs/legal/eula.html` — HTML version matching site style for aletheia.study/eula.html
- Covers: PolyForm Noncommercial license, acceptable use, content restrictions, account termination, subscription terms, AI disclaimers, limitation of liability, governing law (Australia)

## Test plan
- [x] Content completeness reviewed
- [x] HTML matches existing site nav/footer pattern
- [ ] Verify renders correctly on GitHub Pages