### PR TITLE
fix: scrub exception text from semantic guardrail logs and response (close #619)

### DIFF
--- a/docs/reports/619/implementation-report.md
+++ b/docs/reports/619/implementation-report.md
@@ -1,0 +1,74 @@
+# Implementation Report — Issue #619
+
+## Scope
+
+Fix the silent exception swallowing in `src/guardrails/semantic.py` while honoring Aletheia's absolute privacy commitment in `docs/observability.html`: *"NEVER log prompt text, user input, completion text, URLs, or user IDs."*
+
+## Changes
+
+### `src/guardrails/semantic.py:160-173`
+
+Before:
+```python
+except Exception as e:
+    timings["total_ms"] = int((time.time() - start) * 1000)
+    logger.info(f"SEMANTIC_GUARDRAIL_TIMING (error): {json.dumps(timings)}")
+    return {
+        ...
+        "reason": f"Guardrail Error: {str(e)}",
+        ...
+    }
+```
+
+After:
+```python
+except Exception as e:
+    timings["total_ms"] = int((time.time() - start) * 1000)
+    # Privacy: log exception class name only, never str(e) or repr(e).
+    # Exception messages from this path can carry user-derived content
+    # (json.JSONDecodeError, botocore ClientError) — see issue #619.
+    error_class = e.__class__.__name__
+    logger.error(
+        f"SEMANTIC_GUARDRAIL_ERROR: {error_class} | {json.dumps(timings)}"
+    )
+    return {
+        ...
+        "reason": f"Guardrail Error: {error_class}",
+        ...
+    }
+```
+
+Three behavioral changes:
+
+1. **Log level promoted from `info` to `error`** — this is an actual failure condition, not normal flow. Better for CloudWatch filtering and alarming.
+2. **Diagnostic signal added** — log line now includes `SEMANTIC_GUARDRAIL_ERROR: <ClassName>` so future occurrences are attributable to a specific exception class.
+3. **Privacy hardening** — `str(e)` removed from both the log message AND the `reason` field of the returned dict. The `reason` field went over the wire to the client; cleaning it up closes a pre-existing leak.
+
+## Privacy Rationale
+
+The semantic guardrail processes user-selected text. Exceptions raised from that processing path can carry user-derived content:
+
+- `botocore.exceptions.ClientError` — Bedrock validation error messages can echo field values from the request payload (including the user text wrapped in the prompt).
+- `json.JSONDecodeError` — `str(e)` is safe, but `e.doc` holds the full malformed document (LLM output, which often paraphrases user input). Logging `str(e)` today is a foot-gun for any future code that touches `e.doc`.
+- Custom exceptions from transitively-imported libraries — unbounded; the catch-all `except Exception` can receive anything.
+
+Only the exception class name is bounded by a code-readable enumeration, so it's the only safe thing to surface.
+
+## What This Fix Does NOT Cover
+
+The audit performed in service of this issue identified **13 other distinct exception-text leak surfaces** across `src/lambda_function.py`, `src/lambda_auth_function.py`, `src/etymologist.py`, `src/poetic_analyzer.py`, and `src/signal_inspector/fetcher.py` — all introduced before the Mar 12 build. Per "One Issue Per Concern," each will be filed as its own follow-up issue rather than bundled into this PR.
+
+## Closes
+
+- #619
+
+## Blast Radius
+
+- Code change is in `src/guardrails/semantic.py` only — code-only deploy, no dependency layer rebuild
+- Deploy via `provision.sh` repackages the Agent Lambda zip; only `AletheiaAgent` swaps; other 3 Lambdas untouched
+- Rollback: `aws lambda update-function-code --function-name AletheiaAgent --zip-file fileb://<previous>.zip` (or revert + redeploy)
+
+## Verification (post-deploy)
+
+1. Smoke test: `curl https://api.aletheia.study/health` + `curl -X POST https://api.aletheia.study/ ...`
+2. Trigger a deliberate semantic guardrail failure (e.g. via test endpoint or by sending a request known to provoke a `JSONDecodeError` on the model output) and verify CloudWatch `/aws/lambda/AletheiaAgent` shows `SEMANTIC_GUARDRAIL_ERROR: <ClassName>` and nothing else

--- a/docs/reports/619/test-report.md
+++ b/docs/reports/619/test-report.md
@@ -1,0 +1,38 @@
+# Test Report — Issue #619
+
+## New Test Class
+
+`tests/unit/test_semantic.py::TestExceptionTextDoesNotLeak` — 4 tests asserting the privacy property explicitly:
+
+| Test | Assertion |
+|---|---|
+| `test_exception_message_not_in_response_reason` | `result["reason"]` contains the class name but not the canary exception message |
+| `test_exception_message_not_in_any_response_field` | Recursive walk: no string anywhere in the response dict contains the canary |
+| `test_exception_message_not_in_log_output` | Via `caplog`: no log record contains the canary; class name AND `SEMANTIC_GUARDRAIL_ERROR` token DO appear |
+| `test_custom_exception_class_name_preserved` | A custom `WeirdCustomError(Exception)` subclass: class name preserved, canary absent |
+
+The canary string `CANARY-LEAK-9d7e3f0a-WOULD-BE-USER-TEXT` is uniqueness-tagged so any leak point in the future would trip the assertion regardless of intervening string manipulation.
+
+## Pytest Run
+
+```
+cd Aletheia-619
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `827 passed, 13 warnings in 7.43s` — zero failures.
+
+Baseline before this change was 823 tests; the 4 new tests in `TestExceptionTextDoesNotLeak` bring the total to 827. The 13 pre-existing `InsecureKeyLengthWarning` warnings from `jwt.api_jwt` are unrelated to this change.
+
+## Existing Test Compatibility
+
+Two existing tests exercise the exception branch:
+
+- `test_semantic_failure` (line 132-145) asserts `"Guardrail Error" in result["reason"]` — still passes (the prefix `"Guardrail Error:"` is preserved; only the suffix changes from `str(e)` to class name).
+- `TestHardSoftBlockingLogic::test_error_returns_soft_block_with_fallback` (line 260-274) — asserts `block_type == SOFT`, `is_fallback is True`, `is_safe is False`. All still pass; this fix doesn't change the fallback semantics.
+
+No existing tests modified.
+
+## Conclusion
+
+Safe to merge. Pending operator sign-off, the fix is then ready for `provision.sh` deploy + smoke test.

--- a/src/guardrails/semantic.py
+++ b/src/guardrails/semantic.py
@@ -159,15 +159,19 @@ class SemanticGuardrail:
 
         except Exception as e:
             timings["total_ms"] = int((time.time() - start) * 1000)
-            logger.info(f"SEMANTIC_GUARDRAIL_TIMING (error): {json.dumps(timings)}")
-            # Fail closed on infrastructure error - treat as soft block with fallback
-            # (Per LLD 1126: semantic errors → soft block, not hard block)
+            # Privacy: log exception class name only, never str(e) or repr(e).
+            # Exception messages from this path can carry user-derived content
+            # (json.JSONDecodeError, botocore ClientError) — see issue #619.
+            error_class = e.__class__.__name__
+            logger.error(
+                f"SEMANTIC_GUARDRAIL_ERROR: {error_class} | {json.dumps(timings)}"
+            )
             return {
                 "block_type": BLOCK_TYPE_SOFT,
                 "category": "error",
                 "scores": {},
                 "is_safe": False,
-                "reason": f"Guardrail Error: {str(e)}",
+                "reason": f"Guardrail Error: {error_class}",
                 "is_fallback": True,
             }
 

--- a/tests/unit/test_semantic.py
+++ b/tests/unit/test_semantic.py
@@ -406,3 +406,86 @@ class TestRacialVocabularyClassification:
         assert result["block_type"] == BLOCK_TYPE_NONE
         assert result["category"] == "None"
         assert result["is_safe"] is True
+
+
+class TestExceptionTextDoesNotLeak:
+    """Issue #619: exception text must never appear in log output or response payload.
+
+    Aletheia's public privacy commitment (docs/observability.html) is absolute:
+    "NEVER log prompt text, user input, completion text, URLs, or user IDs."
+    Exceptions raised from code that processes user input can carry user-derived
+    content in their message text (json.JSONDecodeError via e.doc, botocore
+    ClientError validation messages, custom wrapped exceptions). Only the
+    exception class name may flow into logs and response fields.
+    """
+
+    CANARY = "CANARY-LEAK-9d7e3f0a-WOULD-BE-USER-TEXT"
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_exception_message_not_in_response_reason(self, mock_boto_client):
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+        mock_client_instance.invoke_model.side_effect = Exception(self.CANARY)
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("test input")
+
+        assert self.CANARY not in result["reason"], (
+            f"Exception text leaked into result['reason']: {result['reason']!r}"
+        )
+        assert "Exception" in result["reason"], "Exception class name missing — lost diagnostic value"
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_exception_message_not_in_any_response_field(self, mock_boto_client):
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+        mock_client_instance.invoke_model.side_effect = Exception(self.CANARY)
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("test input")
+
+        def _no_canary(obj, path="result"):
+            if isinstance(obj, str):
+                assert self.CANARY not in obj, f"Canary leaked at {path}: {obj!r}"
+            elif isinstance(obj, dict):
+                for k, v in obj.items():
+                    _no_canary(v, f"{path}[{k!r}]")
+            elif isinstance(obj, (list, tuple)):
+                for i, v in enumerate(obj):
+                    _no_canary(v, f"{path}[{i}]")
+
+        _no_canary(result)
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_exception_message_not_in_log_output(self, mock_boto_client, caplog):
+        import logging
+
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+        mock_client_instance.invoke_model.side_effect = Exception(self.CANARY)
+
+        guard = SemanticGuardrail()
+        with caplog.at_level(logging.ERROR, logger="src.guardrails.semantic"):
+            guard.check_safety("test input")
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text, (
+            f"Exception text leaked into log output: {log_text!r}"
+        )
+        assert "SEMANTIC_GUARDRAIL_ERROR" in log_text
+        assert "Exception" in log_text, "Exception class name missing from log — lost diagnostic value"
+
+    @patch("src.guardrails.semantic.boto3.client")
+    def test_custom_exception_class_name_preserved(self, mock_boto_client):
+        class WeirdCustomError(Exception):
+            pass
+
+        mock_client_instance = Mock()
+        mock_boto_client.return_value = mock_client_instance
+        mock_client_instance.invoke_model.side_effect = WeirdCustomError(self.CANARY)
+
+        guard = SemanticGuardrail()
+        result = guard.check_safety("test input")
+
+        assert self.CANARY not in result["reason"]
+        assert "WeirdCustomError" in result["reason"]


### PR DESCRIPTION
## Summary

Fixes silent exception swallowing in `src/guardrails/semantic.py` while honoring Aletheia's absolute privacy commitment in `docs/observability.html`: *"NEVER log prompt text, user input, completion text, URLs, or user IDs."*

The original issue body proposed adding `repr(e)` or `str(e)` to the log. The [security/privacy analysis on #619](https://github.com/martymcenroe/Aletheia/issues/619#issuecomment-4536197450) tightened that to **class name only**, because exception messages from this code path can carry user-derived content (`botocore.ClientError` validation messages, `json.JSONDecodeError` via `e.doc`, custom wrapped exceptions).

## Changes

`src/guardrails/semantic.py:160-173`:
- Log: `logger.info(timings)` → `logger.error("SEMANTIC_GUARDRAIL_ERROR: <ClassName> | timings")`
- Response `reason` field: `f"Guardrail Error: {str(e)}"` → `f"Guardrail Error: <ClassName>"`
- Promoted log level from `info` to `error` (this is a real failure)

`tests/unit/test_semantic.py`: added `TestExceptionTextDoesNotLeak` (4 tests) that use a canary string in the raised exception and assert it never appears in:
- the response dict (recursive walk)
- log output (via caplog)
- the response `reason` field
…while asserting the class name DOES appear (so diagnostic value is preserved).

## Test Results

`poetry run pytest tests/unit/ -q` — **827 passed, 0 failures** (was 823; +4 from the new class).

## Blast Radius

Code-only deploy via `provision.sh`. Only `AletheiaAgent` Lambda repackages. No dependency layer rebuild. Rollback is `aws lambda update-function-code` to the previous zip.

## Reports

- `docs/reports/619/implementation-report.md`
- `docs/reports/619/test-report.md`

## Related (audit findings — not in this PR)

The audit done in service of this issue identified **13 other distinct exception-text leak surfaces** across `src/lambda_function.py`, `src/lambda_auth_function.py`, `src/etymologist.py`, `src/poetic_analyzer.py`, and `src/signal_inspector/fetcher.py`. Per "One Issue Per Concern," each will be filed as its own follow-up issue rather than bundled here.

Closes #619