### PR TITLE
chore: session cleanup 2026-04-27 (Closes #598)

### DIFF
--- a/docs/session-logs/2026-04-12.md
+++ b/docs/session-logs/2026-04-12.md
@@ -1,0 +1,37 @@
+# Session Log: 2026-04-12
+
+**Period:** 2026-04-12 3:00 AM CT → 2026-04-13 2:59 AM CT
+
+---
+
+---
+
+## 2026-04-12 09:03 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: 582-session-docs @ d1983a3
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-04-12 09:06 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: 582-session-docs @ d1983a3
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary

--- a/docs/session-logs/2026-04-27.md
+++ b/docs/session-logs/2026-04-27.md
@@ -1,0 +1,60 @@
+# Session Log: 2026-04-27
+
+**Period:** 2026-04-27 3:00 AM CT → 2026-04-28 2:59 AM CT
+
+---
+
+---
+
+## 2026-04-27 05:54 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: 582-session-docs @ d1983a3
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-04-27 05:58 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: 582-session-docs @ d1983a3
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-04-27 06:01 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: 582-session-docs @ d1983a3
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## Session: post-onboard-cleanup
+- **Mode:** normal cleanup
+- **Summary:** Onboarded fresh. Local repo was 5 weeks behind remote (last fetch 2026-03-28). Caught up via fetch+prune+pull, leaving stale local branch 582-session-docs in place pending user decision on -D. Committed accumulated session-log scraps.
+- **Next:** Per user direction


### PR DESCRIPTION
## Summary

- Add session-log scraps accumulated since 2026-04-12
- Files: `docs/session-logs/2026-04-12.md`, `docs/session-logs/2026-04-27.md`
- Repo was 5 weeks behind remote; caught up via fetch+prune+pull

## Test plan

- [ ] Docs-only change — no code modified, no tests required

Closes #598