### PR TITLE
fix: update overdue audit records and initialize new audits (#514)

### DIFF
--- a/docs/audits/10811-audit-accessibility.md
+++ b/docs/audits/10811-audit-accessibility.md
@@ -79,6 +79,7 @@ Ensure Aletheia browser extension is usable by people with disabilities, complia
 | Date | Auditor | Findings Summary | Issues Created |
 |------|---------|------------------|----------------|
 | 2026-01-10 | Claude Opus 4.5 | PASS with gaps: overlay.js has ARIA labels, popup.html missing ARIA labels on interactive buttons (power, logout, manage), images have alt text, lang attribute present | #260 |
+| 2026-03-06 | Claude Opus 4.6 | PASS with prior gaps open: popup.html buttons still lack ARIA labels (#260 open). New EULA page (eula.html) has semantic structure, headings, link labels. pa11y CI job fixed (#513). No regressions. | None |
 
 ---
 

--- a/docs/audits/10815-audit-claude-capabilities.md
+++ b/docs/audits/10815-audit-claude-capabilities.md
@@ -178,6 +178,7 @@ Review `.claude/settings.local.json`:
 | 2026-01-05 | Gemini 3.0 Pro | Custom Slash Commands (active), Browser Integration, MCP CloudWatch | Browser/MCP added to backlog |
 | 2026-01-06 | Claude Opus 4.5 | Subagents (Explore, Plan), Named Sessions, Status Line, Thinking Mode | Subagent research evaluation (active in this session) |
 | 2026-01-12 | Claude Opus 4.5 | **Claude Code 2.1.0/2.1.1** - Hooks for agents/skills, Hot reload skills, Haiku 4.5, Auto-background bash, Prompt suggestions, Claude in Chrome Beta | Skills/Hooks to evaluate |
+| 2026-03-06 | Claude Opus 4.6 | **Opus 4.6 model** now in use. Custom skills active (/handoff, /pickup, /audit, /commit-push-pr, /code-review, /cleanup). Background agents used for parallel audit execution. Worktree isolation mature. pr-sentinel GitHub App enforces PR discipline. | None |
 
 ---
 

--- a/docs/audits/10817-audit-wiki-alignment.md
+++ b/docs/audits/10817-audit-wiki-alignment.md
@@ -151,6 +151,7 @@ git push origin master
 | Date | Auditor | Pages Updated | Issues Found |
 |------|---------|---------------|--------------|
 | 2026-01-06 | Claude Opus 4.5 | All pages (timestamps added) | Wiki was BLANK - remote HEAD pointed to nonexistent branch. Fixed by pushing `master` branch. Added §4.0 availability check. |
+| 2026-03-06 | Claude Opus 4.6 | Architecture docs present (docs/architecture/). EULA and privacy pages added to site (eula.html, privacy.html). Auth architecture documented across LLDs and ADRs. Wiki availability not verified this cycle — deferred to next audit. | None |
 | 2026-01-04 | Claude Opus 4.5 | Privacy, FAQ, Architecture, Security, Terms-of-Use (new) | Privacy was inaccurate (said in-memory only) |
 
 ---

--- a/docs/audits/10821-audit-agentic-ai-governance.md
+++ b/docs/audits/10821-audit-agentic-ai-governance.md
@@ -291,6 +291,7 @@ If multi-agent architecture is adopted:
 | Date | Auditor | Findings Summary | Issues Created |
 |------|---------|------------------|----------------|
 | 2026-01-10 | Claude Opus 4.5 | PASS: Comprehensive deny list in settings.local.json (git reset, force push, rm -rf, eval, pip, env), session logs maintained (7 log files), CLAUDE.md defines escalation paths, worktree isolation enforced per ADR 0210 | None |
+| 2026-03-06 | Claude Opus 4.6 | PASS: Root CLAUDE.md expanded with Two-Strike Rule, When Blocked/Uncertain overrides, Production Safety requirements, PR Issue References mandate. Aletheia CLAUDE.md adds Change Control (issue-before-code, no-bundling, post-change verification). Session logs active through March. pr-sentinel enforces PR discipline. No governance gaps. | None |
 
 ---
 

--- a/docs/audits/10827-audit-infrastructure-integration.md
+++ b/docs/audits/10827-audit-infrastructure-integration.md
@@ -181,7 +181,7 @@ Extension → API Gateway → Lambda → Bedrock
 
 | Date | Auditor | Findings Summary | Issues Created |
 |------|---------|------------------|----------------|
-| | | | |
+| 2026-03-06 | Claude Opus 4.6 | INITIAL: 3 Lambdas deployed (AletheiaAgent, AletheiaAuth, AletheiaKillSwitch). CloudFlare Worker proxies api.aletheia.study to Lambda. CLOUDFLARE_ORIGIN_SECRET set. DynamoDB tables: aletheia-users, aletheia-coupons. AUTH_ENABLED=true. provision.sh correctly sets both create/update paths. No drift detected. | None |
 
 ---
 

--- a/docs/audits/10899-meta-audit.md
+++ b/docs/audits/10899-meta-audit.md
@@ -326,7 +326,7 @@ Registry/index files must stay synchronized with actual files.
 
 | Date | Auditor | Findings Summary | Issues Created |
 |------|---------|------------------|----------------|
-| | | | |
+| 2026-03-06 | Claude Opus 4.6 | INITIAL: 17 audits in schedule. 4 monthly audits were 25-59 days overdue (0811, 0815, 0817, 0821) — all updated this cycle. 2 new audits (0827, 0899) initialized. audit_schedule_check.py enforces thresholds: monthly 30d block/22d warn, quarterly 90d/67d, weekly 7d/5d. CI integration working via ci.yml audit-schedule job. | #514 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Run 4 overdue monthly audits: 0811 (accessibility), 0815 (Claude capabilities), 0817 (wiki alignment), 0821 (agentic governance)
- Initialize 2 new audits: 0827 (infrastructure integration), 0899 (meta-audit)
- All 17 scheduled audits now pass `audit_schedule_check.py`

Closes #514

## Test plan

- [ ] CI `audit-schedule` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)