### PR TITLE
fix: scrub exception text leaks in etymologist.py (close #639, #640, #646, #647)

### DIFF
--- a/docs/reports/639/implementation-report.md
+++ b/docs/reports/639/implementation-report.md
@@ -1,0 +1,50 @@
+# Implementation Report — Issues #639, #640, #646, #647 (audit umbrella #637)
+
+## Scope
+
+PR 2 of 5 in the audit-umbrella #637 arc. Applies the class-name-only pattern to all 4 audit-identified exception-text leak surfaces in `src/etymologist.py`, plus removes two adjacent completion-text leaks in the same JSON decode handler that the original audit did not flag.
+
+## Audit-identified surfaces fixed (4)
+
+| Issue | Line | Pattern before | Pattern after |
+|---|---|---|---|
+| #639 (H2) | 811 | `"error": str(e)` in metadata | `"error": error_class` |
+| #640 (H3) | 882 | `metadata["opus_verifier_error"] = str(e)` | `= error_class` |
+| #646 (M9) | 804 | `logger.error(f"... {type(e).__name__}: {e}")` | drop `{e}`, log token + class |
+| #647 (M10) | 532 | `logger.warning(f"JSON decode failed: {e}")` | class-name-only log |
+
+## Additional fixes in the same JSON decode handler (NOT in original audit, fixed for completeness)
+
+The `extract_json` JSONDecodeError handler had two adjacent completion-text leaks not flagged by the audit. Fixing them in the same PR because they're literally the next lines of the same `except` branch and leaving them in place would have been worse than incomplete:
+
+1. **Removed** `logger.warning(f"JSON string (first 200 chars): {json_str[:200]}")` — `json_str` is the LLM completion text; logging up to 200 chars of it violates the never-log-completion-text constraint.
+2. **Removed** the call to `_log_unicode_diagnostics(json_str, ...)` and the function itself — the helper logged individual non-ASCII characters and their positions from the LLM output, which is a partial information leak about the user-derived content.
+
+Both removals reduce diagnostic richness for a debug scenario (JSON parse failures) but are required by the privacy commitment. If JSON parse failures need investigation in the future, do it with a structured allow-list of safe attributes (e.g. `len(json_str)`, `e.pos`, `e.lineno`) — never raw content.
+
+The `unicodedata` import (top of file) is no longer used and was removed.
+
+## Test Updates
+
+### New: `TestEtymologistExceptionTextDoesNotLeak` (4 tests)
+
+Canary-string assertions for: bedrock exception in metadata, bedrock exception in log, opus verifier exception in metadata, JSON decode handler does not log completion text.
+
+### Updated existing tests
+
+Two existing tests codified the leaky behavior; flipped to assert the fix:
+- `tests/unit/test_etymologist.py:665` (`test_bedrock_exception_returns_error`): was `assert "Bedrock error" in metadata["error"]`, now asserts it's NOT present and class name IS.
+- `tests/unit/test_etymologist.py:1158` (`test_verifier_falls_back_on_opus_exception`): was `assert "Opus unavailable" in opus_verifier_error`, now asserts it's NOT present and class name IS.
+
+## Resolves
+
+- #639 (H2, HIGH)
+- #640 (H3, HIGH)
+- #646 (M9, MEDIUM)
+- #647 (M10, MEDIUM)
+
+Part of umbrella #637 (8 of 14 surfaces resolved after this PR; 6 remaining across PRs 3-5).
+
+## Blast Radius
+
+Code change in `src/etymologist.py` only. Code-only deploy via `provision.sh`. `AletheiaAgent` Lambda only. Rollback: previous zip.

--- a/docs/reports/639/test-report.md
+++ b/docs/reports/639/test-report.md
@@ -1,0 +1,36 @@
+# Test Report — Issues #639, #640, #646, #647
+
+## Pytest Run
+
+```
+cd Aletheia-639
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `834 passed, 13 warnings in 9.03s` — zero failures.
+
+Baseline after PR #652 was 830; this PR adds 4 new privacy tests = 834. Two existing tests were updated in place (no count change).
+
+## New Tests
+
+`tests/unit/test_etymologist.py::TestEtymologistExceptionTextDoesNotLeak`:
+
+| Test | Asserts |
+|---|---|
+| `test_bedrock_exception_text_not_in_metadata` | Canary absent from `metadata.error`; class name IS present |
+| `test_bedrock_exception_text_not_in_log` | Canary absent from log; `BEDROCK_INVOCATION_ERROR` + class name present |
+| `test_opus_verifier_exception_text_not_in_metadata` | Canary absent from `metadata.opus_verifier_error`; class name IS present |
+| `test_json_decode_error_does_not_log_completion_text` | Canary (embedded in malformed JSON) absent from log; `JSON_DECODE_FAILED` + `JSONDecodeError` token present |
+
+## Updated Tests
+
+- `test_etymologist.py::test_bedrock_exception_returns_error` — flipped from asserting `"Bedrock error" in metadata.error` (codifying leak) to asserting `metadata.error == "Exception"` (class name only).
+- `test_etymologist.py::test_verifier_falls_back_on_opus_exception` — flipped same way for `opus_verifier_error`.
+
+## ESLint / mypy / ruff
+
+All pass (per pre-commit hooks at commit time).
+
+## Conclusion
+
+Safe to merge. Then `provision.sh` + smoke test, same pattern as PR #652.

--- a/src/etymologist.py
+++ b/src/etymologist.py
@@ -15,7 +15,6 @@ import logging
 import os
 import re
 import time
-import unicodedata
 from typing import Literal, TypedDict
 
 logger = logging.getLogger(__name__)
@@ -451,30 +450,6 @@ def _peek_next_meaningful_char(text: str, start: int) -> str | None:
     return None
 
 
-def _log_unicode_diagnostics(text: str, context: str) -> None:
-    """Log Unicode codepoints for debugging JSON parse failures.
-
-    Only logs non-ASCII characters that might be causing issues.
-    Limited to first 500 chars and first 10 problematic characters.
-    """
-    non_ascii_chars = []
-    for i, char in enumerate(text[:500]):
-        codepoint = ord(char)
-        if codepoint > 127:
-            try:
-                name = unicodedata.name(char)
-            except ValueError:
-                name = "UNKNOWN"
-            non_ascii_chars.append({"pos": i, "char": char, "codepoint": f"U+{codepoint:04X}", "name": name})
-
-    if non_ascii_chars:
-        logger.warning(f"UNICODE_DIAGNOSTIC [{context}]: Found {len(non_ascii_chars)} non-ASCII chars")
-        for entry in non_ascii_chars[:10]:
-            logger.warning(f"  Position {entry['pos']}: {entry['codepoint']} ({entry['name']}) = '{entry['char']}'")
-    else:
-        logger.warning(f"UNICODE_DIAGNOSTIC [{context}]: No non-ASCII characters found in first 500 chars")
-
-
 def extract_json(raw_response: str) -> dict | None:
     """
     Robustly extract JSON from LLM response.
@@ -529,10 +504,10 @@ def extract_json(raw_response: str) -> dict | None:
     try:
         return json.loads(json_str)
     except json.JSONDecodeError as e:
-        logger.warning(f"JSON decode failed: {e}")
-        logger.warning(f"JSON string (first 200 chars): {json_str[:200]}")
-        # Issue #288: Log Unicode diagnostics for debugging
-        _log_unicode_diagnostics(json_str, f"JSONDecodeError at position {e.pos}")
+        # Privacy (#647): class name only — json_str holds LLM completion text
+        # derived from user input; logging it (or its chars) violates the never-log-
+        # completion-text constraint. See umbrella #637.
+        logger.warning(f"JSON_DECODE_FAILED: {e.__class__.__name__}")
         return None
 
 
@@ -800,15 +775,18 @@ def analyze_term(
         return result
 
     except Exception as e:
+        # Privacy (#639, #646): class name only. Bedrock errors can carry
+        # request-payload echoes. See umbrella #637.
         latency_ms = int((time.time() - start_time) * 1000)
-        logger.error(f"Bedrock invocation failed: {type(e).__name__}: {e}")
+        error_class = e.__class__.__name__
+        logger.error(f"BEDROCK_INVOCATION_ERROR: {error_class}")
         return AnalysisResult(
             status="error",
             response=get_fallback_response(),
             metadata={
                 "latency_ms": latency_ms,
                 "model": model_id,
-                "error": str(e),
+                "error": error_class,
             },
         )
 
@@ -878,6 +856,8 @@ def _verify_with_opus(
             },
         )
     except Exception as e:
-        logger.error(f"Opus verifier failed: {type(e).__name__}: {e}")
-        original_result["metadata"]["opus_verifier_error"] = str(e)
+        # Privacy (#640): class name only. See umbrella #637.
+        error_class = e.__class__.__name__
+        logger.error(f"OPUS_VERIFIER_ERROR: {error_class}")
+        original_result["metadata"]["opus_verifier_error"] = error_class
         return original_result

--- a/tests/unit/test_etymologist.py
+++ b/tests/unit/test_etymologist.py
@@ -656,13 +656,18 @@ class TestAnalyzeTerm:
         assert "latency_ms" in result["metadata"]
 
     def test_bedrock_exception_returns_error(self, mock_bedrock_client):
-        """Test error handling when Bedrock throws exception."""
+        """Test error handling when Bedrock throws exception.
+
+        Privacy (#639, audit umbrella #637): metadata.error must NOT contain
+        the exception message ("Bedrock error") — only the class name.
+        """
         mock_bedrock_client.invoke_model.side_effect = Exception("Bedrock error")
 
         result = analyze_term("test", "", bedrock_client=mock_bedrock_client)
 
         assert result["status"] == "error"
-        assert "Bedrock error" in result["metadata"]["error"]
+        assert "Bedrock error" not in result["metadata"]["error"]
+        assert result["metadata"]["error"] == "Exception"
 
     def test_includes_latency_metadata(self, mock_bedrock_client):
         """Verify latency is tracked in metadata."""
@@ -1154,8 +1159,11 @@ class TestOpusVerifier:
         assert result["response"]["signal"] == "Prompt Injection Attempt"
         assert result["response"]["gem"] == "Haiku original."
         assert result["metadata"]["model"] == HAIKU_MODEL_ID
+        # Privacy (#640, audit umbrella #637): opus_verifier_error must hold
+        # the exception class name only, NOT the exception message text.
         assert "opus_verifier_error" in result["metadata"]
-        assert "Opus unavailable" in result["metadata"]["opus_verifier_error"]
+        assert "Opus unavailable" not in result["metadata"]["opus_verifier_error"]
+        assert result["metadata"]["opus_verifier_error"] == "Exception"
         assert "verified_by_opus" not in result["metadata"]
 
     def test_verifier_doesnt_recurse_on_opus_model_id(self, mock_bedrock_client):
@@ -1187,3 +1195,88 @@ class TestOpusVerifier:
     def test_opus_model_id_in_allowed_models(self):
         """OPUS_MODEL_ID is in the model allowlist."""
         assert OPUS_MODEL_ID in ALLOWED_MODELS
+
+
+class TestEtymologistExceptionTextDoesNotLeak:
+    """Issues #639, #640, #646, #647 (audit umbrella #637):
+
+    Per docs/observability.html: "NEVER log prompt text, user input, completion
+    text, URLs, or user IDs." The etymologist's Bedrock invocation, JSON decode,
+    and Opus verifier exception handlers must surface only the exception class
+    name, never str(e) / repr(e) / e-content.
+    """
+
+    CANARY = "CANARY-LEAK-etymologist-3f8c9a-WOULD-BE-USER-TEXT"
+
+    def test_bedrock_exception_text_not_in_metadata(self):
+        """Issue #639: metadata['error'] must not contain str(e)."""
+        mock_client = MagicMock()
+        mock_client.invoke_model.side_effect = Exception(self.CANARY)
+
+        result = analyze_term("test", "", bedrock_client=mock_client, model_id=HAIKU_MODEL_ID)
+
+        assert result["status"] == "error"
+        assert self.CANARY not in result["metadata"]["error"]
+        assert result["metadata"]["error"] == "Exception"
+
+    def test_bedrock_exception_text_not_in_log(self, caplog):
+        """Issue #646: BEDROCK_INVOCATION_ERROR log must not contain str(e)."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_client.invoke_model.side_effect = Exception(self.CANARY)
+
+        with caplog.at_level(logging.ERROR, logger="src.etymologist"):
+            analyze_term("test", "", bedrock_client=mock_client, model_id=HAIKU_MODEL_ID)
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text, f"Canary leaked into log: {log_text!r}"
+        assert "BEDROCK_INVOCATION_ERROR" in log_text
+        assert "Exception" in log_text
+
+    def test_opus_verifier_exception_text_not_in_metadata(self):
+        """Issue #640: opus_verifier_error must not contain str(e)."""
+        def _haiku_resp(signal):
+            return {
+                "body": MagicMock(
+                    read=MagicMock(
+                        return_value=json.dumps({
+                            "content": [{"type": "text", "text": json.dumps({
+                                "signal": signal, "gem": "g", "context": "c"
+                            })}]
+                        }).encode()
+                    )
+                )
+            }
+
+        mock_client = MagicMock()
+        mock_client.invoke_model.side_effect = [
+            _haiku_resp("Prompt Injection Attempt"),
+            Exception(self.CANARY),
+        ]
+
+        result = analyze_term("gedenken", "ford", bedrock_client=mock_client, model_id=HAIKU_MODEL_ID)
+
+        assert self.CANARY not in result["metadata"]["opus_verifier_error"]
+        assert result["metadata"]["opus_verifier_error"] == "Exception"
+
+    def test_json_decode_error_does_not_log_completion_text(self, caplog):
+        """Issue #647: JSON decode handler must not log the malformed completion
+        text, the JSONDecodeError details, or unicode codepoints derived from
+        the LLM output."""
+        import logging
+        from src.etymologist import extract_json
+
+        # extract_json picks the first {...} from the input; provide a string
+        # that contains a JSON-looking fragment with our canary inside, then
+        # a syntactically broken value.
+        malformed = '{"canary_field": "' + self.CANARY + '", broken_no_quote: value}'
+
+        with caplog.at_level(logging.WARNING, logger="src.etymologist"):
+            result = extract_json(malformed)
+
+        assert result is None  # parse failed
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text, f"Canary leaked into log: {log_text!r}"
+        assert "JSON_DECODE_FAILED" in log_text
+        assert "JSONDecodeError" in log_text


### PR DESCRIPTION
## Summary

PR 2 of 5 in audit umbrella #637. Applies the class-name-only pattern established in PR #636 (and refined in PR #652) to all 4 audit-identified leak surfaces in `src/etymologist.py`, plus removes two adjacent completion-text leaks in the same JSON decode handler that the original audit did not flag.

## Audit-identified surfaces (4)

| Issue | Line | Pattern before | Pattern after |
|---|---|---|---|
| #639 (HIGH) | 811 | `"error": str(e)` in metadata | `"error": error_class` |
| #640 (HIGH) | 882 | `metadata["opus_verifier_error"] = str(e)` | `= error_class` |
| #646 (MEDIUM) | 804 | `logger.error(f"... {type(e).__name__}: {e}")` | token + class name only |
| #647 (MEDIUM) | 532 | `logger.warning(f"JSON decode failed: {e}")` | class name only |

## Additional fixes in the same JSON decode handler (NOT in original audit)

The `extract_json` JSONDecodeError handler had two adjacent completion-text leaks:

- `logger.warning(f"JSON string (first 200 chars): {json_str[:200]}")` removed — LLM completion text leak
- `_log_unicode_diagnostics()` call removed AND the function itself deleted — it logged individual non-ASCII chars and their positions from the LLM output
- The `unicodedata` import is no longer used and was removed

These were fixed in the same PR because they're literally the next lines of the same `except` branch — leaving them would be worse than incomplete.

## Test Results

`poetry run pytest tests/unit/ -q` — **834 passed, 0 failures** (was 830; +4 from new privacy test class).

### New tests
`TestEtymologistExceptionTextDoesNotLeak` (4 tests) using canary strings.

### Updated tests
- `test_bedrock_exception_returns_error` — flipped from asserting `"Bedrock error" in metadata.error` (leak) to `metadata.error == "Exception"` (class only).
- `test_verifier_falls_back_on_opus_exception` — flipped same way for `opus_verifier_error`.

## Blast Radius

Code-only deploy via `provision.sh`. `AletheiaAgent` only.

## Reports

- `docs/reports/639/implementation-report.md`
- `docs/reports/639/test-report.md`

Closes #639
Closes #640
Closes #646
Closes #647