### PR TITLE
chore: session cleanup 2026-04-28 (Closes #601)

### DIFF
--- a/docs/session-logs/2026-04-28.md
+++ b/docs/session-logs/2026-04-28.md
@@ -1,0 +1,76 @@
+# Session Log: 2026-04-28
+
+**Period:** 2026-04-28 3:00 AM CT → 2026-04-29 2:59 AM CT
+
+---
+
+---
+
+## 2026-04-28 05:44 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: main @ 40776a5
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-04-28 07:24 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: main @ 40776a5
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-04-28 12:18 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: main @ 40776a5
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## 2026-04-28 12:23 CT | Claude Opus 4.5
+
+### Summary
+Session ended (auto-logged by stop hook)
+
+### Issues
+- Created: None
+- Closed: None
+
+### State on Exit
+- Branch: main @ 40776a5
+- Open PRs: 0
+- Next: Run /cleanup for detailed summary
+
+---
+
+## Session: method-b-and-adr-0217
+- **Mode:** full cleanup
+- **Summary:** Removed two stale local branches force-free (#582 via git replace --graft, #583 via plain -d). Wrote AssemblyZero ADR 0217 documenting the squash-merge orphan cleanup recipe. Updated Universal CLAUDE.md to point to it.
+- **Next:** Per user direction


### PR DESCRIPTION
## Summary
- Add session log for 2026-04-28 (method-b-and-adr-0217 cleanup session)

## Notes
- Minimal PR — only 2026-04-28.md, which is unique to today's session
- 2026-04-27.md has new stop-hook entries beyond PR #599's snapshot (flagged, not included here)
- Out-of-scope files left untouched: GEMINI.md, .unleashed.json, data/sandbox-method-b/, data/sandbox-method-b-test.sh, data/deep-research-squash-merge-cleanup.md

Closes #601