### PR TITLE
docs(privacy): shrink policy by removing two false claims (close #661, #662)

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -69,7 +69,7 @@
       </ul>
 
       <h3>Full Page Analysis</h3>
-      <p>When you click "Analyze Full Page", the extension extracts up to 10,000 characters of article content from the current page. Before transmission, email addresses and phone numbers found in the text are automatically redacted to protect third-party privacy.</p>
+      <p>When you click "Analyze Full Page", the extension extracts up to 10,000 characters of article content from the current page.</p>
 
       <h3>Account Data</h3>
       <p>If you sign in with LinkedIn, we collect and store:</p>
@@ -140,8 +140,6 @@
       <ul>
         <li><strong>api.aletheia.study:</strong> The only remote server the extension communicates with, for AI analysis and authentication</li>
       </ul>
-
-      <p>We <strong>cannot</strong> access your browsing history or data from other tabs.</p>
 
       <h2>5. Your Rights (GDPR/CCPA)</h2>
       <p>You have the right to:</p>


### PR DESCRIPTION
## Summary

Two deletions in `docs/privacy.html`. Nothing added. Net: −1 paragraph and −1 sentence.

## Edit 1 — line 72 (#662)

Removed the unconditional "email addresses and phone numbers...automatically redacted" claim from the Full Page Analysis section. The extension's regex only catches ASCII email and US-format phone numbers; international phones, SSNs, addresses, names, government IDs etc. all pass through. The operator decided to drop the redaction claim entirely rather than narrow it. The 30-day retention commitment remains as the protection.

The `scrubPII` code in the extension may stay or go — separate concern.

## Edit 2 — line 144 (#661)

Removed the "We cannot access your browsing history or data from other tabs" sentence. The `tabs` permission listed above DOES grant the technical capability; "cannot" was factually false. The permission disclosure (lines 124-137) stands as the honest statement of what each permission does and why.

## Why no reports

Doc-only change. Pre-commit gate accepted the commit without reports (no `docs/reports/<ID>/` required for doc-only PRs in this repo).

## Deploy

GitHub Pages auto-deploys on push to main. No extension republish needed; the CWS/AMO listings link to the same `aletheia.study/privacy.html` URL.

## Operator follow-ups (not in this PR)

- 10051 LLD `docs/lld/done/10051-store-compliance.md` Long Description still contains "We cannot see your browsing history" — needs the same correction if used to fill CWS dashboard text
- CWS dashboard Permission Justification declares only 3 permissions (activeTab, scripting, contextMenus) but manifest requests 7 — needs the other 4 added

Closes #661
Closes #662