### PR TITLE
fix: privacy.html license text and email disclosure (close #520)

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -48,7 +48,7 @@
   <main>
     <div class="container">
       <h1>Privacy Policy</h1>
-      <p class="last-updated">Last updated: January 2026</p>
+      <p class="last-updated">Last updated: March 2026</p>
 
       <div class="highlight-box">
         <strong>Summary:</strong> Aletheia is privacy-first. We only access text you explicitly select, we don't track you, and we don't sell your data.
@@ -61,6 +61,8 @@
         <li>The surrounding text</li>
         <li>The page URL where you selected it</li>
       </ul>
+      <p>If you redeem a coupon code, you may optionally provide an email address. This is stored in our database for account communication purposes only and is never shared with third parties.</p>
+
       <p>We do <strong>not</strong> collect:</p>
       <ul>
         <li>Your browsing history across sites</li>
@@ -106,7 +108,7 @@
       <p>We do not use analytics, advertising networks, or tracking services.</p>
 
       <h2>7. Open Source Transparency</h2>
-      <p>Aletheia is fully open source under the MIT License. You can audit our code at any time:</p>
+      <p>Aletheia is fully open source under the <a href="https://polyformproject.org/licenses/noncommercial/1.0.0/" target="_blank" rel="noopener">PolyForm Noncommercial 1.0.0</a> license. You can audit our code at any time:</p>
       <p><a href="https://github.com/martymcenroe/Aletheia" target="_blank" rel="noopener">github.com/martymcenroe/Aletheia</a></p>
 
       <h2>8. Contact</h2>


### PR DESCRIPTION
## Summary
- Fix incorrect MIT License reference → PolyForm Noncommercial 1.0.0 on line 109
- Add email collection disclosure for coupon redemption (required by #367)
- Update last-updated date

Closes #520

## Test plan
- [ ] Verify privacy.html renders correctly at aletheia.study/privacy.html
- [ ] Confirm license link works
- [ ] Confirm email disclosure text is present in Section 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)