### PR TITLE
fix: scrub exception text leaks in lambda_auth_function.py (close #641, #642, #643, #648, #649)

### DIFF
--- a/docs/reports/641/implementation-report.md
+++ b/docs/reports/641/implementation-report.md
@@ -1,0 +1,54 @@
+# Implementation Report — Issues #641, #642, #643, #648, #649 (audit umbrella #637)
+
+## Scope
+
+PR 3 of 5 in the audit-umbrella #637 arc. Applies the class-name-only pattern to all 5 audit-identified exception-text leak surfaces in `src/lambda_auth_function.py`, plus 3 adjacent leaks in the same handlers not flagged by the original audit.
+
+## Audit-identified surfaces fixed (5)
+
+| Issue | Line(s) | Pattern before | Pattern after |
+|---|---|---|---|
+| #641 (HIGH) | 564, 612 | `json.dumps({"error": str(e)})` (ValueError handlers) | `f"ValueError: {error_class}"` |
+| #642 (HIGH) | 268, 649 | `"message": str(e)` (LinkedIn API error) | `"message": error_class` |
+| #643 (HIGH) | 498 | `"error": str(e)` in logged JSON dict | `"error": e.__class__.__name__` |
+| #648 (MEDIUM) | 131, 165 | `f"...: {response.status_code} - {response.text}"` | `f"...: status={response.status_code}"` |
+| #649 (MEDIUM) | 467 | `logger.info(f"... redirectUri: {redirect_uri}")` | line removed |
+
+## Additional adjacent fixes (NOT in original audit)
+
+The same exception handlers had 3 more `f"...: {e}"` style logger lines:
+
+- Line 262 (`logger.error f"LinkedIn API error during token validation: {e}"`) → `LINKEDIN_API_ERROR_TOKEN_VALIDATION: {class}`
+- Line 567 (`logger.error f"Token exchange error: {e}"`) → `TOKEN_EXCHANGE_ERROR: {class}`
+- Line 615 (`logger.error f"Token refresh error: {e}"`) → `TOKEN_REFRESH_ERROR: {class}`
+- Line 643 (`logger.error f"LinkedIn API error during validation: {e}"`) → `LINKEDIN_API_ERROR_VALIDATION: {class}`
+
+These were fixed in the same PR because they're in the same `except` branches as the audit-identified issues — leaving them in place would have been worse than incomplete.
+
+## Test Updates
+
+### New: `TestAuthLambdaExceptionTextDoesNotLeak` in `tests/unit/test_lambda_auth.py`
+
+3 tests using canary strings:
+
+| Test | Asserts |
+|---|---|
+| `test_token_exchange_failure_log_does_not_include_response_text` | OAuth response body canary absent from log; `TOKEN_EXCHANGE_FAILED` + status code present |
+| `test_token_refresh_failure_log_does_not_include_response_text` | Same for refresh path |
+| `test_redirect_uri_not_logged` | User-supplied redirect URI canary absent from logs entirely |
+
+The 5 audit issues span 8 code locations; 3 are tested by direct canary, the remaining 5 are tested-by-pattern (same mechanical fix applied) and covered by the existing 46-test auth regression suite. Re-audit at the end of the umbrella will surface any leaks the unit tests miss.
+
+## Resolves
+
+- #641 (H4, HIGH)
+- #642 (H5, HIGH)
+- #643 (H6, HIGH)
+- #648 (M11, MEDIUM)
+- #649 (M12, MEDIUM)
+
+Part of umbrella #637 (13 of 14 surfaces resolved after this PR; 1 remaining across PRs 4-5).
+
+## Blast Radius
+
+Code change in `src/lambda_auth_function.py` only. `provision.sh` redeploys the **Auth Lambda** (`AletheiaAuth`) — this is the FIRST audit-arc PR that touches the Auth Lambda specifically. Smoke test must exercise an auth endpoint (e.g. `POST /auth/token` returns 400 for missing params, confirms handler loads).

--- a/docs/reports/641/test-report.md
+++ b/docs/reports/641/test-report.md
@@ -1,0 +1,34 @@
+# Test Report — Issues #641, #642, #643, #648, #649
+
+## Pytest Run
+
+```
+cd Aletheia-641
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `837 passed, 13 warnings in 9.01s` — zero failures.
+
+Baseline after PR #653 was 834; this PR adds 3 new privacy tests = 837. No existing tests required updating (the existing auth test suite asserted on status codes and response shape, not on exception message text).
+
+## New Tests
+
+`tests/unit/test_lambda_auth.py::TestAuthLambdaExceptionTextDoesNotLeak`:
+
+| Test | Surface(s) tested by canary |
+|---|---|
+| `test_token_exchange_failure_log_does_not_include_response_text` | #648 (line 131) |
+| `test_token_refresh_failure_log_does_not_include_response_text` | #648 (line 165) |
+| `test_redirect_uri_not_logged` | #649 |
+
+## Coverage Note
+
+5 audit issues span 8 code locations. Direct canary tests cover 3 of those; the remaining 5 are mechanically-identical fixes covered by existing auth regression tests (46 tests, all passing). The re-audit at the end of umbrella #637 will surface any leaks the unit tests miss.
+
+## ESLint / mypy / ruff
+
+All pass (pre-commit gate).
+
+## Conclusion
+
+Safe to merge. Then `provision.sh` + smoke test. Smoke test must exercise an auth endpoint (e.g. `POST /auth/token` with empty body returns 400, confirms Auth Lambda handler loads cleanly post-edit).

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -128,7 +128,10 @@ def exchange_code_for_tokens(code: str, redirect_uri: str) -> dict:
     )
 
     if response.status_code != 200:
-        logger.error(f"Token exchange failed: {response.status_code} - {response.text}")
+        # Privacy (#648): do NOT log response.text — OAuth provider responses
+        # can contain redirect URI echoes, partial code fragments, or other
+        # sensitive context. Status code only. See umbrella #637.
+        logger.error(f"TOKEN_EXCHANGE_FAILED: status={response.status_code}")
         raise ValueError(f"Token exchange failed: {response.status_code}")
 
     return response.json()
@@ -162,7 +165,8 @@ def refresh_access_token(refresh_token: str) -> dict:
     )
 
     if response.status_code != 200:
-        logger.error(f"Token refresh failed: {response.status_code} - {response.text}")
+        # Privacy (#648): status code only, not response.text. See umbrella #637.
+        logger.error(f"TOKEN_REFRESH_FAILED: status={response.status_code}")
         raise ValueError(f"Token refresh failed: {response.status_code}")
 
     return response.json()
@@ -255,13 +259,16 @@ def validate_token(event: dict, context: Any) -> dict:
     try:
         profile = fetch_linkedin_profile(access_token)
     except Exception as e:
-        logger.error(f"LinkedIn API error during token validation: {e}")
+        # Privacy (#642 + adjacent, audit umbrella #637): class name only.
+        # LinkedIn API exception messages can carry token fragments or URLs.
+        error_class = e.__class__.__name__
+        logger.error(f"LINKEDIN_API_ERROR_TOKEN_VALIDATION: {error_class}")
         return {
             "statusCode": 502,
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
                 "error": "LinkedIn API error",
-                "message": str(e),
+                "message": error_class,
             }),
         }
 
@@ -459,8 +466,9 @@ def handle_token_exchange(body: dict) -> dict:
     code = body.get("code")
     redirect_uri = body.get("redirectUri")
 
-    # Debug logging for redirect URI mismatch issues
-    logger.info(f"Token exchange request - redirectUri: {redirect_uri}")
+    # Privacy (#649): redirect_uri is a user-supplied URL — never log per the
+    # never-log-URLs constraint in docs/observability.html. Code length is
+    # operational and safe to log.
     logger.info(f"Token exchange request - code length: {len(code) if code else 0}")
 
     if not code or not redirect_uri:
@@ -488,12 +496,13 @@ def handle_token_exchange(body: dict) -> dict:
         try:
             allowed, current_count = check_and_increment_cap(TOKEN_CAP_TABLE)
         except Exception as e:
-            # Fail closed: if cap check fails, deny token issuance
+            # Fail closed: if cap check fails, deny token issuance.
+            # Privacy (#643, audit umbrella #637): class name only.
             logger.error(
                 json.dumps({
                     "action": "token_denied",
                     "reason": "cap_check_failed",
-                    "error": str(e),
+                    "error": e.__class__.__name__,
                     "user_id": user["user_id"],
                 })
             )
@@ -555,12 +564,14 @@ def handle_token_exchange(body: dict) -> dict:
         }
 
     except ValueError as e:
+        # Privacy (#641, audit umbrella #637): class name only in body.
         return {
             "statusCode": 400,
-            "body": json.dumps({"error": str(e)}),
+            "body": json.dumps({"error": f"ValueError: {e.__class__.__name__}"}),
         }
     except Exception as e:
-        logger.error(f"Token exchange error: {e}")
+        # Privacy (#641 adjacent): class name only in log.
+        logger.error(f"TOKEN_EXCHANGE_ERROR: {e.__class__.__name__}")
         return {
             "statusCode": 500,
             "body": json.dumps({"error": "Internal server error"}),
@@ -603,12 +614,14 @@ def handle_token_refresh(body: dict) -> dict:
         }
 
     except ValueError as e:
+        # Privacy (#641, audit umbrella #637): class name only in body.
         return {
             "statusCode": 401,
-            "body": json.dumps({"error": str(e)}),
+            "body": json.dumps({"error": f"ValueError: {e.__class__.__name__}"}),
         }
     except Exception as e:
-        logger.error(f"Token refresh error: {e}")
+        # Privacy (#641 adjacent): class name only in log.
+        logger.error(f"TOKEN_REFRESH_ERROR: {e.__class__.__name__}")
         return {
             "statusCode": 500,
             "body": json.dumps({"error": "Internal server error"}),
@@ -636,13 +649,15 @@ def handle_validate_token(headers: dict) -> dict:
     try:
         profile = fetch_linkedin_profile(token)
     except Exception as e:
-        logger.error(f"LinkedIn API error during validation: {e}")
+        # Privacy (#642 + adjacent, audit umbrella #637): class name only.
+        error_class = e.__class__.__name__
+        logger.error(f"LINKEDIN_API_ERROR_VALIDATION: {error_class}")
         return {
             "statusCode": 502,
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
                 "error": "LinkedIn API error",
-                "message": str(e),
+                "message": error_class,
             }),
         }
 

--- a/tests/unit/test_lambda_auth.py
+++ b/tests/unit/test_lambda_auth.py
@@ -502,3 +502,74 @@ class TestLambdaHandlerRouting:
     def test_route_upgrade_cancel(self):
         result = auth_func.lambda_handler({"httpMethod": "GET", "path": "/upgrade-cancel"}, None)
         assert result["statusCode"] == 200
+
+
+class TestAuthLambdaExceptionTextDoesNotLeak:
+    """Issues #641, #642, #643, #648, #649 (audit umbrella #637):
+
+    Per docs/observability.html: "NEVER log prompt text, user input, completion
+    text, URLs, or user IDs." The auth Lambda's exception handlers and OAuth
+    error logging must surface only the exception class name (or status code
+    for HTTP failures), never str(e) / response.text / user-supplied URLs.
+    """
+
+    CANARY = "CANARY-LEAK-auth-7a1c8e-WOULD-BE-USER-DATA"
+
+    @responses.activate
+    def test_token_exchange_failure_log_does_not_include_response_text(self, aws_env, caplog):
+        """Issue #648: OAuth provider response.text must not be logged."""
+        import logging
+
+        responses.add(
+            responses.POST,
+            auth_func.LINKEDIN_TOKEN_URL,
+            json={"error": self.CANARY, "error_description": self.CANARY},
+            status=400,
+        )
+        with caplog.at_level(logging.ERROR, logger="src.lambda_auth_function"):
+            with pytest.raises(ValueError):
+                auth_func.exchange_code_for_tokens("dummy_code", "https://example.com/cb")
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text, f"OAuth response body leaked into log: {log_text!r}"
+        assert "TOKEN_EXCHANGE_FAILED" in log_text
+        assert "status=400" in log_text
+
+    @responses.activate
+    def test_token_refresh_failure_log_does_not_include_response_text(self, aws_env, caplog):
+        """Issue #648: OAuth refresh response.text must not be logged."""
+        import logging
+
+        responses.add(
+            responses.POST,
+            auth_func.LINKEDIN_TOKEN_URL,
+            json={"error": self.CANARY},
+            status=401,
+        )
+        with caplog.at_level(logging.ERROR, logger="src.lambda_auth_function"):
+            with pytest.raises(ValueError):
+                auth_func.refresh_access_token("dummy_refresh")
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text
+        assert "TOKEN_REFRESH_FAILED" in log_text
+        assert "status=401" in log_text
+
+    def test_redirect_uri_not_logged(self, caplog):
+        """Issue #649: user-supplied redirect_uri must not appear in logs."""
+        import logging
+
+        canary_uri = f"https://{self.CANARY}.example.com/callback"
+        body = {"code": "abc123", "redirectUri": canary_uri}
+
+        with caplog.at_level(logging.INFO, logger="src.lambda_auth_function"):
+            # handle_token_exchange will fail at LinkedIn call, but we only care
+            # about logs emitted before that point.
+            try:
+                auth_func.handle_token_exchange(body)
+            except Exception:
+                pass
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert canary_uri not in log_text, f"redirect_uri leaked into log: {log_text!r}"
+        assert self.CANARY not in log_text


### PR DESCRIPTION
## Summary

PR 3 of 5 in audit umbrella #637. Applies the class-name-only pattern to all 5 audit-identified leak surfaces in `src/lambda_auth_function.py`, plus 3 adjacent leaks in the same handlers not flagged by the original audit.

This is the **largest group** (5 issues, 8 code locations) and the **first PR in the arc that redeploys the Auth Lambda** (`AletheiaAuth`).

## Audit-identified surfaces (5)

| Issue | Line(s) | Pattern before | Pattern after |
|---|---|---|---|
| #641 (HIGH) | 564, 612 | `json.dumps({"error": str(e)})` in ValueError body | `f"ValueError: {error_class}"` |
| #642 (HIGH) | 268, 649 | `"message": str(e)` in LinkedIn error body | `"message": error_class` |
| #643 (HIGH) | 498 | `"error": str(e)` in cap-check logged JSON | `e.__class__.__name__` |
| #648 (MEDIUM) | 131, 165 | `f"...: {response.text}"` in OAuth log | status code only |
| #649 (MEDIUM) | 467 | `logger.info f"... redirectUri: {redirect_uri}"` | line removed |

## Additional adjacent fixes

Lines 262, 567, 615, 643 also had `f"...: {e}"` logger patterns in the same `except` branches as audit-identified issues. All four converted to class-name-only.

## Test Results

`poetry run pytest tests/unit/ -q` — **837 passed, 0 failures** (was 834; +3 new privacy tests).

### New tests
`TestAuthLambdaExceptionTextDoesNotLeak` (3 tests) covering token-exchange/refresh log scrubbing and redirect_uri scrubbing.

### Coverage note
5 issues span 8 code locations; 3 are directly canary-tested, 5 are mechanically-identical fixes covered by existing 46-test auth regression suite. Re-audit at end of umbrella will surface any miss.

## Blast Radius

`provision.sh` redeploys **AletheiaAuth** Lambda. First PR in this arc to touch the Auth Lambda; smoke test must exercise an auth endpoint (e.g. `POST /auth/token` with empty body returns 400, confirming handler loads cleanly).

## Reports

- `docs/reports/641/implementation-report.md`
- `docs/reports/641/test-report.md`

Closes #641
Closes #642
Closes #643
Closes #648
Closes #649