### PR TITLE
revert: undo response-field exception scrubbing (close #668)

### DIFF
--- a/docs/reports/668/implementation-report.md
+++ b/docs/reports/668/implementation-report.md
@@ -1,0 +1,69 @@
+# Implementation Report — Issue #668
+
+## Scope
+
+Surgical revert of response-payload scrubbing introduced in PRs #636, #652, #653, #654, #656. Keeps the (correct) log-side scrubbing. Aligns main with what's currently deployed in production.
+
+## Why
+
+Earlier today's umbrella-#637 fix arc conflated two distinct concerns:
+
+- **Logs (server-side)** — Aletheia's public observability commitment in `docs/observability.html` is absolute: *"NEVER log prompt text, user input, completion text, URLs, or user IDs."* Scrubbing exception text from `logger.*` calls is correct.
+- **Response payloads (user-facing)** — The privacy policy in `docs/privacy.html` makes no commitment to scrub responses going back to the user who made the request. The user is the source of their own input; receiving their own error text isn't a privacy leak.
+
+The fix arc applied the same scrub to BOTH surfaces, making user-facing errors strictly worse (e.g., `{"error": "ValueError: ValueError"}` tautology) with zero privacy gain.
+
+## State before this PR
+
+| Surface | State |
+|---|---|
+| Production | Reverted to `str(e)` via emergency direct `provision.sh` deploy |
+| Origin/main | Still has the broken class-name-only response fields from PRs #636, #652, #653, #654, #656 |
+| Risk | Anyone running `provision.sh` from clean main re-deploys the broken behavior |
+
+This PR closes that gap.
+
+## Source code reverts (8 lines)
+
+| File:line | Before this PR | After this PR |
+|---|---|---|
+| `src/guardrails/semantic.py:174` | `"reason": f"Guardrail Error: {error_class}"` | `f"Guardrail Error: {str(e)}"` |
+| `src/lambda_function.py:511` | `"gem": f"Generation Error: {error_class}"` | `"gem": str(e)` |
+| `src/etymologist.py:789` | `"error": error_class` | `"error": str(e)` |
+| `src/etymologist.py:862` | `metadata["opus_verifier_error"] = error_class` | `= str(e)` |
+| `src/lambda_auth_function.py:271` | `"message": error_class` | `"message": str(e)` |
+| `src/lambda_auth_function.py:570` | `"error": f"ValueError: {e.__class__.__name__}"` | `"error": str(e)` |
+| `src/lambda_auth_function.py:620` | same pattern | same fix |
+| `src/lambda_auth_function.py:660` | `"message": error_class` | `"message": str(e)` |
+
+All `logger.error/info/warning` lines REMAIN class-name-only. The privacy comments referencing audit issues were either updated or stayed in place where the log-side reasoning still applies.
+
+## NOT reverting
+
+- `src/signal_inspector/fetcher.py` — CLI-only, not in Lambda's import path.
+- `src/poetic_analyzer.py:333` — only had a log change, no response change to revert.
+- The `_log_unicode_diagnostics` deletion in `src/etymologist.py` — that function logged LLM completion-text characters, which IS a real observability.html violation. Deletion stays.
+- The `json_str[:200]` log removal in `src/etymologist.py` — same reasoning.
+- `tools/cws_image_pad.py` and `screenshots/cws/` (today's CWS image work — uncommitted on local main; separate concern).
+- All doc edits (privacy.html, observability.html, CLAUDE.md, ENGINEERING-JOURNAL.md, 10816 audit) — separate concerns.
+
+## Tests
+
+Full unit suite: **835 passed, 0 failures.**
+
+Changes:
+- Deleted response-checking tests added in the umbrella-#637 arc; kept their log-checking siblings.
+  - `test_semantic.py::TestExceptionTextDoesNotLeak` — kept only `test_exception_message_not_in_log_output`, renamed class to `TestExceptionTextDoesNotLeakIntoLog`.
+  - `test_etymologist.py::TestEtymologistExceptionTextDoesNotLeak` — kept `test_bedrock_exception_text_not_in_log` and `test_json_decode_error_does_not_log_completion_text`, renamed class to `TestEtymologistExceptionTextDoesNotLeakIntoLog`.
+- Restored 3 existing tests that had been modified to codify the broken response-field behavior:
+  - `test_etymologist.py::test_bedrock_exception_returns_error`
+  - `test_etymologist.py::test_verifier_falls_back_on_opus_exception`
+  - `test_persistence.py::test_020_generation_failure_still_saves`
+
+## Deploy
+
+`provision.sh` deploy required after merge to confirm a deploy from clean main produces the same state production already has. Smoke test: curl `/auth/token` with bogus code — expected `{"error": "Token exchange failed: 401"}`, NOT `{"error": "ValueError: ValueError"}`.
+
+## Closes
+
+- #668

--- a/docs/reports/668/test-report.md
+++ b/docs/reports/668/test-report.md
@@ -1,0 +1,54 @@
+# Test Report — Issue #668
+
+## Pytest Run
+
+```
+cd Aletheia-668
+poetry run pytest tests/unit/ -q
+```
+
+**Result:** `835 passed, 13 warnings in 6.50s` — zero failures.
+
+## Tests Deleted
+
+Response-checking tests that asserted canary-not-in-response. Without the revert, they passed; after the revert, they fail because `str(e)` is back. They codified a wrong interpretation of the privacy policy.
+
+| File | Test | Reason for deletion |
+|---|---|---|
+| `test_semantic.py` | `test_exception_message_not_in_response_reason` | Asserts canary not in result["reason"] — `reason` now contains str(e) again |
+| `test_semantic.py` | `test_exception_message_not_in_any_response_field` | Recursive walk asserts canary not in any response field |
+| `test_semantic.py` | `test_custom_exception_class_name_preserved` | Asserts class name in `reason` field — irrelevant now |
+| `test_etymologist.py` | `test_bedrock_exception_text_not_in_metadata` | Asserts canary not in `metadata["error"]` |
+| `test_etymologist.py` | `test_opus_verifier_exception_text_not_in_metadata` | Asserts canary not in `metadata["opus_verifier_error"]` |
+
+## Tests Kept (still pass after revert)
+
+Log-checking tests added in the same arc. The log-side scrubbing is the correct part and stays.
+
+| File | Test |
+|---|---|
+| `test_semantic.py` | `test_exception_message_not_in_log_output` |
+| `test_etymologist.py` | `test_bedrock_exception_text_not_in_log` |
+| `test_etymologist.py` | `test_json_decode_error_does_not_log_completion_text` |
+| `test_lambda_handler.py` | `TestLambdaFunctionExceptionTextDoesNotLeak::test_unhandled_exception_log_does_not_leak` |
+| `test_lambda_auth.py` | All 3 `TestAuthLambdaExceptionTextDoesNotLeak` tests (log + redirect_uri scrubbing) |
+| `test_signal_inspector.py` | Both `TestFetcherExceptionTextDoesNotLeak` tests (fetcher.py not reverted) |
+| `test_poetic_analyzer.py` | `test_bedrock_exception_text_not_in_log` (poetic_analyzer not reverted) |
+
+## Tests Restored to Original Assertions
+
+Three existing tests had been modified to codify the bad behavior. Each restored:
+
+| File | Test | Before this PR | After this PR |
+|---|---|---|---|
+| `test_etymologist.py` | `test_bedrock_exception_returns_error` | `metadata.error == "Exception"` | `"Bedrock error" in metadata.error` |
+| `test_etymologist.py` | `test_verifier_falls_back_on_opus_exception` | `opus_verifier_error == "Exception"` | `"Opus unavailable" in opus_verifier_error` |
+| `test_persistence.py` | `test_020_generation_failure_still_saves` | `"Generation Error" in gem`, `"Bedrock timeout" not in gem` | `"Bedrock timeout" in gem` |
+
+## ESLint / mypy / ruff
+
+All pass (pre-commit gate).
+
+## Conclusion
+
+Safe to merge. After merge, `provision.sh` confirms deploy from clean main produces production-equivalent state.

--- a/src/etymologist.py
+++ b/src/etymologist.py
@@ -786,7 +786,7 @@ def analyze_term(
             metadata={
                 "latency_ms": latency_ms,
                 "model": model_id,
-                "error": error_class,
+                "error": str(e),
             },
         )
 
@@ -859,5 +859,5 @@ def _verify_with_opus(
         # Privacy (#640): class name only. See umbrella #637.
         error_class = e.__class__.__name__
         logger.error(f"OPUS_VERIFIER_ERROR: {error_class}")
-        original_result["metadata"]["opus_verifier_error"] = error_class
+        original_result["metadata"]["opus_verifier_error"] = str(e)
         return original_result

--- a/src/guardrails/semantic.py
+++ b/src/guardrails/semantic.py
@@ -171,7 +171,7 @@ class SemanticGuardrail:
                 "category": "error",
                 "scores": {},
                 "is_safe": False,
-                "reason": f"Guardrail Error: {error_class}",
+                "reason": f"Guardrail Error: {str(e)}",
                 "is_fallback": True,
             }
 

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -268,7 +268,7 @@ def validate_token(event: dict, context: Any) -> dict:
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
                 "error": "LinkedIn API error",
-                "message": error_class,
+                "message": str(e),
             }),
         }
 
@@ -564,13 +564,11 @@ def handle_token_exchange(body: dict) -> dict:
         }
 
     except ValueError as e:
-        # Privacy (#641, audit umbrella #637): class name only in body.
         return {
             "statusCode": 400,
-            "body": json.dumps({"error": f"ValueError: {e.__class__.__name__}"}),
+            "body": json.dumps({"error": str(e)}),
         }
     except Exception as e:
-        # Privacy (#641 adjacent): class name only in log.
         logger.error(f"TOKEN_EXCHANGE_ERROR: {e.__class__.__name__}")
         return {
             "statusCode": 500,
@@ -614,13 +612,11 @@ def handle_token_refresh(body: dict) -> dict:
         }
 
     except ValueError as e:
-        # Privacy (#641, audit umbrella #637): class name only in body.
         return {
             "statusCode": 401,
-            "body": json.dumps({"error": f"ValueError: {e.__class__.__name__}"}),
+            "body": json.dumps({"error": str(e)}),
         }
     except Exception as e:
-        # Privacy (#641 adjacent): class name only in log.
         logger.error(f"TOKEN_REFRESH_ERROR: {e.__class__.__name__}")
         return {
             "statusCode": 500,
@@ -657,7 +653,7 @@ def handle_validate_token(headers: dict) -> dict:
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
                 "error": "LinkedIn API error",
-                "message": error_class,
+                "message": str(e),
             }),
         }
 

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -502,16 +502,19 @@ def _analysis_handler(
         }
     except Exception as e:
         # Issue #178: Capture error state for debugging.
-        # Privacy (#638, #651): log/return exception class name only — never str(e).
-        # Bedrock errors can carry request-payload echoes; see #637 audit umbrella.
+        # Issue #178: Capture error state for debugging.
+        # Privacy: only the SERVER-side log is scrubbed to class name (per
+        # docs/observability.html). The response payload — including the gem
+        # field below — goes back to the user who made the request and may
+        # contain their own data; scrubbing it provides no privacy benefit.
+        # See #668 for the reasoning.
         generation_error = e
-        error_class = e.__class__.__name__
         response_data = {
             "signal": "error",
-            "gem": f"Generation Error: {error_class}",
+            "gem": str(e),
             "context": "Generation failed",
         }
-        logger.error(f"ETYMOLOGY_GENERATION_ERROR: {error_class}")
+        logger.error(f"ETYMOLOGY_GENERATION_ERROR: {e.__class__.__name__}")
     finally:
         # Issue #162: Skip persistence if noarchive signal is present
         if skip_persistence:

--- a/tests/unit/test_etymologist.py
+++ b/tests/unit/test_etymologist.py
@@ -656,18 +656,13 @@ class TestAnalyzeTerm:
         assert "latency_ms" in result["metadata"]
 
     def test_bedrock_exception_returns_error(self, mock_bedrock_client):
-        """Test error handling when Bedrock throws exception.
-
-        Privacy (#639, audit umbrella #637): metadata.error must NOT contain
-        the exception message ("Bedrock error") — only the class name.
-        """
+        """Test error handling when Bedrock throws exception."""
         mock_bedrock_client.invoke_model.side_effect = Exception("Bedrock error")
 
         result = analyze_term("test", "", bedrock_client=mock_bedrock_client)
 
         assert result["status"] == "error"
-        assert "Bedrock error" not in result["metadata"]["error"]
-        assert result["metadata"]["error"] == "Exception"
+        assert "Bedrock error" in result["metadata"]["error"]
 
     def test_includes_latency_metadata(self, mock_bedrock_client):
         """Verify latency is tracked in metadata."""
@@ -1159,11 +1154,8 @@ class TestOpusVerifier:
         assert result["response"]["signal"] == "Prompt Injection Attempt"
         assert result["response"]["gem"] == "Haiku original."
         assert result["metadata"]["model"] == HAIKU_MODEL_ID
-        # Privacy (#640, audit umbrella #637): opus_verifier_error must hold
-        # the exception class name only, NOT the exception message text.
         assert "opus_verifier_error" in result["metadata"]
-        assert "Opus unavailable" not in result["metadata"]["opus_verifier_error"]
-        assert result["metadata"]["opus_verifier_error"] == "Exception"
+        assert "Opus unavailable" in result["metadata"]["opus_verifier_error"]
         assert "verified_by_opus" not in result["metadata"]
 
     def test_verifier_doesnt_recurse_on_opus_model_id(self, mock_bedrock_client):
@@ -1197,27 +1189,18 @@ class TestOpusVerifier:
         assert OPUS_MODEL_ID in ALLOWED_MODELS
 
 
-class TestEtymologistExceptionTextDoesNotLeak:
-    """Issues #639, #640, #646, #647 (audit umbrella #637):
+class TestEtymologistExceptionTextDoesNotLeakIntoLog:
+    """Issues #646, #647 (audit umbrella #637):
 
     Per docs/observability.html: "NEVER log prompt text, user input, completion
-    text, URLs, or user IDs." The etymologist's Bedrock invocation, JSON decode,
-    and Opus verifier exception handlers must surface only the exception class
-    name, never str(e) / repr(e) / e-content.
+    text, URLs, or user IDs." The etymologist's Bedrock invocation and JSON
+    decode log lines must surface only the exception class name.
+
+    Response metadata going back to the requesting user is NOT scrubbed —
+    user's own data is not a privacy leak. See #668.
     """
 
     CANARY = "CANARY-LEAK-etymologist-3f8c9a-WOULD-BE-USER-TEXT"
-
-    def test_bedrock_exception_text_not_in_metadata(self):
-        """Issue #639: metadata['error'] must not contain str(e)."""
-        mock_client = MagicMock()
-        mock_client.invoke_model.side_effect = Exception(self.CANARY)
-
-        result = analyze_term("test", "", bedrock_client=mock_client, model_id=HAIKU_MODEL_ID)
-
-        assert result["status"] == "error"
-        assert self.CANARY not in result["metadata"]["error"]
-        assert result["metadata"]["error"] == "Exception"
 
     def test_bedrock_exception_text_not_in_log(self, caplog):
         """Issue #646: BEDROCK_INVOCATION_ERROR log must not contain str(e)."""
@@ -1233,32 +1216,6 @@ class TestEtymologistExceptionTextDoesNotLeak:
         assert self.CANARY not in log_text, f"Canary leaked into log: {log_text!r}"
         assert "BEDROCK_INVOCATION_ERROR" in log_text
         assert "Exception" in log_text
-
-    def test_opus_verifier_exception_text_not_in_metadata(self):
-        """Issue #640: opus_verifier_error must not contain str(e)."""
-        def _haiku_resp(signal):
-            return {
-                "body": MagicMock(
-                    read=MagicMock(
-                        return_value=json.dumps({
-                            "content": [{"type": "text", "text": json.dumps({
-                                "signal": signal, "gem": "g", "context": "c"
-                            })}]
-                        }).encode()
-                    )
-                )
-            }
-
-        mock_client = MagicMock()
-        mock_client.invoke_model.side_effect = [
-            _haiku_resp("Prompt Injection Attempt"),
-            Exception(self.CANARY),
-        ]
-
-        result = analyze_term("gedenken", "ford", bedrock_client=mock_client, model_id=HAIKU_MODEL_ID)
-
-        assert self.CANARY not in result["metadata"]["opus_verifier_error"]
-        assert result["metadata"]["opus_verifier_error"] == "Exception"
 
     def test_json_decode_error_does_not_log_completion_text(self, caplog):
         """Issue #647: JSON decode handler must not log the malformed completion

--- a/tests/unit/test_persistence.py
+++ b/tests/unit/test_persistence.py
@@ -271,15 +271,11 @@ class TestAIResponsePersistence:
             assert item["domContext"]["S"] == "Some context here."
             assert item["url"]["S"] == "https://example.com"
 
-            # Verify error response was captured.
-            # Privacy (#638): the gem field must NOT contain the exception message
-            # ("Bedrock timeout") — only the exception class name. See umbrella #637.
+            # Verify error response was captured
             assert "response" in item
             response_data = json.loads(item["response"]["S"])
             assert response_data["signal"] == "error"
-            assert "Bedrock timeout" not in response_data["gem"]
-            assert "Generation Error" in response_data["gem"]
-            assert "Exception" in response_data["gem"]
+            assert "Bedrock timeout" in response_data["gem"]
 
     def test_030_signal_values_stored_correctly(self):
         """Scenario 030: Signal color values are stored correctly."""

--- a/tests/unit/test_semantic.py
+++ b/tests/unit/test_semantic.py
@@ -408,53 +408,20 @@ class TestRacialVocabularyClassification:
         assert result["is_safe"] is True
 
 
-class TestExceptionTextDoesNotLeak:
-    """Issue #619: exception text must never appear in log output or response payload.
+class TestExceptionTextDoesNotLeakIntoLog:
+    """Issue #619: exception text must not appear in server-side log output.
 
-    Aletheia's public privacy commitment (docs/observability.html) is absolute:
-    "NEVER log prompt text, user input, completion text, URLs, or user IDs."
-    Exceptions raised from code that processes user input can carry user-derived
-    content in their message text (json.JSONDecodeError via e.doc, botocore
-    ClientError validation messages, custom wrapped exceptions). Only the
-    exception class name may flow into logs and response fields.
+    Per docs/observability.html: "NEVER log prompt text, user input, completion
+    text, URLs, or user IDs." Exceptions raised from code that processes user
+    input can carry user-derived content in their message text. Only the
+    exception class name may flow into logger.* calls.
+
+    Response payloads going back to the requesting user are NOT scrubbed —
+    the user is the source of their own request and re-receiving their data
+    is not a privacy violation. See #668.
     """
 
     CANARY = "CANARY-LEAK-9d7e3f0a-WOULD-BE-USER-TEXT"
-
-    @patch("src.guardrails.semantic.boto3.client")
-    def test_exception_message_not_in_response_reason(self, mock_boto_client):
-        mock_client_instance = Mock()
-        mock_boto_client.return_value = mock_client_instance
-        mock_client_instance.invoke_model.side_effect = Exception(self.CANARY)
-
-        guard = SemanticGuardrail()
-        result = guard.check_safety("test input")
-
-        assert self.CANARY not in result["reason"], (
-            f"Exception text leaked into result['reason']: {result['reason']!r}"
-        )
-        assert "Exception" in result["reason"], "Exception class name missing — lost diagnostic value"
-
-    @patch("src.guardrails.semantic.boto3.client")
-    def test_exception_message_not_in_any_response_field(self, mock_boto_client):
-        mock_client_instance = Mock()
-        mock_boto_client.return_value = mock_client_instance
-        mock_client_instance.invoke_model.side_effect = Exception(self.CANARY)
-
-        guard = SemanticGuardrail()
-        result = guard.check_safety("test input")
-
-        def _no_canary(obj, path="result"):
-            if isinstance(obj, str):
-                assert self.CANARY not in obj, f"Canary leaked at {path}: {obj!r}"
-            elif isinstance(obj, dict):
-                for k, v in obj.items():
-                    _no_canary(v, f"{path}[{k!r}]")
-            elif isinstance(obj, (list, tuple)):
-                for i, v in enumerate(obj):
-                    _no_canary(v, f"{path}[{i}]")
-
-        _no_canary(result)
 
     @patch("src.guardrails.semantic.boto3.client")
     def test_exception_message_not_in_log_output(self, mock_boto_client, caplog):
@@ -474,18 +441,3 @@ class TestExceptionTextDoesNotLeak:
         )
         assert "SEMANTIC_GUARDRAIL_ERROR" in log_text
         assert "Exception" in log_text, "Exception class name missing from log — lost diagnostic value"
-
-    @patch("src.guardrails.semantic.boto3.client")
-    def test_custom_exception_class_name_preserved(self, mock_boto_client):
-        class WeirdCustomError(Exception):
-            pass
-
-        mock_client_instance = Mock()
-        mock_boto_client.return_value = mock_client_instance
-        mock_client_instance.invoke_model.side_effect = WeirdCustomError(self.CANARY)
-
-        guard = SemanticGuardrail()
-        result = guard.check_safety("test input")
-
-        assert self.CANARY not in result["reason"]
-        assert "WeirdCustomError" in result["reason"]


### PR DESCRIPTION
## Summary

Surgical revert of response-field scrubbing introduced by PRs #636, #652, #653, #654, #656. Keeps the (correct) log-side scrubbing. Aligns main with what's already deployed in production via emergency \`provision.sh\` from earlier today.

## Why

Two distinct concerns were conflated in the umbrella-#637 fix arc:

- **Logs** (server-side) — \`docs/observability.html\` commits to no exception text. Correct to scrub.
- **Response payloads** (user-facing) — \`docs/privacy.html\` makes no such commitment. The response goes to the user who made the request; their own input flowing back is not a privacy leak.

I scrubbed both. The response scrubbing broke user-facing error messages (e.g., \`{\"error\": \"ValueError: ValueError\"}\` tautology) with zero privacy benefit.

## State table

| Surface | Before this PR | After this PR |
|---|---|---|
| Production (post emergency revert) | Has \`str(e)\` in response fields | Same — already correct |
| Origin/main | Has class-name-only response fields (wrong) | Has \`str(e)\` (matches production) |
| Local main (pre-merge) | Had uncommitted revert | Will be clean after ff-merge |

## Changes

**Source:** 8 lines across 4 files restored to \`str(e)\`. All \`logger.*\` lines remain class-name-only. See \`docs/reports/668/implementation-report.md\` for line-by-line table.

**Tests:** Deleted response-checking tests added in the bad arc, restored 3 existing tests that were modified to codify the bad behavior. Full suite: **835 passed, 0 failures.**

## NOT touched

- \`src/signal_inspector/fetcher.py\` (CLI-only)
- \`src/poetic_analyzer.py\` (only log change there)
- \`_log_unicode_diagnostics\` deletion and \`json_str[:200]\` log removal in \`src/etymologist.py\` (those WERE real observability.html violations; stay deleted)
- All doc files
- All \`tools/\` files (including today's CWS image tool)
- All \`screenshots/\` files

## After merge

1. Manual \`gh pr merge --squash --delete-branch\` (no \`merge_pr.py\` — deleted in #665)
2. ADR-0217 graft cleanup for the squash-merge orphan branch
3. \`provision.sh\` deploy to confirm a clean-main deploy produces the same production state
4. Smoke test: \`curl -X POST .../auth/token -d '{\"code\":\"BOGUS\",\"redirectUri\":\"http://localhost:8585/callback\"}'\` expects \`{\"error\": \"Token exchange failed: 401\"}\` (the original useful error)

Closes #668