### PR TITLE
chore: bump extension versions to 1.1.2 (close #525)

### DIFF
--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Aletheia",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "AI-Powered Context Analysis",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwqhKPypEh3MS48mKuwfehoz2koJ1uAxX1ZokOvzz5jhqONCzi5qL5WSZm9f7tOe2i6gby7D211qFcna/5h0V8J1tafVSWPA6WWAh3zlTDpk/i9/s74Usfo4PZJIMlPp++xXBzdoihL3iudOaUbQXwlyKupjgn2BDE9pav9u5j0/Pom0Djmg94/8G/CfxtB+qJweztm7d6WMlMBPLa04ed2G/GiHK7XTHdTv8mBu/bnN03Bx0i+2CXeIcPwGVyXzhziL924VggzkVHjfqaHMap13KIxVfZqOg7MnMv4+XJp9U8GuUC6LgXai3c1aTzQyfpvxtJmyzMqzMm5UzjYVIvwIDAQAB",
   "permissions": [

--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Aletheia",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "AI-Powered Context Analysis",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
## Summary
- Bump Chrome manifest 1.1.1 → 1.1.2
- Bump Firefox manifest 1.1.1 → 1.1.2

Required for store deployment of coupon feature (#521).

Closes #525

## Test plan
- [ ] Verify both manifests show 1.1.2
- [ ] Build zips after merge
- [ ] Upload to AMO and Chrome Web Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)