### PR TITLE
fix: scrub exception text leaks in lambda_function.py (close #638, #650, #651)

### DIFF
--- a/docs/reports/638/implementation-report.md
+++ b/docs/reports/638/implementation-report.md
@@ -1,0 +1,80 @@
+# Implementation Report — Issues #638, #650, #651 (audit umbrella #637)
+
+## Scope
+
+PR 1 of 5 in the audit-umbrella #637 fix arc. Applies the class-name-only pattern (established by PR #636 / close #619) to all 3 exception-text leak surfaces in `src/lambda_function.py`.
+
+## Changes
+
+### `src/lambda_function.py:503-512` (closes #638 + #651)
+
+The etymology-generation `except Exception as e` block previously did:
+
+```python
+response_data = {
+    "signal": "error",
+    "gem": str(e),               # #638 (HIGH): exception text → response field → client
+    "context": "Generation failed",
+}
+logger.error(f"Etymology generation failed: {e}")  # #651 (LOW): exception text → CloudWatch
+```
+
+Replaced with:
+
+```python
+error_class = e.__class__.__name__
+response_data = {
+    "signal": "error",
+    "gem": f"Generation Error: {error_class}",
+    "context": "Generation failed",
+}
+logger.error(f"ETYMOLOGY_GENERATION_ERROR: {error_class}")
+```
+
+### `src/lambda_function.py:760-762` (closes #650)
+
+The catch-all unhandled-exception logger previously did:
+
+```python
+logger.error(f"CRITICAL: Unhandled exception: {type(e).__name__}: {e}")  # trailing {e} is the leak
+```
+
+Replaced with:
+
+```python
+logger.error(f"CRITICAL: Unhandled exception: {e.__class__.__name__}")
+```
+
+The class name is preserved for diagnostic value; only the trailing `{e}` interpolation is removed.
+
+## Test Updates
+
+### New: `TestLambdaFunctionExceptionTextDoesNotLeak` in `tests/unit/test_lambda_handler.py`
+
+3 tests using a canary string in the raised exception:
+
+- `test_etymology_exception_not_in_response_gem` — exception text absent from response body AND log output; `ETYMOLOGY_GENERATION_ERROR` token + class name present
+- `test_etymology_exception_class_name_preserved_in_gem` — class name appears in gem field for diagnostic value
+- `test_unhandled_exception_log_does_not_leak` — catch-all logger preserves class name without leaking the message text
+
+### Updated: `tests/unit/test_persistence.py:278` (test_020_generation_failure_still_saves)
+
+The existing test asserted `"Bedrock timeout" in response_data["gem"]` — that assertion codified the leaky behavior we just fixed. Updated to assert the privacy-preserving behavior:
+
+```python
+assert "Bedrock timeout" not in response_data["gem"]   # canary absent
+assert "Generation Error" in response_data["gem"]      # prefix preserved
+assert "Exception" in response_data["gem"]             # class name present
+```
+
+## Closes
+
+- #638 (H1, HIGH)
+- #650 (L13, LOW)
+- #651 (L14, LOW)
+
+Part of umbrella #637 (4 of 14 surfaces resolved; 10 remaining across the next 4 PRs).
+
+## Blast Radius
+
+Code change in `src/lambda_function.py` only — code-only deploy via `provision.sh`. Only `AletheiaAgent` Lambda repackages. Rollback: `aws lambda update-function-code` to previous zip.

--- a/docs/reports/638/test-report.md
+++ b/docs/reports/638/test-report.md
@@ -1,0 +1,36 @@
+# Test Report — Issues #638, #650, #651
+
+## Pytest Run
+
+```
+cd Aletheia-638
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `830 passed, 13 warnings in 5.79s` — zero failures.
+
+Baseline after PR #636 was 827; this PR adds 3 new privacy tests = 830.
+
+## New Tests
+
+`tests/unit/test_lambda_handler.py::TestLambdaFunctionExceptionTextDoesNotLeak`:
+
+| Test | Asserts |
+|---|---|
+| `test_etymology_exception_not_in_response_gem` | Canary absent from response body (recursive walk) AND log output; `ETYMOLOGY_GENERATION_ERROR` + class name present in log |
+| `test_etymology_exception_class_name_preserved_in_gem` | Class name (e.g. `RuntimeError`) appears in gem field; canary absent |
+| `test_unhandled_exception_log_does_not_leak` | Catch-all logger preserves class name without leaking message text |
+
+## Updated Test
+
+`tests/unit/test_persistence.py:278` — `test_020_generation_failure_still_saves`
+
+Previously asserted `"Bedrock timeout" in response_data["gem"]` (codifying the leak). Now asserts the inverse plus the new prefix + class-name presence.
+
+## ESLint
+
+Unchanged from baseline — no JS files modified.
+
+## Conclusion
+
+Safe to merge. Pending operator sign-off (or auto-deploy under the audit-umbrella authorization), `provision.sh` + smoke test follow.

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -501,14 +501,17 @@ def _analysis_handler(
             "context": result["response"]["context"],
         }
     except Exception as e:
-        # Issue #178: Capture error state for debugging
+        # Issue #178: Capture error state for debugging.
+        # Privacy (#638, #651): log/return exception class name only — never str(e).
+        # Bedrock errors can carry request-payload echoes; see #637 audit umbrella.
         generation_error = e
+        error_class = e.__class__.__name__
         response_data = {
             "signal": "error",
-            "gem": str(e),
+            "gem": f"Generation Error: {error_class}",
             "context": "Generation failed",
         }
-        logger.error(f"Etymology generation failed: {e}")
+        logger.error(f"ETYMOLOGY_GENERATION_ERROR: {error_class}")
     finally:
         # Issue #162: Skip persistence if noarchive signal is present
         if skip_persistence:
@@ -758,8 +761,9 @@ def lambda_handler(
         return {"statusCode": 500, "body": json.dumps({"error": "Service error"})}
 
     except Exception as e:
-        # Catch-all: NEVER proceed to generation on unhandled error
-        logger.error(f"CRITICAL: Unhandled exception: {type(e).__name__}: {e}")
+        # Catch-all: NEVER proceed to generation on unhandled error.
+        # Privacy (#650): class name only — never str(e). See #637 audit umbrella.
+        logger.error(f"CRITICAL: Unhandled exception: {e.__class__.__name__}")
         # Issue #369: Emit error metric (fail-open)
         try:
             emit_error_rate_metric(500)

--- a/tests/unit/test_lambda_handler.py
+++ b/tests/unit/test_lambda_handler.py
@@ -666,3 +666,108 @@ class TestMetricsEndpoint:
         assert "users" in body
         assert "usage" in body
         assert "caps" in body
+
+
+class TestLambdaFunctionExceptionTextDoesNotLeak:
+    """Issues #638, #650, #651 (audit umbrella #637):
+
+    Per docs/observability.html: "NEVER log prompt text, user input, completion
+    text, URLs, or user IDs." Exception messages from etymology generation and
+    the catch-all handler must not leak into the response body or log output.
+    Only the exception class name may surface.
+    """
+
+    CANARY = "CANARY-LEAK-lambda-fn-d9b3e7-WOULD-BE-USER-TEXT"
+
+    def _safe_semantic_mock(self):
+        from src.guardrails.semantic import BLOCK_TYPE_NONE
+
+        mock_guard = MagicMock()
+        mock_guard.check_safety.return_value = {
+            "block_type": BLOCK_TYPE_NONE,
+            "category": "None",
+            "is_safe": True,
+            "reason": "None",
+            "scores": {},
+        }
+        return mock_guard
+
+    def test_etymology_exception_not_in_response_gem(self, caplog):
+        """Issue #638: etymology generation exception must not appear in response gem field."""
+        import logging
+
+        event = {"text": "apple"}
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, patch(
+            "src.lambda_function.generate_etymology"
+        ) as mock_gen, patch(
+            "src.lambda_function.get_dynamodb_client"
+        ) as mock_dynamo:
+            mock_semantic.return_value = self._safe_semantic_mock()
+            mock_gen.side_effect = Exception(self.CANARY)
+            mock_dynamo.return_value = MagicMock()
+
+            with caplog.at_level(logging.ERROR, logger="src.lambda_function"):
+                result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+            body = json.loads(result["body"])
+
+            def _no_canary(obj, path="body"):
+                if isinstance(obj, str):
+                    assert self.CANARY not in obj, f"Canary leaked at {path}: {obj!r}"
+                elif isinstance(obj, dict):
+                    for k, v in obj.items():
+                        _no_canary(v, f"{path}[{k!r}]")
+                elif isinstance(obj, (list, tuple)):
+                    for i, v in enumerate(obj):
+                        _no_canary(v, f"{path}[{i}]")
+
+            _no_canary(body)
+
+            log_text = "\n".join(r.getMessage() for r in caplog.records)
+            assert self.CANARY not in log_text, f"Canary leaked into logs: {log_text!r}"
+            assert "ETYMOLOGY_GENERATION_ERROR" in log_text
+            assert "Exception" in log_text
+
+    def test_etymology_exception_class_name_preserved_in_gem(self):
+        """Issue #638: the diagnostic class name must still appear in the gem field."""
+        event = {"text": "apple"}
+
+        with patch("src.lambda_function.get_semantic_guardrail") as mock_semantic, patch(
+            "src.lambda_function.generate_etymology"
+        ) as mock_gen, patch(
+            "src.lambda_function.get_dynamodb_client"
+        ) as mock_dynamo:
+            mock_semantic.return_value = self._safe_semantic_mock()
+            mock_gen.side_effect = RuntimeError(self.CANARY)
+            mock_dynamo.return_value = MagicMock()
+
+            result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+        body = json.loads(result["body"])
+        if "response" in body and isinstance(body.get("response"), dict):
+            gem = body["response"].get("gem", "")
+            assert "RuntimeError" in gem, f"Class name missing from gem: {gem!r}"
+            assert self.CANARY not in gem
+
+    def test_unhandled_exception_log_does_not_leak(self, caplog):
+        """Issue #650: catch-all unhandled exception logger must not include str(e)."""
+        import logging
+
+        event = {"text": "apple"}
+
+        with patch("src.lambda_function.validate_input") as mock_validate:
+            mock_validate.side_effect = RuntimeError(self.CANARY)
+
+            with caplog.at_level(logging.ERROR, logger="src.lambda_function"):
+                result = lambda_handler(event, None, denylist=MOCK_DENYLIST)
+
+        body = json.loads(result["body"])
+        assert result["statusCode"] == 500
+        assert self.CANARY not in json.dumps(body)
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text, f"Canary leaked into logs: {log_text!r}"
+        # Class name should still be present somewhere in the log (either
+        # the CRITICAL line or earlier handlers).
+        assert "RuntimeError" in log_text

--- a/tests/unit/test_persistence.py
+++ b/tests/unit/test_persistence.py
@@ -271,11 +271,15 @@ class TestAIResponsePersistence:
             assert item["domContext"]["S"] == "Some context here."
             assert item["url"]["S"] == "https://example.com"
 
-            # Verify error response was captured
+            # Verify error response was captured.
+            # Privacy (#638): the gem field must NOT contain the exception message
+            # ("Bedrock timeout") — only the exception class name. See umbrella #637.
             assert "response" in item
             response_data = json.loads(item["response"]["S"])
             assert response_data["signal"] == "error"
-            assert "Bedrock timeout" in response_data["gem"]
+            assert "Bedrock timeout" not in response_data["gem"]
+            assert "Generation Error" in response_data["gem"]
+            assert "Exception" in response_data["gem"]
 
     def test_030_signal_values_stored_correctly(self):
         """Scenario 030: Signal color values are stored correctly."""


### PR DESCRIPTION
## Summary

PR 1 of 5 in audit umbrella #637. Applies the class-name-only pattern established by PR #636 to all 3 exception-text leak surfaces in `src/lambda_function.py`.

## Changes

| Issue | Line | Pattern before | Pattern after |
|---|---|---|---|
| #638 (HIGH) | 508 | `"gem": str(e)` | `"gem": f"Generation Error: {error_class}"` |
| #651 (LOW) | 511 | `logger.error(f"...: {e}")` | `logger.error("ETYMOLOGY_GENERATION_ERROR: " + class)` |
| #650 (LOW) | 762 | `logger.error(f"... {type(e).__name__}: {e}")` | drop trailing `{e}`, keep class name |

## Test Results

`poetry run pytest tests/unit/ -q` — **830 passed, 0 failures** (was 827; +3 from new privacy test class).

### New tests
`TestLambdaFunctionExceptionTextDoesNotLeak` (3 tests) using a canary in raised exceptions — assert canary absent from response + logs, class name present.

### Updated test
`tests/unit/test_persistence.py:278` (`test_020_generation_failure_still_saves`) — the existing assertion `"Bedrock timeout" in response_data["gem"]` codified the leaky behavior; flipped to assert the fix.

## Blast Radius

Code-only deploy via `provision.sh`. `AletheiaAgent` only. Rollback: `aws lambda update-function-code` to previous zip.

## Reports

- `docs/reports/638/implementation-report.md`
- `docs/reports/638/test-report.md`

Closes #638
Closes #650
Closes #651