### PR TITLE
fix: set Codecov fail_ci_if_error to false (#512)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   extension-lint:
     needs: policy-check  # Only run if policy check passes


### PR DESCRIPTION
## Summary

- Set `fail_ci_if_error: false` on Codecov upload action
- Coverage upload is nice-to-have, should not block CI

Closes #512

## Test plan

- [ ] CI `test` job passes (Codecov upload failure no longer blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)