### PR TITLE
fix: revert overreach on Discworld asides (Closes #630)

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -137,7 +137,7 @@
         </div>
       </div>
 
-      <p class="discworld-aside">The Encyclopedia Galactica was Hari Seldon's first move: catalogue everything, then watch what falls out of the patterns. The Plan needed the encyclopedia to be filed correctly more than it needed any particular entry to be read. Every request Aletheia handles is filed before it is acted on.</p>
+      <p class="discworld-aside">Much like the Unseen University Library, where every book must pass through several layers of cataloguing before reaching the shelves &mdash; and the Librarian knows exactly where each one belongs &mdash; every request is filed, classified, and stored with precision. Ook.</p>
 
       <h2>Context &amp; Memory Strategy</h2>
       <p>Aletheia uses request-scoped context enrichment, not conversational memory. When a user selects text, the extension captures a context bundle of three signals:</p>

--- a/docs/observability.html
+++ b/docs/observability.html
@@ -57,7 +57,7 @@
 
       <p>Observability in LLM systems is fundamentally different from traditional web services. You can't just log request/response bodies &mdash; those contain user-generated text that may be sensitive. Every metric, trace annotation, and dashboard widget must be designed with the assumption that the content is private, while the operational metadata is not.</p>
 
-      <p class="discworld-aside">Hermes carried messages between the gods and the dead. His winged sandals were not the load-bearing element of his work. The load-bearing element was that he always remembered who sent each message, to whom, and at what hour. Tracing is older than computers; it used to wear winged sandals.</p>
+      <p class="discworld-aside">Like the Clacks towers of the Grand Trunk, every message carries overhead bytes recording its journey &mdash; how long each tower held it, which ones dropped it, the cost of the semaphore time &mdash; but the message itself is never read by the operators. GNU Terry Pratchett.</p>
 
       <h2>X-Ray Distributed Tracing</h2>
       <p>AWS X-Ray traces requests end-to-end across Lambda, DynamoDB, and Bedrock. Sampling is set at <strong>5%</strong> to balance visibility against cost.</p>

--- a/docs/operations.html
+++ b/docs/operations.html
@@ -55,7 +55,7 @@
         <strong>The problem:</strong> LLM APIs charge per token. A single runaway loop or DDoS can generate an unbounded bill. Every layer of the system is designed to prevent this &mdash; not just detect it after the fact.
       </div>
 
-      <p class="discworld-aside">Odin governed the Nine Worlds not by ruling them but by watching from Hlidskjalf, the high seat from which he could see everything that happened. He sent ravens to ask questions. He sent Valkyries to settle wars. He intervened only when a thread was about to unravel. The same principle applies here.</p>
+      <p class="discworld-aside">Lord Vetinari governs Ankh-Morpork not through force but through careful observation and the occasional, precise intervention. The city runs itself; he merely ensures nothing runs away with it. The same principle applies here.</p>
 
       <h2>Three-Layer Kill Switch</h2>
       <p>When something goes wrong, the system shuts itself down. Three independent mechanisms ensure that no single failure mode can result in unbounded spend:</p>

--- a/docs/reports/630/implementation-report.md
+++ b/docs/reports/630/implementation-report.md
@@ -1,0 +1,38 @@
+# Implementation Report — Issue #630
+
+**Title:** fix: revert overreach on Discworld asides — restore originals on engineering pages
+**Date:** 2026-05-23
+**Status:** Complete (pending review + merge)
+**Branch:** `630-restore-discworld-asides`
+
+## Summary
+
+#628 over-scoped. The user direction (during #625 review) was to remove the Discworld reference I had introduced in `demos.html`, not to touch the pre-existing Discworld asides on the engineering documentation pages. This PR restores the original Pratchett character on the four engineering pages and leaves the legitimate Ulysses replacement in `demos.html` alone.
+
+## Files Modified
+
+| File | Action | Restored content |
+|------|--------|------------------|
+| `docs/architecture.html` | Restore | Unseen University Library + cataloguing + Ook |
+| `docs/observability.html` | Restore | Clacks towers / Grand Trunk / GNU Terry Pratchett |
+| `docs/operations.html` | Restore | Lord Vetinari governing Ankh-Morpork |
+| `docs/safety.html` | Restore | Librarian of Unseen University zero-tolerance |
+
+## Files NOT Modified
+
+- `docs/demos.html` — keeps the Ulysses / Trojan Horse aside from #628. That was the one legitimate change (the Lancre quote was something I added in #625; the user asked for it to be replaced with something mainstream).
+- `docs/threat-model.html` — its `discworld-aside` CSS class styles a paragraph whose content is not actually Discworld (it's an original observation about hostile-text-on-the-page). Unaffected.
+
+## Lesson
+
+When the user said "nobody knows Discworld," that applied specifically to the new Discworld reference I had introduced — not as an invitation to clean up every Discworld reference site-wide. The pre-existing engineering-page asides are part of the project's voice and were not part of the request. I should have asked before expanding the scope.
+
+## Verification
+
+- Diff against pre-#628 content for each file is byte-equivalent
+- Post-merge: `https://aletheia.study/architecture.html`, `/observability.html`, `/operations.html`, `/safety.html` show their original Pratchett asides
+
+## Related
+
+- #625 — original demo content
+- #628 — the over-scoped change being partially reverted

--- a/docs/reports/630/test-report.md
+++ b/docs/reports/630/test-report.md
@@ -1,0 +1,32 @@
+# Test Report — Issue #630
+
+**Title:** fix: revert overreach on Discworld asides
+**Date:** 2026-05-23
+
+## Validation
+
+Four single-paragraph content reverts. No structural change, no CSS change, no code change.
+
+| Check | Result |
+|-------|--------|
+| `docs/architecture.html` aside restored to UU Library / Ook | ✓ |
+| `docs/observability.html` aside restored to Clacks towers / GNU Terry Pratchett | ✓ |
+| `docs/operations.html` aside restored to Lord Vetinari / Ankh-Morpork | ✓ |
+| `docs/safety.html` aside restored to Librarian of UU | ✓ |
+| `docs/demos.html` Ulysses aside untouched | ✓ |
+| `docs/threat-model.html` original-observation aside untouched | ✓ |
+
+## Post-deploy smoke
+
+```bash
+curl -s https://aletheia.study/architecture.html | grep -ic "unseen university\|librarian"
+curl -s https://aletheia.study/observability.html | grep -ic "clacks\|gnu terry pratchett"
+curl -s https://aletheia.study/operations.html | grep -ic "vetinari\|ankh-morpork"
+curl -s https://aletheia.study/safety.html | grep -ic "librarian of unseen university"
+```
+
+Each should return at least 1 after CloudFlare publishes.
+
+## Regression risk
+
+Zero. Reverting to known-good prior content.

--- a/docs/safety.html
+++ b/docs/safety.html
@@ -55,7 +55,7 @@
         <strong>Core principle:</strong> The LLM classifies; code enforces. Policy decisions &mdash; what to block, what to warn, what to allow &mdash; are never delegated to the model. The model's job is classification. The code's job is enforcement.
       </div>
 
-      <p class="discworld-aside">The Butlerian Jihad ended ten thousand years before House Atreides reached Arrakis, and it ended with a single commandment: thou shalt not make a machine in the likeness of a human mind. The machines did not propose this rule. It was made by humans, applied to machines, and enforced by humans. Aletheia's guardrails follow the same shape.</p>
+      <p class="discworld-aside">The Librarian of Unseen University has a simple policy regarding the mistreatment of books: zero tolerance, applied instantly, with no appeals process. The books don't decide their own protection &mdash; the Librarian does. Our guardrails follow the same philosophy.</p>
 
       <h2>Two-Layer Guardrail Pipeline</h2>
       <p>Every request passes through two sequential guardrail layers before reaching the LLM. The layers are deliberately different in design: one is fast and deterministic, the other is slow and semantic. Together they provide both breadth and depth of coverage.</p>


### PR DESCRIPTION
Restoring original Discworld asides on architecture.html, observability.html, operations.html, safety.html. #628 over-scoped — user only asked to replace the demos.html aside (the one I introduced in #625), not the pre-existing ones on the engineering pages.

demos.html's Ulysses replacement is untouched.

Closes #630