### PR TITLE
fix: scrub URL and exception text leaks in signal_inspector/fetcher.py (close #644)

### DIFF
--- a/docs/reports/644/implementation-report.md
+++ b/docs/reports/644/implementation-report.md
@@ -1,0 +1,44 @@
+# Implementation Report — Issue #644 (audit umbrella #637)
+
+## Scope
+
+PR 4 of 5 in the audit-umbrella #637 arc. Fixes `src/signal_inspector/fetcher.py` line 140 (audit M7) plus 4 adjacent URL/exception-text leaks in the same exception handlers.
+
+## Audit-identified surface (1)
+
+| Issue | Line | Pattern before | Pattern after |
+|---|---|---|---|
+| #644 (MEDIUM) | 140 | `return None, {}, None, str(e)` | `return ..., e.__class__.__name__` |
+
+## Additional adjacent fixes (NOT in original audit)
+
+The fetcher's three exception handlers (lines 132-140) all logged the user-supplied `url` AND, where applicable, `{e}`. The URL logging violates the never-log-URLs constraint from `docs/observability.html`:
+
+| Line | Pattern before | Pattern after |
+|---|---|---|
+| 133 | `logger.warning(f"Timeout fetching {url}")` | `logger.warning("FETCH_TIMEOUT")` |
+| 136 | `logger.warning(f"Connection error fetching {url}: {e}")` | `logger.warning(f"FETCH_CONNECTION_ERROR: {class}")` |
+| 139 | `logger.warning(f"Error fetching {url}: {e}")` | `logger.warning(f"FETCH_REQUEST_ERROR: {class}")` |
+
+## Deploy Disposition
+
+**No `provision.sh` required.** `signal_inspector` is not imported by anything in `src/` — it's a CLI-only module used by `tools/inspect_signals.py` for offline signal auditing. The fix lands on `main` but does not need a Lambda redeploy.
+
+## Test Updates
+
+### New: `TestFetcherExceptionTextDoesNotLeak` (2 tests)
+
+| Test | Asserts |
+|---|---|
+| `test_request_exception_does_not_leak_url_or_message_into_log` | Canary URL absent from log; `FETCH_*` token present |
+| `test_request_exception_does_not_leak_message_into_return_tuple` | Canary URL absent from 4th tuple element of `fetch_page` return |
+
+## Resolves
+
+- #644 (M7, MEDIUM)
+
+Part of umbrella #637 (14 of 14 surfaces resolved after this PR plus PR 5; this PR resolves 1).
+
+## Blast Radius
+
+CLI-only. No runtime change to any Lambda. Rollback is `git revert`.

--- a/docs/reports/644/test-report.md
+++ b/docs/reports/644/test-report.md
@@ -1,0 +1,29 @@
+# Test Report — Issue #644
+
+## Pytest Run
+
+```
+cd Aletheia-644
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `839 passed, 13 warnings in 10.77s` — zero failures.
+
+Baseline after PR #654 was 837; this PR adds 2 new privacy tests = 839.
+
+## New Tests
+
+`tests/unit/test_signal_inspector.py::TestFetcherExceptionTextDoesNotLeak`:
+
+| Test | Mechanism |
+|---|---|
+| `test_request_exception_does_not_leak_url_or_message_into_log` | `responses` library, no matcher registered → ConnectionError → asserts canary URL not in log |
+| `test_request_exception_does_not_leak_message_into_return_tuple` | Same mechanism, asserts canary URL not in 4th tuple element of `fetch_page` return |
+
+## ESLint / mypy / ruff
+
+All pass (pre-commit gate).
+
+## Conclusion
+
+Safe to merge. **No `provision.sh` deploy needed** — `signal_inspector` is not in any Lambda's import path (CLI-only module).

--- a/src/signal_inspector/fetcher.py
+++ b/src/signal_inspector/fetcher.py
@@ -130,11 +130,13 @@ def fetch_page(
             return None, headers, response.status_code, f"HTTP {response.status_code}"
 
     except requests.exceptions.Timeout:
-        logger.warning(f"Timeout fetching {url}")
+        # Privacy (#644 + adjacent, audit umbrella #637): never log url —
+        # docs/observability.html bans logging URLs. Class name only for exception.
+        logger.warning("FETCH_TIMEOUT")
         return None, {}, None, "timeout"
     except requests.exceptions.ConnectionError as e:
-        logger.warning(f"Connection error fetching {url}: {e}")
+        logger.warning(f"FETCH_CONNECTION_ERROR: {e.__class__.__name__}")
         return None, {}, None, "dns_error"
     except requests.exceptions.RequestException as e:
-        logger.warning(f"Error fetching {url}: {e}")
-        return None, {}, None, str(e)
+        logger.warning(f"FETCH_REQUEST_ERROR: {e.__class__.__name__}")
+        return None, {}, None, e.__class__.__name__

--- a/tests/unit/test_signal_inspector.py
+++ b/tests/unit/test_signal_inspector.py
@@ -477,3 +477,45 @@ class TestLiveWebsites:
 
         assert result.fetch_status == FetchStatus.ROBOTS_BLOCKED
         assert result.aletheia_action == AletheiaAction.BLOCK
+
+
+class TestFetcherExceptionTextDoesNotLeak:
+    """Issue #644 (audit umbrella #637):
+
+    Per docs/observability.html: "NEVER log prompt text, user input, completion
+    text, URLs, or user IDs." The fetcher's exception handlers must not log
+    the URL or the exception text — only the exception class name.
+    """
+
+    CANARY_URL = "https://CANARY-LEAK-fetcher-5e2d4f.example.com/secret-path"
+
+    @responses.activate
+    def test_request_exception_does_not_leak_url_or_message_into_log(self, caplog):
+        """Issue #644: RequestException handler must not log url or str(e)."""
+        import logging
+        from signal_inspector.fetcher import fetch_page
+
+        # responses lib raises ConnectionError if no matcher registered for
+        # the URL — perfect for triggering the exception path.
+        with caplog.at_level(logging.WARNING, logger="signal_inspector.fetcher"):
+            html, headers, status, error = fetch_page(self.CANARY_URL, "TestBot/1.0", timeout=5)
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY_URL not in log_text, f"URL leaked into log: {log_text!r}"
+        assert "CANARY-LEAK" not in log_text
+        # Class name should be present for diagnostic value
+        assert any(token in log_text for token in (
+            "FETCH_CONNECTION_ERROR", "FETCH_REQUEST_ERROR", "FETCH_TIMEOUT"
+        ))
+
+    @responses.activate
+    def test_request_exception_does_not_leak_message_into_return_tuple(self):
+        """Issue #644: 4th element of return tuple must be a fixed token or class
+        name, never str(e) with embedded URL/content."""
+        from signal_inspector.fetcher import fetch_page
+
+        html, headers, status, error = fetch_page(self.CANARY_URL, "TestBot/1.0", timeout=5)
+
+        assert html is None
+        assert self.CANARY_URL not in (error or "")
+        assert "CANARY-LEAK" not in (error or "")


### PR DESCRIPTION
## Summary

PR 4 of 5 in audit umbrella #637. Fixes `src/signal_inspector/fetcher.py:140` (audit M7) plus 4 adjacent URL/exception-text leaks in the same exception handlers.

## Audit-identified surface (1)

| Issue | Line | Pattern before | Pattern after |
|---|---|---|---|
| #644 (MEDIUM) | 140 | `return None, {}, None, str(e)` | `return ..., e.__class__.__name__` |

## Additional adjacent fixes

All three exception handlers in `fetch_page` logged `url` (banned per `docs/observability.html`) AND `{e}`:

| Line | Before | After |
|---|---|---|
| 133 | `f"Timeout fetching {url}"` | `"FETCH_TIMEOUT"` |
| 136 | `f"Connection error fetching {url}: {e}"` | `f"FETCH_CONNECTION_ERROR: {class}"` |
| 139 | `f"Error fetching {url}: {e}"` | `f"FETCH_REQUEST_ERROR: {class}"` |

## Deploy Disposition — NO `provision.sh` needed

`signal_inspector` is not imported by anything in `src/` (verified by grep). It is a CLI-only module used by `tools/inspect_signals.py` for offline signal auditing. This PR lands on `main` but no Lambda redeploy.

## Test Results

`poetry run pytest tests/unit/ -q` — **839 passed, 0 failures** (was 837; +2 new privacy tests).

## Blast Radius

CLI-only. Zero runtime change. Rollback: `git revert`.

## Reports

- `docs/reports/644/implementation-report.md`
- `docs/reports/644/test-report.md`

Closes #644