### PR TITLE
fix: update WAF test and smoke test for AUTH_ENABLED=true (#515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
             exit 1
           fi
 
-      - name: Analysis endpoint (AUTH_ENABLED guard)
+      - name: Analysis endpoint (AUTH_ENABLED=true expected)
         run: |
           HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
             -X POST https://api.aletheia.study/ \
@@ -393,7 +393,11 @@ jobs:
             -d '{"text":"smoke test"}')
           echo "Analysis: $HTTP_STATUS"
           if [ "$HTTP_STATUS" = "401" ]; then
-            echo "FAIL: AUTH_ENABLED=true detected — extension auth not verified"
+            echo "OK: AUTH_ENABLED=true — unauthenticated request correctly rejected"
+          elif [ "$HTTP_STATUS" = "200" ]; then
+            echo "OK: Analysis endpoint responded successfully"
+          else
+            echo "FAIL: Unexpected status $HTTP_STATUS"
             exit 1
           fi
 

--- a/tests/e2e/waf-integration.spec.js
+++ b/tests/e2e/waf-integration.spec.js
@@ -12,7 +12,9 @@ test.describe('Header Enforcement (#95, #349)', () => {
     // CloudFlare rate limit: 3 req/10s/IP — run serial with delay to avoid 429
     test.describe.configure({ mode: 'serial' });
 
-    test('020: API accepts request with valid header', async ({ request }) => {
+    test('020: API returns 401 for unauthenticated request with valid header', async ({ request }) => {
+        // AUTH_ENABLED=true — valid client header passes CloudFlare Worker
+        // but Lambda requires JWT authentication
         const response = await request.post(API_URL, {
             headers: {
                 'Content-Type': 'application/json',
@@ -26,8 +28,7 @@ test.describe('Header Enforcement (#95, #349)', () => {
             }
         });
 
-        expect(response.status()).toBe(200);
-        expect(response.ok()).toBe(true);
+        expect(response.status()).toBe(401);
     });
 
     test('030: Worker blocks request without header', async ({ request }) => {
@@ -54,7 +55,7 @@ test.describe('Header Enforcement (#95, #349)', () => {
         expect(response.status()).toBe(403);
     });
 
-    test('050: Future version accepted', async ({ request }) => {
+    test('050: Future version returns 401 (passes Worker, blocked by auth)', async ({ request }) => {
         // Wait for CloudFlare rate-limit window to reset (3 req/10s)
         await new Promise(r => setTimeout(r, 11_000));
         const response = await request.post(API_URL, {
@@ -70,7 +71,7 @@ test.describe('Header Enforcement (#95, #349)', () => {
             }
         });
 
-        expect(response.status()).toBe(200);
+        expect(response.status()).toBe(401);
     });
 
 });


### PR DESCRIPTION
## Summary

- WAF integration tests 020/050: expect 401 (valid header passes Worker, Lambda requires JWT)
- Post-deploy smoke test: accept 401 as valid (AUTH_ENABLED=true is intentional)

Closes #515

## Test plan

- [ ] CI `e2e-chrome` job passes
- [ ] Post-deploy smoke test accepts 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)