### PR TITLE
docs(runbooks): correct UTC-mislabeled timestamps to true Central (Closes #684)

### DIFF
--- a/docs/reports/684/implementation-report.md
+++ b/docs/reports/684/implementation-report.md
@@ -1,0 +1,29 @@
+# Implementation Report — #684
+
+**Issue:** [#684](https://github.com/martymcenroe/Aletheia/issues/684) — runbook timestamps were UTC mislabeled as Central
+**Date:** 2026-05-29 Central
+**Type:** Documentation (timestamp correction)
+
+## Root cause
+
+The runbook timestamps were generated with `TZ='America/Chicago' date`. Git Bash has no IANA timezone database, so it ignores the named zone and returns **UTC**, which was then labeled "Central" — off by 5 hours (CDT, UTC-5) and a calendar day after ~7 PM Central. The correct command is plain `date` (the system clock is already Central); it was used to produce the v1.0.2 timestamps in this change.
+
+## Changes (both `10905-runbook-cws-publish.md` and `10907-runbook-amo-publish.md`)
+
+| Field | Was (UTC-as-Central) | Now (true Central) |
+|---|---|---|
+| v1.0.0 changelog date | 2026-05-28 11:49:42 PM | 2026-05-28 06:49:42 PM |
+| v1.0.1 changelog date | 2026-05-29 01:05:10 AM | 2026-05-28 08:05:10 PM |
+| Header "Last updated" | 2026-05-29 01:05:10 AM | 2026-05-29 12:18:55 AM (v1.0.2 stamp) |
+| Version | 1.0.1 | 1.0.2 |
+
+Added a v1.0.2 changelog row to each runbook documenting the correction and the cause.
+
+## Out of repo (also done this session)
+
+- Root CLAUDE.md (`C:\Users\mcwiz\Projects\CLAUDE.md`): the "Surface timestamps in US Central" rule now states to use plain `date`, never the `TZ=` prefix, never PowerShell.
+- Agent memory `reference-central-time-on-windows`: corrected to recommend plain `date`.
+
+## Verification
+
+See test-report.md. `grep` confirms no `01:05:10 AM` / `11:49:42 PM` remain; corrected values present; both runbooks at v1.0.2.

--- a/docs/reports/684/test-report.md
+++ b/docs/reports/684/test-report.md
@@ -1,0 +1,19 @@
+# Test Report — #684
+
+**Issue:** [#684](https://github.com/martymcenroe/Aletheia/issues/684)
+**Date:** 2026-05-29 Central
+**Type:** Documentation — no application code changed.
+
+## Verification performed
+
+| Check | Method | Result |
+|---|---|---|
+| Wrong stamps removed | `grep -n "01:05:10 AM\|11:49:42 PM"` over both runbooks | ✅ none remain |
+| Corrected stamps present | `grep` for `06:49:42 PM`, `08:05:10 PM`, `12:18:55 AM` | ✅ present in both |
+| Version bumped | `grep "Version:** 1.0.2"` | ✅ both at 1.0.2 |
+| Conversion is correct | plain `date` vs `date -u` | ✅ plain `date` = CDT (UTC-5): `date -u` 05:18 → Central 12:18 AM; UTC-as-Central values minus 5h match the corrected values |
+| Correct command used for new stamp | plain `date` (no `TZ=` prefix, no PowerShell) | ✅ |
+
+## Conclusion
+
+All timestamps in both runbooks are now true US Central. Root cause (the `TZ=` prefix) is recorded in the root CLAUDE.md and agent memory to prevent recurrence.

--- a/docs/runbooks/10905-runbook-cws-publish.md
+++ b/docs/runbooks/10905-runbook-cws-publish.md
@@ -1,7 +1,7 @@
 # 10905 — Chrome Web Store Publishing (Aletheia)
 
-> **Version:** 1.0.1
-> **Last updated:** 2026-05-29 01:05:10 AM Central
+> **Version:** 1.0.2
+> **Last updated:** 2026-05-29 12:18:55 AM Central
 > **Applies to:** Aletheia Chrome extension, every submission to the Chrome Web Store
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -537,5 +537,6 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.0.1 | 2026-05-29 01:05:10 AM Central | Patch: replaced the `rm -f <glob>` artifact-clean steps in §4a (main + fallback) with a list → inspect → delete-by-name procedure (Closes #681); corrected the deployment-state line to "live; updated 2026-05-25" (CWS is genuinely at 1.1.2). |
-| 1.0.0 | 2026-05-28 11:49:42 PM Central | Restructured to the AZ#1362 runbook standard, modeled on [Clio 30002](https://github.com/martymcenroe/Clio/blob/main/docs/runbooks/30002-chrome-web-store-publish.md). Renamed `10905-runbook-extension-store-publish.md` → `10905-runbook-cws-publish.md` and scoped Chrome-only; Firefox/AMO split to new [10907](./10907-runbook-amo-publish.md). Added: semver+timestamp header, deployment-state block (Extension ID `pfkfdlcdbajamklbneflfbkmnceooijm`, install URL, publisher), §0 invoke phrases, §1 reading-path matrix, §3a/§3b split pre-flight, agent-owned `build_release.py` build, dashboard-order §7–§13, publisher-level §10 Account Settings (shared with Clio). Lifted the audit-corrected Long Description, Privacy Policy URL (`aletheia.study/privacy.html`), and all seven permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md` as inline canonical paste-blocks; flagged the "Open Source" vs PolyForm-Noncommercial wording. Closes #678 (with [10907](./10907-runbook-amo-publish.md)). |
+| 1.0.2 | 2026-05-29 12:18:55 AM Central | Patch: corrected timestamps that were UTC mislabeled as Central — the v1.0.0/v1.0.1 dates and the header were produced with `TZ='America/Chicago' date`, which Git Bash returns as UTC. Re-derived to true Central (CDT, UTC-5) with plain `date` (Closes #684). |
+| 1.0.1 | 2026-05-28 08:05:10 PM Central | Patch: replaced the `rm -f <glob>` artifact-clean steps in §4a (main + fallback) with a list → inspect → delete-by-name procedure (Closes #681); corrected the deployment-state line to "live; updated 2026-05-25" (CWS is genuinely at 1.1.2). |
+| 1.0.0 | 2026-05-28 06:49:42 PM Central | Restructured to the AZ#1362 runbook standard, modeled on [Clio 30002](https://github.com/martymcenroe/Clio/blob/main/docs/runbooks/30002-chrome-web-store-publish.md). Renamed `10905-runbook-extension-store-publish.md` → `10905-runbook-cws-publish.md` and scoped Chrome-only; Firefox/AMO split to new [10907](./10907-runbook-amo-publish.md). Added: semver+timestamp header, deployment-state block (Extension ID `pfkfdlcdbajamklbneflfbkmnceooijm`, install URL, publisher), §0 invoke phrases, §1 reading-path matrix, §3a/§3b split pre-flight, agent-owned `build_release.py` build, dashboard-order §7–§13, publisher-level §10 Account Settings (shared with Clio). Lifted the audit-corrected Long Description, Privacy Policy URL (`aletheia.study/privacy.html`), and all seven permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md` as inline canonical paste-blocks; flagged the "Open Source" vs PolyForm-Noncommercial wording. Closes #678 (with [10907](./10907-runbook-amo-publish.md)). |

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,7 +1,7 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.1
-> **Last updated:** 2026-05-29 01:05:10 AM Central
+> **Version:** 1.0.2
+> **Last updated:** 2026-05-29 12:18:55 AM Central
 > **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -443,5 +443,6 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.0.1 | 2026-05-29 01:05:10 AM Central | Patch: corrected the deployment-state, §1 Path B, and §3a.1 to state the live AMO version is `1.1.1` (1.1.2 was release-noted but never published — it is the pending upload) (Closes #682); replaced the `rm -f <glob>` artifact-clean step in §4a with a list → inspect → delete-by-name procedure (Closes #681). |
-| 1.0.0 | 2026-05-28 11:49:42 PM Central | New runbook, built to the AZ#1362 standard, split out of `10905-runbook-extension-store-publish.md` (which became the Chrome-only [10905](./10905-runbook-cws-publish.md)). Firefox-AMO-specific coverage the Chrome runbook lacks: §10b manifest `data_collection_permissions` disclosure (authenticationInfo + websiteContent), §11 PolyForm-Noncommercial custom-license trap (was wrongly MIT), §12 five-permission set (no `identity`/`notifications`; tabs-based OAuth), §13 source-code-submission question, §17 AMO API-key + `web-ext sign` path with secret-handling discipline. Lifted the audit-corrected Description, Privacy Policy URL, and permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md`. Closes #678 (with [10905](./10905-runbook-cws-publish.md)). |
+| 1.0.2 | 2026-05-29 12:18:55 AM Central | Patch: corrected timestamps that were UTC mislabeled as Central — the v1.0.0/v1.0.1 dates and the header were produced with `TZ='America/Chicago' date`, which Git Bash returns as UTC. Re-derived to true Central (CDT, UTC-5) with plain `date` (Closes #684). |
+| 1.0.1 | 2026-05-28 08:05:10 PM Central | Patch: corrected the deployment-state, §1 Path B, and §3a.1 to state the live AMO version is `1.1.1` (1.1.2 was release-noted but never published — it is the pending upload) (Closes #682); replaced the `rm -f <glob>` artifact-clean step in §4a with a list → inspect → delete-by-name procedure (Closes #681). |
+| 1.0.0 | 2026-05-28 06:49:42 PM Central | New runbook, built to the AZ#1362 standard, split out of `10905-runbook-extension-store-publish.md` (which became the Chrome-only [10905](./10905-runbook-cws-publish.md)). Firefox-AMO-specific coverage the Chrome runbook lacks: §10b manifest `data_collection_permissions` disclosure (authenticationInfo + websiteContent), §11 PolyForm-Noncommercial custom-license trap (was wrongly MIT), §12 five-permission set (no `identity`/`notifications`; tabs-based OAuth), §13 source-code-submission question, §17 AMO API-key + `web-ext sign` path with secret-handling discipline. Lifted the audit-corrected Description, Privacy Policy URL, and permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md`. Closes #678 (with [10905](./10905-runbook-cws-publish.md)). |


### PR DESCRIPTION
Corrects timestamps in both store-publish runbooks that were UTC wearing a "Central" label.

They were generated with `TZ=America/Chicago date`, which Git Bash cannot resolve (no IANA tzdata), so it returns UTC. Re-derived to true Central (CDT, UTC-5) with plain `date`:

| Field | Was (UTC-as-Central) | Now (true Central) |
|---|---|---|
| v1.0.0 changelog | 2026-05-28 11:49:42 PM | 2026-05-28 06:49:42 PM |
| v1.0.1 changelog | 2026-05-29 01:05:10 AM | 2026-05-28 08:05:10 PM |
| header "Last updated" | 2026-05-29 01:05:10 AM | 2026-05-29 12:18:55 AM |
| version | 1.0.1 | 1.0.2 |

Both runbooks bumped to v1.0.2 with a changelog row documenting the correction and its cause. The recurrence guard (use plain `date`, never the `TZ=` prefix, never PowerShell) was added to the root CLAUDE.md and agent memory in the same session.

Closes #684