### PR TITLE
docs(runbooks): fix rm -f glob deletion + correct AMO live version (Closes #681, Closes #682)

### DIFF
--- a/docs/reports/681/implementation-report.md
+++ b/docs/reports/681/implementation-report.md
@@ -1,0 +1,35 @@
+# Implementation Report — #681, #682
+
+**Issues:** [#681](https://github.com/martymcenroe/Aletheia/issues/681) (rm -f glob in runbooks), [#682](https://github.com/martymcenroe/Aletheia/issues/682) (AMO runbook wrong version fact)
+**Date:** 2026-05-29 Central
+**Type:** Documentation (runbook corrections to PR #679)
+
+## Why
+
+Two defects in the store-publish runbooks shipped in PR #679, caught in operator review:
+
+1. **#681 — banned deletion pattern.** Both runbooks instructed `rm -f dist/aletheia-*-v*.zip` to clear stale build artifacts. That is a glob force-delete — the "wipe by pattern" hammer the universal CLAUDE.md bans.
+2. **#682 — wrong fact.** The AMO runbook (`10907`) claimed "Current published version: 1.1.2". The live AMO version is `1.1.1` (per the AMO public API; 1.1.2 was release-noted but never published).
+
+## Changes
+
+`docs/runbooks/10905-runbook-cws-publish.md` (→ v1.0.1):
+- §4a build + fallback: `rm -f <glob>` → list (`ls -1`) → inspect → delete identified file by name → STOP if unexpected.
+- Hardening-gap note rewritten (no `rm -f`; future `build_release.py` auto-clean must delete by exact name).
+- Deployment-state date corrected to "live; updated 2026-05-25" (CWS version 1.1.2 is correct).
+- Changelog row added.
+
+`docs/runbooks/10907-runbook-amo-publish.md` (→ v1.0.1):
+- Same `rm -f` → list/inspect/delete-by-name fix in §4a + hardening note.
+- Version fact corrected in 3 places: deployment-state, §1 Path B, §3a.1 — now "AMO live 1.1.1; repo/next-upload 1.1.2 (pending, never published)".
+- Changelog row added.
+
+## Verification
+
+`grep "rm -f"` over both files returns only the changelog text describing the fix and the safe named-delete example (`rm <file>`), no `rm -f` commands. AMO version reads 1.1.1-live/1.1.2-pending in all three locations. See test-report.md.
+
+## Not in scope (separate follow-ons)
+
+- `build_release.py` stale-artifact auto-clean (a code change; the runbooks flag it).
+- CWS listing-copy corrections from `docs/10920` (dashboard edits; CWS was last updated 2026-05-25, before the 2026-05-27 corrections doc).
+- Getting Firefox 1.1.2 actually live on AMO (operator publish, pending operator direction).

--- a/docs/reports/681/test-report.md
+++ b/docs/reports/681/test-report.md
@@ -1,0 +1,21 @@
+# Test Report — #681, #682
+
+**Issues:** [#681](https://github.com/martymcenroe/Aletheia/issues/681), [#682](https://github.com/martymcenroe/Aletheia/issues/682)
+**Date:** 2026-05-29 Central
+**Type:** Documentation — no application code changed; automated suites not applicable.
+
+## Verification performed
+
+| Check | Method | Result |
+|---|---|---|
+| No `rm -f` command remains | `grep -n "rm -f"` over both runbooks | ✅ only the changelog text describing the change + the safe named-delete example `rm dist/…-v1.1.1.zip` |
+| Safe deletion pattern present | inspect §4a (both) | ✅ `ls -1` list → inspect → delete by name → STOP-if-unexpected |
+| AMO version corrected | `grep "1.1.1\|1.1.2"` in 10907 | ✅ deployment-state, §1 Path B, §3a.1 all state 1.1.1 live / 1.1.2 pending |
+| AMO live version is actually 1.1.1 | AMO public API `addons.mozilla.org/api/v5/addons/addon/aletheia-ai/` | ✅ `current_version` = 1.1.1, updated 2026-03-06 |
+| CWS version unchanged (correct) | operator confirmed CWS = 1.1.2 (updated 2026-05-25) | ✅ 10905 keeps 1.1.2, date refined |
+| Version headers bumped | `grep "Version:** 1.0."` | ✅ both at 1.0.1 |
+| Changelog entries added | inspect §20 (both) | ✅ 1.0.1 rows with Closes #681 / #682 |
+
+## Conclusion
+
+Both defects corrected; runbooks are internally consistent and factually aligned with the live stores. No automated regression surface.

--- a/docs/runbooks/10905-runbook-cws-publish.md
+++ b/docs/runbooks/10905-runbook-cws-publish.md
@@ -1,7 +1,7 @@
 # 10905 — Chrome Web Store Publishing (Aletheia)
 
-> **Version:** 1.0.0
-> **Last updated:** 2026-05-28 11:49:42 PM Central
+> **Version:** 1.0.1
+> **Last updated:** 2026-05-29 01:05:10 AM Central
 > **Applies to:** Aletheia Chrome extension, every submission to the Chrome Web Store
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -18,7 +18,7 @@ Durable identifiers for the live Aletheia Chrome listing. Agent commands below (
 | Install URL | `https://chromewebstore.google.com/detail/aletheia/pfkfdlcdbajamklbneflfbkmnceooijm` |
 | Dashboard listing | `https://chrome.google.com/webstore/devconsole` → Items → Aletheia |
 | Publisher | ThriveTech.ai (`cto@thrivetech.ai`) |
-| Current published version | `1.1.2` (submitted 2026-03-10) |
+| Current published version | `1.1.2` (live; updated 2026-05-25) |
 | Stable-ID key | `manifest.json` → `key` field pins the dev-load ID to the published ID — not a secret |
 | Submission tracking | per-release issue (see §16); this runbook tracked by [#678](https://github.com/martymcenroe/Aletheia/issues/678) |
 
@@ -120,19 +120,23 @@ If any §3a item is unchecked, the agent fixes what it can (write missing releas
 
 ```bash
 cd /c/Users/mcwiz/Projects/Aletheia
-rm -f dist/aletheia-chrome-v*.zip   # clean stale artifacts so the operator can't upload an old one
+# Clear stale artifacts safely — never glob-delete. List first, inspect, then delete by name:
+ls -1 dist/aletheia-chrome-*.zip 2>/dev/null || echo "(none present)"
+#   If an older-version zip is listed, delete that file BY NAME (e.g. rm dist/aletheia-chrome-v1.1.1.zip).
+#   If the list shows anything you do not recognize, STOP and investigate before deleting.
 poetry run python tools/build_release.py
 ```
 
 `tools/build_release.py` verifies all four icons exist and are non-empty in both extension dirs, validates manifest parity (`name`, `version`, `description`, `icons`), runs `web-ext lint` on the Firefox source, reads the version from the Chrome manifest, and produces **both** `dist/aletheia-chrome-v{version}.zip` and `dist/aletheia-firefox-v{version}.zip`. For a CWS submission you use the **chrome** ZIP.
 
-> **Known hardening gap (principle 17):** `build_release.py` does NOT delete stale `dist/*.zip` before building (Clio's `build_release.py` does). Until that's fixed, the manual `rm -f` above is required. Follow-up: file an issue to add auto-clean to `build_release.py`.
+> **Known hardening gap (principle 17):** `build_release.py` does NOT delete stale `dist/*.zip` before building. Until that is fixed, do the list-inspect-delete-by-name step above. Follow-up: add stale-artifact cleanup to `build_release.py` that removes the prior Aletheia zips by exact name (never a glob).
 
 Fallback if `tools/build_release.py` is missing or broken:
 
 ```bash
 cd /c/Users/mcwiz/Projects/Aletheia
-rm -f dist/aletheia-chrome-v*.zip
+# List, inspect, then delete any stale chrome zip BY NAME (never a glob); STOP if the list is unexpected:
+ls -1 dist/aletheia-chrome-*.zip 2>/dev/null || echo "(none present)"
 cd extensions/chrome
 zip -r ../../dist/aletheia-chrome-vX.Y.Z.zip . -x '.*' -x '*/.*' -x 'node_modules/*'
 ```
@@ -533,4 +537,5 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.1 | 2026-05-29 01:05:10 AM Central | Patch: replaced the `rm -f <glob>` artifact-clean steps in §4a (main + fallback) with a list → inspect → delete-by-name procedure (Closes #681); corrected the deployment-state line to "live; updated 2026-05-25" (CWS is genuinely at 1.1.2). |
 | 1.0.0 | 2026-05-28 11:49:42 PM Central | Restructured to the AZ#1362 runbook standard, modeled on [Clio 30002](https://github.com/martymcenroe/Clio/blob/main/docs/runbooks/30002-chrome-web-store-publish.md). Renamed `10905-runbook-extension-store-publish.md` → `10905-runbook-cws-publish.md` and scoped Chrome-only; Firefox/AMO split to new [10907](./10907-runbook-amo-publish.md). Added: semver+timestamp header, deployment-state block (Extension ID `pfkfdlcdbajamklbneflfbkmnceooijm`, install URL, publisher), §0 invoke phrases, §1 reading-path matrix, §3a/§3b split pre-flight, agent-owned `build_release.py` build, dashboard-order §7–§13, publisher-level §10 Account Settings (shared with Clio). Lifted the audit-corrected Long Description, Privacy Policy URL (`aletheia.study/privacy.html`), and all seven permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md` as inline canonical paste-blocks; flagged the "Open Source" vs PolyForm-Noncommercial wording. Closes #678 (with [10907](./10907-runbook-amo-publish.md)). |

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,7 +1,7 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.0
-> **Last updated:** 2026-05-28 11:49:42 PM Central
+> **Version:** 1.0.1
+> **Last updated:** 2026-05-29 01:05:10 AM Central
 > **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -20,7 +20,7 @@ Durable identifiers for the live Aletheia Firefox listing. Agent commands below 
 | Developer Hub | `https://addons.mozilla.org/developers/` |
 | Manage Versions | `https://addons.mozilla.org/developers/addon/aletheia-ai/versions/` |
 | Account | `cto@thrivetech.ai` (forwards to `cto.thrivetech.ai@gmail.com`) |
-| Current published version | `1.1.2` (submitted 2026-03-10) |
+| Current published version | `1.1.1` (live on AMO; updated 2026-03-06). `1.1.2` is built + release-noted but never went live — it is the pending upload. |
 | Minimum Firefox | `140.0` desktop / `142.0` Android (`browser_specific_settings.gecko`) |
 | License (must be) | **PolyForm Noncommercial 1.0.0** — NOT MIT (recurring error; see §11) |
 
@@ -60,7 +60,7 @@ The agent's reply includes (a) a one-line confirmation, (b) findings/follow-ups,
 | Situation | Read sections |
 |-----------|--------------|
 | **Path A — First AMO submission** (add-on not yet in the Developer Hub) | §2 → §3 → §4 → §5 → §7 → §8 → §9 → §10 → §11 → §12 → §13 → §14 → §15 |
-| **Path B — Subsequent update** (Aletheia already in My Add-ons — the normal case; current version 1.1.2) | §2 → §3 → §4 → §6 → (review §7–§13 if listing copy changed) → §13 source check → §14 → §15 |
+| **Path B — Subsequent update** (Aletheia already in My Add-ons — the normal case; AMO is live at 1.1.1, the repo is at 1.1.2 = the pending upload) | §2 → §3 → §4 → §6 → (review §7–§13 if listing copy changed) → §13 source check → §14 → §15 |
 | **Path C — New machine or new AMO account** | Stop. Confirm the `cto@thrivetech.ai` AMO login (2FA) and, if automating, regenerate API credentials (§17). Then return as Path A or Path B. |
 
 §16 Version bump, §17 API/`web-ext` path, §18 Troubleshooting, §19 Related documents, §20 Change log are reference material.
@@ -79,7 +79,7 @@ Split by responsibility, items numbered for "§3a.N" / "§3b.N" reference.
 
 ### 3a. Agent does (in the repo, before producing the ZIP)
 
-1. `extensions/firefox/manifest.json` has the new `version`, monotonic from the last published version (currently `1.1.2`), and **matching `extensions/chrome/manifest.json`** (`build_release.py` enforces parity on `name`, `version`, `description`, `icons`).
+1. `extensions/firefox/manifest.json` has the new `version`, monotonic from the last published AMO version (currently `1.1.1` live; the repo is already at `1.1.2`, which is the pending upload), and **matching `extensions/chrome/manifest.json`** (`build_release.py` enforces parity on `name`, `version`, `description`, `icons`).
 2. Firefox `permissions` is exactly `activeTab`, `tabs`, `scripting`, `contextMenus`, `storage` — **five, not seven**. Firefox does NOT request `identity` (it uses a tabs-based OAuth flow, not `chrome.identity`) or `notifications`. `host_permissions` is exactly `["https://api.aletheia.study/*"]`. Every permission has a §12 paste-block.
 3. `browser_specific_settings.gecko` is intact: `id` = `extension@aletheia.study`, `strict_min_version` = `140.0`, `gecko_android.strict_min_version` = `142.0`. The `data_collection_permissions` block declares `required: ["authenticationInfo", "websiteContent"]`, `optional: []` — this must match the §10 data-collection disclosure.
 4. No live debug-tier console calls in `extensions/firefox/*.js` (same banned/allowed rule as the Chrome runbook §3a.3). No hardcoded test URLs or dev flags; all API traffic goes to `https://api.aletheia.study/*`.
@@ -106,13 +106,16 @@ Split by responsibility, items numbered for "§3a.N" / "§3b.N" reference.
 
 ```bash
 cd /c/Users/mcwiz/Projects/Aletheia
-rm -f dist/aletheia-firefox-v*.zip   # clean stale artifacts
+# Clear stale artifacts safely — never glob-delete. List first, inspect, then delete by name:
+ls -1 dist/aletheia-firefox-*.zip 2>/dev/null || echo "(none present)"
+#   If an older-version zip is listed, delete that file BY NAME (e.g. rm dist/aletheia-firefox-v1.1.1.zip).
+#   If the list shows anything you do not recognize, STOP and investigate before deleting.
 poetry run python tools/build_release.py
 ```
 
 Produces `dist/aletheia-firefox-v{version}.zip` (and the Chrome ZIP). `build_release.py` runs `web-ext lint` on the Firefox source as Step 3.
 
-> **Known hardening gap (principle 17):** `build_release.py` does not auto-clean stale `dist/*.zip`. The manual `rm -f` above is required until that's fixed (file a follow-up issue — same gap noted in [10905](./10905-runbook-cws-publish.md) §4a).
+> **Known hardening gap (principle 17):** `build_release.py` does not auto-clean stale `dist/*.zip`. Do the list-inspect-delete-by-name step above until that is fixed (same gap noted in [10905](./10905-runbook-cws-publish.md) §4a; follow-up: have the script remove prior Aletheia zips by exact name, never a glob).
 
 Fallback if the build tool is broken:
 
@@ -440,4 +443,5 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.1 | 2026-05-29 01:05:10 AM Central | Patch: corrected the deployment-state, §1 Path B, and §3a.1 to state the live AMO version is `1.1.1` (1.1.2 was release-noted but never published — it is the pending upload) (Closes #682); replaced the `rm -f <glob>` artifact-clean step in §4a with a list → inspect → delete-by-name procedure (Closes #681). |
 | 1.0.0 | 2026-05-28 11:49:42 PM Central | New runbook, built to the AZ#1362 standard, split out of `10905-runbook-extension-store-publish.md` (which became the Chrome-only [10905](./10905-runbook-cws-publish.md)). Firefox-AMO-specific coverage the Chrome runbook lacks: §10b manifest `data_collection_permissions` disclosure (authenticationInfo + websiteContent), §11 PolyForm-Noncommercial custom-license trap (was wrongly MIT), §12 five-permission set (no `identity`/`notifications`; tabs-based OAuth), §13 source-code-submission question, §17 AMO API-key + `web-ext sign` path with secret-handling discipline. Lifted the audit-corrected Description, Privacy Policy URL, and permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md`. Closes #678 (with [10905](./10905-runbook-cws-publish.md)). |


### PR DESCRIPTION
## Summary

Fixes two defects in the store-publish runbooks that shipped in PR #679, caught in operator review.

## #681 — banned deletion pattern

§4a of both `10905-runbook-cws-publish.md` and `10907-runbook-amo-publish.md` instructed `rm -f dist/aletheia-*-v*.zip` — a glob force-delete (the "wipe by pattern" hammer the universal CLAUDE.md bans). Replaced with: list (`ls -1`) -> inspect -> delete the identified file by name -> STOP if the list is unexpected. Hardening-gap notes rewritten to match.

## #682 — wrong fact

`10907` claimed "Current published version: 1.1.2". The live AMO version is **1.1.1** (per the AMO public API; 1.1.2 was release-noted but never published). Corrected in the deployment-state block, §1 Path B, and §3a.1 — now "AMO live 1.1.1; repo / next-upload 1.1.2 (pending)". CWS is genuinely at 1.1.2, so `10905` only got a date refinement.

Both runbooks bumped to v1.0.1 with changelog entries (version bump + changelog per the runbook standard). Reports under `docs/reports/681/`.

Closes #681
Closes #682