### PR TITLE
chore: remove dead ETYMOLOGIST_MODEL routing (Closes #620)

### DIFF
--- a/docs/lld/active/LLD-620.md
+++ b/docs/lld/active/LLD-620.md
@@ -1,0 +1,71 @@
+# 620 - Chore: Remove dead ETYMOLOGIST_MODEL routing
+
+<!-- Template Metadata
+Last Updated: 2026-05-23
+Updated By: Issue #620 LLD creation
+Update Reason: Config hygiene cleanup discovered while investigating #618 gedenken misclassification
+-->
+
+## 1. Context & Goal
+
+* **Issue:** #620
+* **Objective:** Remove dead code that reads the `ETYMOLOGIST_MODEL` env var. The production Lambda reads `BEDROCK_MODEL_ID` (in `lambda_function.py:50`) instead. The `ETYMOLOGIST_MODEL` path was specified by LLD #294 as the model switch but was never wired into the Lambda's call path.
+* **Status:** Draft
+* **Related Issues:** #618 (gedenken misclassification — discovery), #535 (Bedrock AIPs), #294 (Nova Micro switch — never landed on the production code path).
+
+### Open Questions
+
+None. Decision is made: keep Haiku as production model (user direction on #618 discussion), delete the dead Nova Micro routing.
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/etymologist.py` | Modify | Delete `DEFAULT_MODEL_ID` constant, delete `get_model_id()` function, change `model_id is None` defaults to `HAIKU_MODEL_ID` in `build_etymologist_prompt` and `analyze_term`. |
+| `tests/unit/test_etymologist.py` | Modify | Remove imports of `DEFAULT_MODEL_ID` and `get_model_id`. Delete `TestGetModelId` class. Delete `test_default_model_is_nova`. Update `TestAnalyzeTermModelSelection`: default-when-none test expects `HAIKU_MODEL_ID`; env-var test deleted. |
+
+### 2.1.1 Files NOT Changed
+
+* `src/lambda_function.py` — `BEDROCK_MODEL_ID` is already the production path; no change needed.
+* `src/guardrails/semantic.py` — uses `ALETHEIA_AIP_HAIKU` directly; unaffected.
+* `docs/lld/done/10294-nova-micro-switch.md` — historical file (per Aletheia rule, `done/` is immutable). The LLD's deploy step references `ETYMOLOGIST_MODEL` which never worked, but the doc itself must remain unchanged. This issue serves as the record of correction.
+* `docs/reports/done/1294-implementation-report.md` — same reason.
+* `docs/audits/10827-audit-infrastructure-integration.md` — already references `BEDROCK_MODEL_ID` (the var that works). No change required.
+
+### 2.2 Code Behavior After Change
+
+* `analyze_term(word, context, bedrock_client=None, model_id=None)` — when `model_id is None`, defaults to `HAIKU_MODEL_ID` (which reads `ALETHEIA_AIP_HAIKU` env var, falling back to the raw Haiku 4.5 model ID).
+* `build_etymologist_prompt(word, page_context, model_id=None)` — same.
+* No environment variable is read by `etymologist.py`. The Lambda passes `BEDROCK_MODEL_ID` explicitly to `analyze_term`.
+* `NOVA_MICRO_MODEL_ID`, `HAIKU_MODEL_ID`, `ALLOWED_MODELS`, `is_nova_model()`, `validate_model_id()`, `build_nova_prompt()` — all retained. Nova prompt format support remains in place even though no current configuration routes to Nova.
+
+### 2.3 Production Deploy Plan
+
+1. Merge PR → main.
+2. `provision.sh` deploys Lambda with new code.
+3. Smoke test: `curl health` + `curl POST /` returns expected etymology JSON (with `signal` and `gem`).
+4. Verify no `ETYMOLOGIST_MODEL` env var leaked into Lambda config: `aws lambda get-function-configuration --function-name AletheiaAgent --query 'Environment.Variables.ETYMOLOGIST_MODEL'` should return `null`.
+5. Verify model identity in response metadata is still the Haiku AIP ARN.
+
+## 3. Blast Radius
+
+**Low.** The deleted code paths are unreachable from production:
+
+* `get_model_id()` is only called via `model_id is None` argument in `build_etymologist_prompt` and `analyze_term`. The Lambda always passes the explicit `BEDROCK_MODEL_ID` value (see `src/lambda_function.py:265`), so the `None` branch never executes in production.
+* `DEFAULT_MODEL_ID` is only read inside `get_model_id()` and a test that asserts its value.
+* `ETYMOLOGIST_MODEL` env var is not set on the Lambda (confirmed via `aws lambda get-function-configuration`).
+
+Unit-test impact: `TestGetModelId` (5 tests), `test_default_model_is_nova` (1 test), `test_uses_env_var_model_when_set` (1 test), and `test_uses_default_model_when_none_provided` (1 test — updated to expect `HAIKU_MODEL_ID` instead of deletion).
+
+## 4. Rollback
+
+`git revert <commit-sha>` + `provision.sh`. No data migration. No external systems affected. Local-only refactor.
+
+## 5. Verification
+
+* `ruff check .`
+* `poetry run pytest tests/unit/test_etymologist.py -v`
+* `npm run lint` (no JS changes, but project rule)
+* Post-deploy: smoke test (curl health + curl POST /)

--- a/docs/reports/620/implementation-report.md
+++ b/docs/reports/620/implementation-report.md
@@ -1,0 +1,63 @@
+# Implementation Report — Issue #620
+
+**Title:** chore: remove dead ETYMOLOGIST_MODEL routing — consolidate etymologist model selection
+**Date:** 2026-05-23
+**Status:** Complete (pending review + merge + deploy)
+**Branch:** `620-remove-etymologist-model-routing`
+
+## Summary
+
+Removed dead code paths in `src/etymologist.py` that read the `ETYMOLOGIST_MODEL` environment variable. The Lambda's production code path goes through `BEDROCK_MODEL_ID` (in `lambda_function.py:50`) which is wired correctly; the parallel `ETYMOLOGIST_MODEL` path was specified in LLD #294 but never reached during a real request.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/etymologist.py` | Deleted `DEFAULT_MODEL_ID` constant (line 35) |
+| `src/etymologist.py` | Deleted `get_model_id()` function (lines 206-216) |
+| `src/etymologist.py` | Changed `build_etymologist_prompt()` fallback: `model_id is None` now defaults to `HAIKU_MODEL_ID` (was: `get_model_id()`) |
+| `src/etymologist.py` | Changed `analyze_term()` fallback: same |
+| `src/etymologist.py` | Updated docstrings on `build_etymologist_prompt()` and `analyze_term()` to reflect new behavior |
+| `tests/unit/test_etymologist.py` | Removed imports of `DEFAULT_MODEL_ID` and `get_model_id` |
+| `tests/unit/test_etymologist.py` | Deleted `test_default_model_is_nova` (asserts a deleted constant) |
+| `tests/unit/test_etymologist.py` | Deleted `TestGetModelId` class (5 tests, all exercised dead code) |
+| `tests/unit/test_etymologist.py` | Restructured `TestAnalyzeTermModelSelection`: replaced env-var/default-Nova tests with single `test_defaults_to_haiku_when_model_id_none` test |
+| `docs/lld/active/LLD-620.md` | New LLD documenting the decision and scope |
+
+## Files Intentionally NOT Changed
+
+- `src/lambda_function.py` — `BEDROCK_MODEL_ID` is the correct prod path; no change needed.
+- `src/guardrails/semantic.py` — uses `ALETHEIA_AIP_HAIKU` directly; unaffected.
+- `docs/lld/done/10294-nova-micro-switch.md` — historical, immutable per project rule.
+- `docs/reports/done/1294-implementation-report.md` — same.
+- `docs/audits/10827-audit-infrastructure-integration.md` — already references the correct env var (`BEDROCK_MODEL_ID`).
+- `NOVA_MICRO_MODEL_ID`, `ALLOWED_MODELS`, `is_nova_model()`, `validate_model_id()`, `build_nova_prompt()` — all retained. Nova prompt format remains supported even though no production route currently selects it.
+
+## Lambda Behavior After Deploy
+
+- `BEDROCK_MODEL_ID` env var: unset (no change)
+- `lambda_function.py:50` `BEDROCK_MODEL_ID` constant: falls back to `HAIKU_MODEL_ID` (no change)
+- `HAIKU_MODEL_ID` reads `ALETHEIA_AIP_HAIKU` env var → `arn:aws:bedrock:us-east-1:383687041805:application-inference-profile/hbcetfkyu7ft` (no change)
+- Production etymology requests continue to use Haiku 4.5 (no change in user-visible behavior)
+
+The cleanup is non-functional from a runtime perspective — it removes dead code that was confusing the model-selection picture (per #618 investigation) but does not change which model serves traffic.
+
+## Deploy
+
+1. Merge PR → main.
+2. `provision.sh` deploys Lambda.
+3. Smoke test:
+   - `curl https://api.aletheia.study/health` → 200 OK
+   - `curl -X POST https://api.aletheia.study/ -H "Content-Type: application/json" -H "X-Aletheia-Client-Version: 1.0" -d '{"text":"test"}'` → response with `signal` and `gem`
+4. Confirm `ETYMOLOGIST_MODEL` env var still absent: `aws lambda get-function-configuration --function-name AletheiaAgent --region us-east-1 --query 'Environment.Variables.ETYMOLOGIST_MODEL'` → `null`.
+
+## Rollback
+
+`git revert <commit-sha>` + `provision.sh`. No data migration. No external systems affected.
+
+## Related
+
+- #618 — discovery (gedenken misclassification, includes empirical model probe)
+- #294 — original Nova Micro switch (LLD documented `ETYMOLOGIST_MODEL` as the deploy variable; that env var was never wired into the Lambda code path)
+- #535 — Bedrock AIPs (introduced `ALETHEIA_AIP_*` env vars; orthogonal to this cleanup)
+- #621 — separate pre-existing issue: `httpx` missing from `pyproject.toml` and `provision.sh` (discovered while running tests for this issue)

--- a/docs/reports/620/test-report.md
+++ b/docs/reports/620/test-report.md
@@ -1,0 +1,81 @@
+# Test Report — Issue #620
+
+**Title:** chore: remove dead ETYMOLOGIST_MODEL routing
+**Date:** 2026-05-23
+**Branch:** `620-remove-etymologist-model-routing`
+
+## Lint
+
+```
+$ poetry run ruff check src/etymologist.py tests/unit/test_etymologist.py
+All checks passed!
+```
+
+## Unit Tests (etymologist module — the changed module)
+
+```
+$ poetry run pytest tests/unit/test_etymologist.py -v
+...
+============================= 157 passed in 0.19s =============================
+```
+
+All 157 tests pass. Net change from this issue:
+
+| Action | Tests removed | Tests added | Tests modified |
+|---|---|---|---|
+| Removed `TestGetModelId` class | 5 (covered dead `get_model_id`) | 0 | 0 |
+| Removed `test_default_model_is_nova` | 1 (asserted deleted `DEFAULT_MODEL_ID`) | 0 | 0 |
+| Restructured `TestAnalyzeTermModelSelection` | 2 (env-var read; default-Nova) | 1 (`test_defaults_to_haiku_when_model_id_none`) | 0 |
+
+Net: -7 dead tests, +1 new test reflecting new contract. Total test count before: ~163. After: 157.
+
+## Broader Unit Test Suite (pre-existing breakage, NOT introduced by #620)
+
+```
+$ poetry run pytest tests/unit/ -q
+ERROR ... ModuleNotFoundError: No module named 'httpx'
+ERROR ... ModuleNotFoundError: No module named 'jwt'  (resolved after `poetry install --with dev`)
+!!! Interrupted: 23 errors during collection !!!
+```
+
+23 unit test modules fail to collect due to missing dependencies:
+
+- `httpx` is imported by `src/auth/linkedin_oauth.py:32`, `src/auth/token_manager.py:26`, `tests/unit/test_linkedin_oauth.py:19`, `tests/unit/test_token_manager.py:18` — but is not declared in `pyproject.toml` and not installed by `provision.sh`. Filed as #621.
+
+These failures are **pre-existing** on `main` (verified by running the same command against the main worktree's venv). The #620 change does not introduce them and does not change them. The etymologist module — the only module modified by #620 — has full test coverage that passes.
+
+## Smoke Test (post-deploy — to be executed after merge + provision)
+
+```bash
+# Health
+curl -s https://api.aletheia.study/health
+# Expected: {"status":"ok",...} (200)
+
+# Analysis (Haiku path)
+curl -s -X POST https://api.aletheia.study/ \
+  -H "Content-Type: application/json" \
+  -H "X-Aletheia-Client-Version: 1.0" \
+  -d '{"text":"zeitgeist"}'
+# Expected: {"signal":"...","gem":"...","context":"..."} (200) — Haiku continues to serve
+
+# Verify env state unchanged
+aws lambda get-function-configuration \
+  --function-name AletheiaAgent --region us-east-1 \
+  --query 'Environment.Variables.ETYMOLOGIST_MODEL'
+# Expected: null
+
+aws lambda get-function-configuration \
+  --function-name AletheiaAgent --region us-east-1 \
+  --query 'Environment.Variables.BEDROCK_MODEL_ID'
+# Expected: null
+```
+
+## Regression Risk Assessment
+
+**None for production traffic.** The Lambda's call path uses `BEDROCK_MODEL_ID` (line 50 in `lambda_function.py`), which is unchanged. The deleted code was on a `model_id is None` branch that the Lambda never takes (the Lambda always passes an explicit `model_id`).
+
+The `model_id is None` branch is exercised by:
+- Direct test callers in `test_etymologist.py` (covered by `test_defaults_to_haiku_when_model_id_none`)
+- Direct script callers (e.g., `data/probe_models.py` and similar — all pass explicit `model_id`)
+
+No production caller relies on the `None` default.

--- a/src/etymologist.py
+++ b/src/etymologist.py
@@ -31,9 +31,6 @@ HAIKU_MODEL_ID = os.environ.get(
     "ALETHEIA_AIP_HAIKU", "anthropic.claude-haiku-4-5-20251001-v1:0"
 )
 
-# Issue #294: Default to Nova Micro for improved latency (532ms vs 1469ms)
-DEFAULT_MODEL_ID = NOVA_MICRO_MODEL_ID
-
 # Issue #535: Allowlist — accepts AIP ARNs and raw model IDs
 ALLOWED_MODELS = {
     NOVA_MICRO_MODEL_ID,
@@ -203,19 +200,6 @@ def validate_model_id(model_id: str) -> bool:
     return model_id in ALLOWED_MODELS
 
 
-def get_model_id() -> str:
-    """Issue #294: Get model ID from environment or use default.
-
-    Validates model against allowlist, falls back to default if invalid.
-    Logs warning for invalid model IDs to aid debugging.
-    """
-    model_id = os.environ.get("ETYMOLOGIST_MODEL", DEFAULT_MODEL_ID)
-    if not validate_model_id(model_id):
-        logger.warning(f"Invalid model ID '{model_id}', falling back to {DEFAULT_MODEL_ID}")
-        return DEFAULT_MODEL_ID
-    return model_id
-
-
 class EtymologistResponse(TypedDict):
     """Structured response from the Digital Etymologist."""
 
@@ -320,10 +304,13 @@ def build_etymologist_prompt(word: str, page_context: str = "", model_id: str | 
     Issue #294: Build model-appropriate prompt based on model ID.
 
     Dispatches to Nova or Haiku prompt builder based on model ID prefix.
-    If model_id is None, uses get_model_id() to read from environment.
+    If model_id is None, defaults to HAIKU_MODEL_ID. The Lambda caller
+    always passes an explicit model_id (BEDROCK_MODEL_ID env var in
+    lambda_function.py); the None default exists for direct callers
+    (tests, scripts).
     """
     if model_id is None:
-        model_id = get_model_id()
+        model_id = HAIKU_MODEL_ID
 
     if is_nova_model(model_id):
         return build_nova_prompt(word, page_context)
@@ -714,16 +701,18 @@ def analyze_term(
         word: The term to analyze.
         context: Page context for disambiguation.
         bedrock_client: boto3 Bedrock client (optional, for dependency injection).
-        model_id: Bedrock model ID to use. If None, reads from ETYMOLOGIST_MODEL env var.
+        model_id: Bedrock model ID to use. If None, defaults to HAIKU_MODEL_ID.
+            The Lambda caller always passes an explicit model_id (BEDROCK_MODEL_ID
+            env var in lambda_function.py:50); the None default exists for direct
+            callers (tests, scripts).
 
     Returns:
         AnalysisResult with status, response, and metadata.
     """
     start_time = time.time()
 
-    # Issue #294: Resolve model_id from environment if not provided
     if model_id is None:
-        model_id = get_model_id()
+        model_id = HAIKU_MODEL_ID
 
     # Handle empty input gracefully
     if not word or not word.strip():

--- a/tests/unit/test_etymologist.py
+++ b/tests/unit/test_etymologist.py
@@ -12,7 +12,6 @@ import pytest
 
 from src.etymologist import (
     ALLOWED_MODELS,
-    DEFAULT_MODEL_ID,
     FALLBACK_RESPONSE,
     HAIKU_MODEL_ID,
     NOVA_MICRO_MODEL_ID,
@@ -30,7 +29,6 @@ from src.etymologist import (
     extract_token_usage,
     fix_mixed_quote_pairs,
     get_fallback_response,
-    get_model_id,
     is_nova_model,
     process_bedrock_response,
     validate_model_id,
@@ -778,10 +776,6 @@ class TestModelConstants:
         """Issue #535: Haiku model ID defaults to Haiku 4.5."""
         assert HAIKU_MODEL_ID == "anthropic.claude-haiku-4-5-20251001-v1:0"
 
-    def test_default_model_is_nova(self):
-        """Default model is Nova Micro for improved latency."""
-        assert DEFAULT_MODEL_ID == NOVA_MICRO_MODEL_ID
-
     def test_allowed_models_contains_nova(self):
         """Allowlist contains Nova Micro."""
         assert NOVA_MICRO_MODEL_ID in ALLOWED_MODELS
@@ -836,30 +830,6 @@ class TestIsNovaModel:
         assert is_nova_model(
             "arn:aws:bedrock:us-east-1:383687041805:inference-profile/aletheia-haiku"
         ) is False
-
-
-class TestGetModelId:
-    """Issue #294: Tests for get_model_id with environment variable handling."""
-
-    def test_returns_default_when_env_not_set(self, monkeypatch):
-        """Returns default model when env var not set."""
-        monkeypatch.delenv("ETYMOLOGIST_MODEL", raising=False)
-        assert get_model_id() == DEFAULT_MODEL_ID
-
-    def test_returns_nova_when_set_to_nova(self, monkeypatch):
-        """Returns Nova Micro when env var set to Nova."""
-        monkeypatch.setenv("ETYMOLOGIST_MODEL", NOVA_MICRO_MODEL_ID)
-        assert get_model_id() == NOVA_MICRO_MODEL_ID
-
-    def test_returns_haiku_when_set_to_haiku(self, monkeypatch):
-        """Returns Haiku when env var set to Haiku."""
-        monkeypatch.setenv("ETYMOLOGIST_MODEL", HAIKU_MODEL_ID)
-        assert get_model_id() == HAIKU_MODEL_ID
-
-    def test_falls_back_to_default_for_invalid_model(self, monkeypatch):
-        """Falls back to default when env var has invalid model ID."""
-        monkeypatch.setenv("ETYMOLOGIST_MODEL", "invalid-model")
-        assert get_model_id() == DEFAULT_MODEL_ID
 
 
 class TestBuildNovaPrompt:
@@ -1060,27 +1030,18 @@ class TestNovaSystemPrompt:
 
 
 class TestAnalyzeTermModelSelection:
-    """Issue #294: Tests for model selection in analyze_term."""
+    """Issue #620: Tests for model selection in analyze_term."""
 
-    def test_uses_default_model_when_none_provided(self, mock_bedrock_client, monkeypatch):
-        """Uses default model when model_id is None."""
-        monkeypatch.delenv("ETYMOLOGIST_MODEL", raising=False)
-        # Will fail at invoke_model but we can check what model was used
+    def test_defaults_to_haiku_when_model_id_none(self, mock_bedrock_client):
+        """When model_id is None, defaults to HAIKU_MODEL_ID."""
         mock_bedrock_client.invoke_model.side_effect = Exception("test")
         result = analyze_term("test", "", bedrock_client=mock_bedrock_client)
-        assert result["metadata"]["model"] == DEFAULT_MODEL_ID
+        assert result["metadata"]["model"] == HAIKU_MODEL_ID
 
     def test_uses_provided_model_id(self, mock_bedrock_client):
         """Uses explicitly provided model_id."""
         mock_bedrock_client.invoke_model.side_effect = Exception("test")
         result = analyze_term("test", "", bedrock_client=mock_bedrock_client, model_id=HAIKU_MODEL_ID)
-        assert result["metadata"]["model"] == HAIKU_MODEL_ID
-
-    def test_uses_env_var_model_when_set(self, mock_bedrock_client, monkeypatch):
-        """Uses model from ETYMOLOGIST_MODEL env var."""
-        monkeypatch.setenv("ETYMOLOGIST_MODEL", HAIKU_MODEL_ID)
-        mock_bedrock_client.invoke_model.side_effect = Exception("test")
-        result = analyze_term("test", "", bedrock_client=mock_bedrock_client)
         assert result["metadata"]["model"] == HAIKU_MODEL_ID
 
     def test_successful_nova_call_with_mock(self, mock_bedrock_client):


### PR DESCRIPTION
## Summary

Removes the dead `ETYMOLOGIST_MODEL` env-var path in `src/etymologist.py`. The Lambda's production code path goes through `BEDROCK_MODEL_ID` (`lambda_function.py:50`); the parallel `ETYMOLOGIST_MODEL` routing — which LLD #294 documented as the production switch — was never wired in. The Lambda has been serving Haiku via the `BEDROCK_MODEL_ID` → `HAIKU_MODEL_ID` fallback since launch, not Nova Micro as #294 intended.

Discovered during #618 (gedenken misclassification) investigation. User direction: keep Haiku, delete the dead Nova-Micro routing.

## Changes

- Deleted `DEFAULT_MODEL_ID`, `get_model_id()`, and `ETYMOLOGIST_MODEL` env reads in `src/etymologist.py`
- `build_etymologist_prompt()` and `analyze_term()`: `model_id is None` now defaults to `HAIKU_MODEL_ID`
- Removed dead-path unit tests; added one new contract test
- New: LLD-620, implementation-report, test-report

## No production behavior change

Lambda still serves Haiku 4.5 via the unchanged `BEDROCK_MODEL_ID` → `HAIKU_MODEL_ID` path. This is dead-code removal, not a feature change.

## Test plan

- [x] `ruff check src/etymologist.py tests/unit/test_etymologist.py` — clean
- [x] `pytest tests/unit/test_etymologist.py` — 157 passed
- [ ] After merge: `provision.sh` deploy
- [ ] Smoke test: `curl /health` + `curl POST /` (returns signal+gem)
- [ ] Verify `ETYMOLOGIST_MODEL` env var still absent on Lambda

Closes #620

Discovered separately during testing: #621 (pre-existing `httpx` dep gap — not fixed here, filed for follow-up).