### PR TITLE
fix: Firefox popup displays 'pending' during OAuth flow (#510)

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Aletheia",
-  "version": "1.1",
+  "version": "1.1.1",
   "description": "AI-Powered Context Analysis",
   "permissions": [
     "activeTab",

--- a/extensions/firefox/popup.js
+++ b/extensions/firefox/popup.js
@@ -335,7 +335,15 @@ async function handleLoginClick() {
     // continues the flow. When popup reopens, init() will find stored tokens.
     const user = await window.AletheiaAuth.initiateLogin();
 
-    // If we get here, popup stayed open and flow completed
+    // Firefox tabs-based flow returns {id: 'pending', name: 'pending'} immediately.
+    // The SW completes the token exchange asynchronously via onUpdated listener.
+    // Close the popup — user will reopen after completing LinkedIn auth.
+    if (user.id === 'pending') {
+      window.close();
+      return;
+    }
+
+    // If we get here, popup stayed open and flow completed synchronously
     userName.textContent = user.name;
     showView('main');
     await renderMainView();


### PR DESCRIPTION
## Summary

- Handle `pending` response from Firefox tabs-based OAuth in `handleLoginClick()` — close popup instead of showing "pending" as username
- Bump Firefox manifest to v1.1.1 (already published to AMO)

Closes #510

## Test plan

- [ ] Firefox: Click sign in → LinkedIn tab opens → popup closes (not "pending" text)
- [ ] Firefox: Complete LinkedIn auth → reopen popup → correct username displayed
- [ ] Chrome: Auth flow unchanged, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)