### PR TITLE
docs: delete fabricated no-console-log rule (Closes #691)

### DIFF
--- a/docs/reports/691/implementation-report.md
+++ b/docs/reports/691/implementation-report.md
@@ -1,0 +1,48 @@
+# Issue #691 — Implementation Report
+
+## Issue summary
+
+Delete the fabricated runbook rule that banned live `console.log` / `console.debug` / `console.info` / `console.warn` calls in extension JavaScript. The rule was framed as a privacy-policy concern by the agent in the 2026-05-29 onboard, but had no grounding in `docs/privacy.html` or any other source document.
+
+## Change set
+
+### `docs/runbooks/10907-runbook-amo-publish.md`
+
+- Version: 1.0.4 → 1.0.5.
+- Last updated: 2026-05-29 11:26:54 AM Central.
+- **§3a.4**: removed the *"No live debug-tier console calls in `extensions/firefox/*.js` (same banned/allowed rule as the Chrome runbook §3a.3)"* clause. The item now reads only the kept *"No hardcoded test URLs or dev flags"* portion. No renumbering needed — items 5–8 keep their numbers, and the §3b.5 + §8b cross-references to §3a.7 and §3a.8 remain accurate.
+- Change-log entry added at v1.0.5.
+
+### `docs/runbooks/10905-runbook-cws-publish.md`
+
+- Version: 1.0.2 → 1.0.3.
+- Last updated: 2026-05-29 11:26:54 AM Central.
+- **§3a.3 deleted in full.** Remaining §3a items 4–11 renumbered to 3–10.
+- §3b.3 cross-reference updated: §3a.10 → §3a.9.
+- §3b.5 cross-reference updated: §3a.11 → §3a.10.
+- §8 (Graphic assets) cross-reference updated: §3a.9 → §3a.8.
+- Change-log entry added at v1.0.3.
+
+## Grounding (why the rule had to go)
+
+`docs/privacy.html` (last updated March 2026):
+
+- Commits to what is sent to servers, stored for 30 days, not used for training, not sold.
+- No mention of console output. No mention of local browser-state behavior.
+
+Grep across `docs/*.html`, `docs/lld/done/10051-store-compliance.md`, and the broader `docs/` tree for `console\.|local.{0,10}log|browser.{0,10}console` (case-insensitive): no matches outside the two runbooks themselves.
+
+`console.log(...)` writes to the user's own browser DevTools panel on the user's own machine. It is not transmitted, not stored on a remote server, not shared with a third party. The privacy policy makes no commitment that prohibits it.
+
+## Out of scope
+
+- The two `extensions/firefox/service-worker.js` lines (`:566`, `:585`) flagged in the original handoff are **not** modified by this PR. With the rule removed, they are a code-hygiene matter, not a publishing blocker. A future decision about removing them belongs in its own issue if anyone chooses to pursue it.
+- The other ~28 mundane `console.log` calls across `extensions/firefox/{auth.js, popup.js, service-worker.js}` are also unaffected.
+- The blog draft at `C:/Users/mcwiz/Projects/dispatch/drafts/2026-05-29-vigilance-is-the-eternal-price-of-freedom-from-Aletheia.md` is in a separate repo and uncommitted.
+- The lessons-learned entry on `main` is uncommitted on main and will batch with `/cleanup` per project rule.
+
+## Related artifacts
+
+- Issue body of #691 was rewritten before opening this PR; the "Decision pending" section now reads "Decision: delete the rule."
+- `data/pickup-read-log.md` entry 2026-05-29 08:11:30 contains the grep results that established the rule had no upstream source.
+- `docs/lessons-learned.md` entry dated 2026-05-29 captures the broader lesson (agent-authored rule + agent-applied privacy framing = self-confirming false constraint).

--- a/docs/reports/691/test-report.md
+++ b/docs/reports/691/test-report.md
@@ -1,0 +1,26 @@
+# Issue #691 — Test Report
+
+## What changed
+
+Docs-only edits to two markdown files: `docs/runbooks/10907-runbook-amo-publish.md` and `docs/runbooks/10905-runbook-cws-publish.md`. No code, no configuration, no build artifacts touched.
+
+## Test plan
+
+| Check | Result |
+|---|---|
+| Automated test suites (`poetry run pytest`, `npx playwright test`) | Not applicable — no Python or JavaScript was modified. No code paths changed. |
+| Lint (`npm run lint`, `web-ext lint`) | Not applicable — no JavaScript or extension manifest was modified. |
+| Markdown rendering | Both files render correctly under GitHub Flavored Markdown; numbered lists in §3a maintain sequential numbering after the deletion + renumber. |
+| Cross-reference integrity | `grep -n '§3a\.[0-9]\+' docs/runbooks/10907-runbook-amo-publish.md docs/runbooks/10905-runbook-cws-publish.md` — every surviving §3a.N reference still resolves to a valid §3a item in its file. |
+| No banned-rule survivors | `grep -in 'no live debug-tier console' docs/runbooks/` — no matches in the body text of either runbook. (The phrase still appears inside the change-log entries that record the deletion; that is correct and expected.) |
+| Existing main-branch test failure | The pre-existing failure in `tests/integration/test_user_data_deletion.py` is tracked at issue #680 and is unrelated to this PR. It will cause `mergeable_state` to read `unstable` rather than `clean` on this PR; squash-merge still works and Cerberus still auto-approves under `unstable`. |
+
+## Verification on merge
+
+After merge to `main`:
+
+```
+grep -n 'no live debug-tier console' docs/runbooks/*.md
+```
+
+Expected output: matches **only** inside the change-log rows of `10905-runbook-cws-publish.md` and `10907-runbook-amo-publish.md` that record this deletion. Zero matches in the body text of either runbook.

--- a/docs/runbooks/10905-runbook-cws-publish.md
+++ b/docs/runbooks/10905-runbook-cws-publish.md
@@ -1,7 +1,7 @@
 # 10905 — Chrome Web Store Publishing (Aletheia)
 
-> **Version:** 1.0.2
-> **Last updated:** 2026-05-29 12:18:55 AM Central
+> **Version:** 1.0.3
+> **Last updated:** 2026-05-29 11:26:54 AM Central
 > **Applies to:** Aletheia Chrome extension, every submission to the Chrome Web Store
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -88,23 +88,22 @@ Split by responsibility. **Agent items** happen in the repo. **Operator items** 
 
 1. `extensions/chrome/manifest.json` has the new `version`, monotonically increasing from the last published version (currently `1.1.2`). For Path A first submission, no prior published version exists; auto-pass. The Chrome manifest version is the build's source of truth (`tools/build_release.py` Step 4).
 2. `permissions` is exactly `activeTab`, `tabs`, `scripting`, `contextMenus`, `storage`, `identity`, `notifications`. `host_permissions` is exactly `["https://api.aletheia.study/*"]`. **Every permission has a §12 paste-block.** If §12 has fewer entries than the manifest, that's the finding — the 2026-05-26 privacy audit found the dashboard was missing justifications for `tabs`, `storage`, `identity`, and `notifications` (see #670–#672 / `docs/10920-cws-listing-corrections-2026-05-27.md`). Adding a new permission to the manifest requires adding a §12 paste-block in the same change.
-3. No live debug-tier console calls in `extensions/chrome/*.js`. **Banned:** live `console.log` / `console.debug` / `console.info` / `console.warn`. **Allowed:** `console.error` inside a `try/catch` that also surfaces the error to the user via the popup/overlay UI; commented-out calls; explanatory comments.
-4. No hardcoded test URLs, dev flags, or scratch code. **All API traffic goes through `https://api.aletheia.study/*` — never a raw Lambda Function URL** (this was a v1.1.2 security fix).
-5. All tests pass: `poetry run pytest` (backend) and `npx playwright test` (extension e2e).
-6. Lint clean: `npm run lint` (or `npx eslint .`).
-7. Version bump merged to `main` — build from `main`, never a feature branch.
-8. Release notes file `docs/releases/chrome-vX.Y.Z.md` written before the §4 build — see §18.
-9. Listing screenshots exist at `screenshots/cws/cws-image-N-<slug>.png`, format **24-bit PNG (no alpha)**, dimensions **1280×800** (or 640×400; 1280×800 is the default). Mechanical check; agent reports file list, sizes, dimensions, and color mode (must be `RGB`, never `RGBA`). **Current state:** only `screenshots/cws/cws-image-1-epocha.png` exists; the live listing carries 4 identical placeholder screenshots. **[#635](https://github.com/martymcenroe/Aletheia/issues/635) tracks producing 4 distinct images** — produce them with [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) before the next listing-copy submission.
-10. Agent reads each `screenshots/cws/*.png` and pre-describes what's visible (browser chrome, overlay state, page content) so the operator's §3b.3 review is "approve the flag-list," not "review from scratch."
-11. Agent reports the current `main` HEAD commit SHA and this runbook's `> **Version:**` line so the operator can sanity-check a printed copy.
+3. No hardcoded test URLs, dev flags, or scratch code. **All API traffic goes through `https://api.aletheia.study/*` — never a raw Lambda Function URL** (this was a v1.1.2 security fix).
+4. All tests pass: `poetry run pytest` (backend) and `npx playwright test` (extension e2e).
+5. Lint clean: `npm run lint` (or `npx eslint .`).
+6. Version bump merged to `main` — build from `main`, never a feature branch.
+7. Release notes file `docs/releases/chrome-vX.Y.Z.md` written before the §4 build — see §18.
+8. Listing screenshots exist at `screenshots/cws/cws-image-N-<slug>.png`, format **24-bit PNG (no alpha)**, dimensions **1280×800** (or 640×400; 1280×800 is the default). Mechanical check; agent reports file list, sizes, dimensions, and color mode (must be `RGB`, never `RGBA`). **Current state:** only `screenshots/cws/cws-image-1-epocha.png` exists; the live listing carries 4 identical placeholder screenshots. **[#635](https://github.com/martymcenroe/Aletheia/issues/635) tracks producing 4 distinct images** — produce them with [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) before the next listing-copy submission.
+9. Agent reads each `screenshots/cws/*.png` and pre-describes what's visible (browser chrome, overlay state, page content) so the operator's §3b.3 review is "approve the flag-list," not "review from scratch."
+10. Agent reports the current `main` HEAD commit SHA and this runbook's `> **Version:**` line so the operator can sanity-check a printed copy.
 
 ### 3b. Operator does (on the publishing machine)
 
 1. §2 Account check passes — Publisher chip `ThriveTech.ai`, avatar `cto@thrivetech.ai`.
 2. The version isn't already in the dashboard. For Path B, check the Package tab's version history. For Path A, Aletheia isn't in the Items list yet; auto-pass.
-3. Approve the agent's §3a.10 screenshot pre-description, or flag personal info / embarrassing content the agent missed.
+3. Approve the agent's §3a.9 screenshot pre-description, or flag personal info / embarrassing content the agent missed.
 4. Review §7–§12 paste-blocks for changes since last submission — these are the canonical source; no second document to open. **The dashboard may still carry pre-audit text** (e.g. the false "cannot see your browsing history" claim, the stale `github.io` privacy URL, missing permission justifications). Where the dashboard disagrees with §7/§11/§12, overwrite the dashboard to match this runbook.
-5. Operator's printed-copy version line matches the version the agent reported in §3a.11.
+5. Operator's printed-copy version line matches the version the agent reported in §3a.10.
 
 If any §3a item is unchecked, the agent fixes what it can (write missing release notes, regenerate screenshots, etc.) and surfaces the rest before producing the ZIP. If any §3b item is unchecked, the operator pauses before clicking Upload.
 
@@ -255,7 +254,7 @@ cto@thrivetech.ai
 
 ## 8. Store listing — graphic assets
 
-The **Graphic assets** section of the Store listing tab. Upload in dashboard order; the agent confirmed existence + dimensions + format in §3a.9.
+The **Graphic assets** section of the Store listing tab. Upload in dashboard order; the agent confirmed existence + dimensions + format in §3a.8.
 
 ### 8a. Store icon (required)
 
@@ -537,6 +536,7 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.3 | 2026-05-29 11:26:54 AM Central | Patch: deleted §3a.3 (no live debug-tier console calls in `extensions/chrome/*.js`). The rule was authored in the 2026-05-28 v1.0.0 restructure with no upstream source — not in `docs/privacy.html`, not in any LLD, not in `docs/safety.html`/`docs/threat-model.html`. Local browser-console output never leaves the user's machine, so the rule had no privacy-policy grounding. The remaining §3a items 4–11 renumber to 3–10; §3b.3 cross-reference (§3a.10 → §3a.9), §3b.5 cross-reference (§3a.11 → §3a.10), and §8 graphic-assets cross-reference (§3a.9 → §3a.8) update accordingly (Closes #691). |
 | 1.0.2 | 2026-05-29 12:18:55 AM Central | Patch: corrected timestamps that were UTC mislabeled as Central — the v1.0.0/v1.0.1 dates and the header were produced with `TZ='America/Chicago' date`, which Git Bash returns as UTC. Re-derived to true Central (CDT, UTC-5) with plain `date` (Closes #684). |
 | 1.0.1 | 2026-05-28 08:05:10 PM Central | Patch: replaced the `rm -f <glob>` artifact-clean steps in §4a (main + fallback) with a list → inspect → delete-by-name procedure (Closes #681); corrected the deployment-state line to "live; updated 2026-05-25" (CWS is genuinely at 1.1.2). |
 | 1.0.0 | 2026-05-28 06:49:42 PM Central | Restructured to the AZ#1362 runbook standard, modeled on [Clio 30002](https://github.com/martymcenroe/Clio/blob/main/docs/runbooks/30002-chrome-web-store-publish.md). Renamed `10905-runbook-extension-store-publish.md` → `10905-runbook-cws-publish.md` and scoped Chrome-only; Firefox/AMO split to new [10907](./10907-runbook-amo-publish.md). Added: semver+timestamp header, deployment-state block (Extension ID `pfkfdlcdbajamklbneflfbkmnceooijm`, install URL, publisher), §0 invoke phrases, §1 reading-path matrix, §3a/§3b split pre-flight, agent-owned `build_release.py` build, dashboard-order §7–§13, publisher-level §10 Account Settings (shared with Clio). Lifted the audit-corrected Long Description, Privacy Policy URL (`aletheia.study/privacy.html`), and all seven permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md` as inline canonical paste-blocks; flagged the "Open Source" vs PolyForm-Noncommercial wording. Closes #678 (with [10907](./10907-runbook-amo-publish.md)). |

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,7 +1,7 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.4
-> **Last updated:** 2026-05-29 12:57:37 AM Central
+> **Version:** 1.0.5
+> **Last updated:** 2026-05-29 11:26:54 AM Central
 > **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -82,7 +82,7 @@ Split by responsibility, items numbered for "§3a.N" / "§3b.N" reference.
 1. `extensions/firefox/manifest.json` has the new `version`, monotonic from the last published AMO version (see the deployment-state block for the current live and pending versions), and **matching `extensions/chrome/manifest.json`** (`build_release.py` enforces parity on `name`, `version`, `description`, `icons`).
 2. Firefox `permissions` is exactly `activeTab`, `tabs`, `scripting`, `contextMenus`, `storage` — **five, not seven**. Firefox does NOT request `identity` (it uses a tabs-based OAuth flow, not `chrome.identity`) or `notifications`. `host_permissions` is exactly `["https://api.aletheia.study/*"]`. Every permission has a §12 paste-block.
 3. `browser_specific_settings.gecko` is intact: `id` = `extension@aletheia.study`, `strict_min_version` = `140.0`, `gecko_android.strict_min_version` = `142.0`. The `data_collection_permissions` block declares `required: ["authenticationInfo", "websiteContent"]`, `optional: []` — this must match the §10 data-collection disclosure.
-4. No live debug-tier console calls in `extensions/firefox/*.js` (same banned/allowed rule as the Chrome runbook §3a.3). No hardcoded test URLs or dev flags; all API traffic goes to `https://api.aletheia.study/*`.
+4. No hardcoded test URLs or dev flags; all API traffic goes to `https://api.aletheia.study/*`.
 5. All tests pass: `poetry run pytest` + `npx playwright test`. `web-ext lint` is clean — `build_release.py` Step 3 runs it automatically and fails on errors (warnings are reported but non-blocking).
 6. Release notes file `docs/releases/firefox-vX.Y.Z.md` written before the §4 build — see §18.
 7. Listing screenshots exist at `screenshots/amo/amo-image-N-<slug>.png`. **Current state: none exist.** AMO accepts up to 10 screenshots with no strict dimension requirement, but use high-resolution images; produce them with [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) (it has an AMO output convention and `--width/--height` flags). The CWS 1280×800 images can be reused.
@@ -442,6 +442,7 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.5 | 2026-05-29 11:26:54 AM Central | Patch: removed the "no live debug-tier console calls" clause from §3a.4. The §3a.4 item now reads only the kept "no hardcoded test URLs or dev flags" portion. The console-call ban was authored in this runbook's 2026-05-28 v1.0.0 split with no upstream source — not in `docs/privacy.html`, not in any LLD, not in `docs/safety.html`/`docs/threat-model.html`. Local browser-console output never leaves the user's machine, so the rule had no privacy-policy grounding. Removing it eliminates the framing that allowed an agent in a later session to mis-label two existing `service-worker.js` `console.log` calls as "privacy-relevant" and present three "disposition" options to the operator. The cross-reference to the Chrome runbook's deleted §3a.3 went with the deleted clause (Closes #691). |
 | 1.0.4 | 2026-05-29 12:57:37 AM Central | Patch: removed a redundant lead-in in §10b — a dangling "Aletheia declares:" the v1.0.3 table rewrite left in front of the new sentence; merged the two into one. Found by the §0 `Audit 10907` self-audit (Closes #689). |
 | 1.0.3 | 2026-05-29 12:41:37 AM Central | Patch: applied the §0 `Audit 10907` findings. §17c no longer passes the API secret on the command line — `web-ext` reads `WEB_EXT_API_KEY`/`WEB_EXT_API_SECRET` from the environment, keeping the secret out of argv per §17b (Closes #686). §15a now refreshes the deployment-state Current published version, the update trigger includes "on each publish," and §1 Path B / §3a.1 reference the deployment-state block as the single source so the live/pending version is not duplicated three ways (Closes #687). Cosmetics: §10b shows the single `data_collection_permissions.required` array, §16 notes `Closes #N` belongs in the PR body, §4b clarifies the 10-root-file count. |
 | 1.0.2 | 2026-05-29 12:18:55 AM Central | Patch: corrected timestamps that were UTC mislabeled as Central — the v1.0.0/v1.0.1 dates and the header were produced with `TZ='America/Chicago' date`, which Git Bash returns as UTC. Re-derived to true Central (CDT, UTC-5) with plain `date` (Closes #684). |


### PR DESCRIPTION
## Summary

- Deletes the runbook rule banning live `console.log` / `console.debug` / `console.info` / `console.warn` in extension JavaScript.
- The rule was framed as a privacy-policy concern but had no grounding in `docs/privacy.html`, no upstream source in any LLD, and no entry in `docs/safety.html` or `docs/threat-model.html`. `console.log` writes to the user's own browser DevTools panel and never leaves their machine.
- `docs/runbooks/10907-runbook-amo-publish.md` v1.0.4 → v1.0.5: console clause removed from §3a.4 (test-URL clause kept).
- `docs/runbooks/10905-runbook-cws-publish.md` v1.0.2 → v1.0.3: §3a.3 deleted entirely; §3a items 4–11 renumbered to 3–10; three internal cross-references updated (§3b.3, §3b.5, §8).

## Test plan

- [x] `grep -in 'no live debug-tier console' docs/runbooks/*.md` — matches only inside the change-log rows that record this deletion; zero matches in body text.
- [x] `grep -n '§3a\.[0-9]\+' docs/runbooks/*.md` — every surviving §3a.N reference resolves to a real §3a item.
- [x] Pre-commit hooks: all required checks passed, including PRE-MERGE GATE (Reports Required).
- [x] No code changed → no executable test suites apply.

## Notes

`mergeable_state` will read `unstable` rather than `clean` because of the pre-existing failure in `tests/integration/test_user_data_deletion.py` on `main` (tracked at #680). Squash-merge still works under `unstable`, and `Cerberus-AZ` still auto-approves.

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)