### PR TITLE
fix: scrub exception text leak in poetic_analyzer.py (close #645)

### DIFF
--- a/docs/reports/645/implementation-report.md
+++ b/docs/reports/645/implementation-report.md
@@ -1,0 +1,41 @@
+# Implementation Report — Issue #645 (audit umbrella #637)
+
+## Scope
+
+PR 5 of 5 — the **final PR** in the audit-umbrella #637 arc. Fixes the single exception-text leak in `src/poetic_analyzer.py:333`.
+
+## Change
+
+`src/poetic_analyzer.py:333`:
+
+```python
+# Before
+logger.error(f"Poetic analysis failed: {type(e).__name__}: {e}")
+
+# After
+logger.error(f"POETIC_ANALYSIS_ERROR: {e.__class__.__name__}")
+```
+
+The class name prefix was already present; only the trailing `{e}` interpolation is removed. Bedrock invocation errors can carry request-payload echoes.
+
+## Deploy Disposition
+
+`poetry_analyzer` IS imported by `src/etymologist.py` and `src/lambda_function.py` — so it IS in the `AletheiaAgent` Lambda's reach graph. `provision.sh` deploy required after merge.
+
+## Test Updates
+
+### New: `TestPoeticAnalyzerExceptionTextDoesNotLeak` (1 test)
+
+| Test | Asserts |
+|---|---|
+| `test_bedrock_exception_text_not_in_log` | Canary absent from log; `POETIC_ANALYSIS_ERROR` + class name present; result returns error status |
+
+## Resolves
+
+- #645 (M8, MEDIUM)
+
+This is the **14th of 14** surfaces resolved. After this PR + deploy + re-audit confirms clean, the audit umbrella #637 can close.
+
+## Blast Radius
+
+Code-only deploy via `provision.sh`. `AletheiaAgent` Lambda repackages. Rollback: previous zip.

--- a/docs/reports/645/test-report.md
+++ b/docs/reports/645/test-report.md
@@ -1,0 +1,24 @@
+# Test Report — Issue #645
+
+## Pytest Run
+
+```
+cd Aletheia-645
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `840 passed, 13 warnings in 10.45s` — zero failures.
+
+Baseline after PR #655 was 839; this PR adds 1 new privacy test = 840.
+
+## New Test
+
+`tests/unit/test_poetic_analyzer.py::TestPoeticAnalyzerExceptionTextDoesNotLeak::test_bedrock_exception_text_not_in_log` — canary string asserts: canary absent from log, `POETIC_ANALYSIS_ERROR` + class name present in log, error fallback returned.
+
+## ESLint / mypy / ruff
+
+All pass (pre-commit gate).
+
+## Conclusion
+
+Safe to merge. Then `provision.sh` (poetic_analyzer is in AletheiaAgent's reach graph) + smoke test. After deploy lands, all 14 audit-identified surfaces will be resolved; re-audit can then confirm clean state and umbrella #637 can close.

--- a/src/poetic_analyzer.py
+++ b/src/poetic_analyzer.py
@@ -329,8 +329,10 @@ def analyze_poetic_resonance(
         )
 
     except Exception as e:
+        # Privacy (#645, audit umbrella #637): class name only — Bedrock errors
+        # can carry request-payload echoes. See docs/observability.html.
         latency_ms = int((time.time() - start_time) * 1000)
-        logger.error(f"Poetic analysis failed: {type(e).__name__}: {e}")
+        logger.error(f"POETIC_ANALYSIS_ERROR: {e.__class__.__name__}")
         return PoeticAnalysisResult(
             status="error",
             synthesis="",

--- a/tests/unit/test_poetic_analyzer.py
+++ b/tests/unit/test_poetic_analyzer.py
@@ -489,3 +489,37 @@ class TestBoundaryConditions:
         }
         is_valid, errors = _validate_poetic_result(result)
         assert is_valid
+
+
+class TestPoeticAnalyzerExceptionTextDoesNotLeak:
+    """Issue #645 (audit umbrella #637):
+
+    Per docs/observability.html: "NEVER log prompt text, user input, completion
+    text, URLs, or user IDs." The poetic analyzer's Bedrock exception handler
+    must surface only the exception class name, never str(e).
+    """
+
+    CANARY = "CANARY-LEAK-poetic-7b3e2a-WOULD-BE-USER-TEXT"
+
+    def test_bedrock_exception_text_not_in_log(self, caplog):
+        """Issue #645: BEDROCK_INVOCATION exception log must not contain str(e)."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_client.invoke_model.side_effect = Exception(self.CANARY)
+
+        with caplog.at_level(logging.ERROR, logger="src.poetic_analyzer"):
+            result = analyze_poetic_resonance(
+                "test_word",
+                {"signal": "test", "gem": "test", "context": "test"},
+                "test page context",
+                ["religious", "architectural"],
+                bedrock_client=mock_client,
+            )
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.CANARY not in log_text, f"Canary leaked into log: {log_text!r}"
+        assert "POETIC_ANALYSIS_ERROR" in log_text
+        assert "Exception" in log_text
+        # Result is a dict (TypedDict-like) — verify it returned the error fallback
+        assert result["status"] == "error"


### PR DESCRIPTION
## Summary

**PR 5 of 5 — final PR** in audit umbrella #637. Single-line fix at `src/poetic_analyzer.py:333`.

## Change

`src/poetic_analyzer.py:333`:

```python
# Before
logger.error(f"Poetic analysis failed: {type(e).__name__}: {e}")

# After
logger.error(f"POETIC_ANALYSIS_ERROR: {e.__class__.__name__}")
```

Class name prefix preserved; trailing `{e}` removed (Bedrock errors can carry request-payload echoes).

## Deploy Disposition

`poetic_analyzer` IS imported by `etymologist.py` and `lambda_function.py` — in the `AletheiaAgent` Lambda's reach graph. `provision.sh` deploy required after merge.

## Test Results

`poetry run pytest tests/unit/ -q` — **840 passed, 0 failures** (was 839; +1 new privacy test).

## Status After This PR

- 14 of 14 audit-identified surfaces resolved across this 5-PR arc
- Umbrella #637 ready to close once re-audit confirms clean state
- Re-audit via Explore subagent will be the next step after deploy

## Reports

- `docs/reports/645/implementation-report.md`
- `docs/reports/645/test-report.md`

Closes #645