### PR TITLE
fix(e2e): disable Firefox content sandbox for overlay tests (Closes #695)

### DIFF
--- a/docs/reports/695/implementation-report.md
+++ b/docs/reports/695/implementation-report.md
@@ -1,0 +1,58 @@
+# Implementation Report — Issue #695
+
+## Scope
+
+Resolve the local playwright Firefox `browserContext.newPage()` hang on the operator workstation that blocked runbook 10907 §3a.5 pre-flight ("All tests pass") for the Aletheia 1.1.2 AMO publish.
+
+## Root cause (per Gemini investigation)
+
+The Windows content sandbox was silently crashing Playwright's Firefox renderer during `newPage` initialization, producing a Juggler `remoteTab is null` IPC error. Playwright's `newPage()` promise never resolved because the renderer it was waiting on had already died on the sandbox boundary.
+
+This matches the symptom recorded in #695:
+- `firefox.launch()` succeeded in ~330 ms (parent process started fine)
+- `browser.newContext()` succeeded in ~75 ms (context handle created)
+- `context.newPage()` never returned (renderer died on sandbox; no signal back to Playwright)
+- CI green on the same commit (CI runs Firefox in a Linux container where the Windows sandbox path is not exercised)
+
+The handoff also confirms the local repro is now resolved with the change applied.
+
+## Change
+
+### `playwright.config.js`
+
+Injected `MOZ_DISABLE_CONTENT_SANDBOX: '1'` into the `firefox-overlay` project's `launchOptions.env`. The `...process.env` spread preserves the existing environment; only the one variable is added.
+
+```js
+launchOptions: {
+    args: [],
+    env: {
+        ...process.env,
+        MOZ_DISABLE_CONTENT_SANDBOX: '1'
+    }
+}
+```
+
+Scope notes:
+- The change is **per-project** (firefox-overlay only). Other Firefox projects in the config are unaffected.
+- The change is **build-tool scope**, not production scope. The sandbox setting applies to Playwright's bundled Firefox executable launched for tests; it has no effect on the user-facing extension or on Firefox installations users have.
+- The env var is read by Firefox itself (it's a Mozilla-supported runtime switch); no Playwright API was added or modified.
+
+### `docs/runbooks/10907-runbook-amo-publish.md`
+
+- §18 Troubleshooting: new row documenting the hang signature and pointing at the applied fix.
+- Header version bumped 1.0.5 → 1.0.6.
+- §20 Change log: new 1.0.6 entry.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `playwright.config.js` | +4 / −1 — `env` block added to firefox-overlay launchOptions |
+| `docs/runbooks/10907-runbook-amo-publish.md` | +2 / 0 in §18 + §20, header version line updated |
+
+No other files modified. No code changes outside the test config. No new dependencies.
+
+## Out of scope
+
+- Not investigated: the deeper question of why Windows content sandbox crashes Playwright's Firefox renderer specifically on this workstation. Disabling the sandbox is a workaround, not a root-cause fix. If the cause is workstation-specific (Defender, AV, driver), other workstations may not need the workaround; if it's a general Playwright + Firefox + Windows interaction, it's a fleet-level concern that would belong in a separate AssemblyZero runbook.
+- Not modified: production extension code, manifest, release-notes, or any user-facing surface. `dist/aletheia-firefox-v1.1.2.zip` content is unaffected.

--- a/docs/reports/695/test-report.md
+++ b/docs/reports/695/test-report.md
@@ -1,0 +1,81 @@
+# Test Report — Issue #695
+
+## Verification of the fix
+
+### Before the change
+
+Minimal isolation test (recorded in #695 body), workstation post-reboot, no other Firefox process running:
+
+```
+[0ms] launching firefox
+[332ms] launched
+[408ms] context created
+[59862ms] DISCONNECTED event fired
+FAIL: browserContext.newPage: Target page, context or browser has been closed
+```
+
+`context.newPage()` never returns; the outer Bash `timeout 60` kills the parent node process, which in turn causes the IPC pipe to close and Firefox to disconnect.
+
+### After the change
+
+Per the Gemini handoff at `data/claude-firefox-fix-handoff.md`:
+
+> "This bypassed the sandbox crash and resolved the hang (Suite now passes locally)."
+
+The applied workaround disables the Windows content sandbox for the Playwright-launched Firefox instance only. The firefox-overlay suite (`tests/e2e/firefox/overlay.spec.js`, 10 tests covering rendering, shadow-DOM isolation, interaction, accessibility, and XSS prevention) now runs to completion locally.
+
+## Regression scope
+
+Changes are limited to test-config and a runbook. Surfaces NOT touched:
+
+- Production extension code (`extensions/firefox/`, `extensions/chrome/`)
+- Manifest (`extensions/firefox/manifest.json`)
+- Release notes (`docs/releases/firefox-v1.1.2.md`)
+- Build pipeline (`tools/build_release.py`)
+- The `dist/aletheia-firefox-v1.1.2.zip` content
+- CI workflows (`.github/workflows/`)
+- Any other Playwright project's launchOptions
+
+The change only affects what happens when `npx playwright test --project=firefox-overlay` is executed. Other Playwright projects (chrome variants, other firefox projects if any) launch Firefox with their pre-existing launchOptions, no env override.
+
+## CI continuity
+
+CI on the parent commit (`06ca012`) was green per the issue #695 evidence. The change does not modify any CI workflow file; CI's `test-firefox` job will continue to run the same tests in the same Linux container environment, where the `MOZ_DISABLE_CONTENT_SANDBOX=1` env var is benign (the sandbox path that's failing on Windows is not exercised in the CI container layout).
+
+The local workaround does NOT alter CI behavior or pass/fail outcomes. CI remains the source of truth for "does the suite work in a clean environment"; the local workaround is the workstation parity fix.
+
+## Manual smoke test for the reviewer
+
+To verify locally after pulling:
+
+```bash
+cd /c/Users/mcwiz/Projects/Aletheia
+npx playwright test --project=firefox-overlay
+```
+
+Expected: all 10 firefox-overlay tests pass. The hang at `browserContext.newPage()` no longer occurs.
+
+Alternate minimal repro (matches the original #695 evidence, now with the env var):
+
+```bash
+cd /c/Users/mcwiz/Projects/Aletheia
+timeout 60 env MOZ_DISABLE_CONTENT_SANDBOX=1 node -e '
+const { firefox } = require("playwright");
+(async () => {
+  const t0 = Date.now();
+  const log = (s) => console.log("["+ (Date.now()-t0) +"ms] " + s);
+  log("launch"); const b = await firefox.launch();
+  log("launched"); const c = await b.newContext();
+  log("context"); const p = await c.newPage();
+  log("newPage OK"); await b.close(); log("closed");
+})().catch(e => { console.error("FAIL:", e.message); process.exit(1); });
+'
+```
+
+Expected: `newPage OK` printed within a few hundred ms after `context`, total wall-clock well under 5 seconds.
+
+## What this report does NOT claim
+
+- Does not claim the underlying Windows content sandbox crash is fixed. It's bypassed.
+- Does not claim the workaround is needed on every workstation. The sandbox crash may be specific to this machine's Defender / AV / driver configuration.
+- Does not provide regression coverage for the disabled-sandbox path. Playwright's bundled Firefox running with `MOZ_DISABLE_CONTENT_SANDBOX=1` may behave differently from production Firefox on user machines; for test-config that's acceptable because we're verifying overlay rendering, not sandboxed-process behavior.

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,7 +1,7 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.5
-> **Last updated:** 2026-05-29 11:26:54 AM Central
+> **Version:** 1.0.6
+> **Last updated:** 2026-05-30 12:15:15 AM Central
 > **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -421,6 +421,7 @@ npx web-ext sign \
 | AMO asks for source code | Validator flagged code as hard-to-read | Aletheia is not minified — answer No and link the repo; if a specific file is flagged, upload source + build steps (§13) |
 | Data-collection disclosure mismatch | AMO form drifted from the manifest | Make the AMO disclosure match `data_collection_permissions` (auth info + website content only) (§10b) |
 | `web-ext lint` errors on build | A manifest or file issue | Read the lint output; `build_release.py` fails the build on errors |
+| `npx playwright test` hangs on Firefox | Windows sandbox crashes the renderer (Juggler `remoteTab is null`) | Workaround applied in `playwright.config.js` (`MOZ_DISABLE_CONTENT_SANDBOX=1`). If running standalone reproduction scripts, export that env var first. |
 | Gecko ID mismatch / "add-on ID changed" | `browser_specific_settings.gecko.id` edited | Restore `extension@aletheia.study` — changing it creates a *new* add-on, orphaning the listing |
 | `strict_min_version` rejected | Set below a feature's availability | Keep `140.0` desktop / `142.0` Android unless a feature requires higher |
 | Listing still shows "cannot see your browsing history" | Pre-audit text | Overwrite §7d Description; verify in private browsing (per `docs/10920`) |
@@ -442,6 +443,7 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.6 | 2026-05-30 12:15:15 AM Central | Patch: documented the Windows sandbox Playwright hang in §18 Troubleshooting. The `MOZ_DISABLE_CONTENT_SANDBOX=1` workaround is now permanently applied in `playwright.config.js`. |
 | 1.0.5 | 2026-05-29 11:26:54 AM Central | Patch: removed the "no live debug-tier console calls" clause from §3a.4. The §3a.4 item now reads only the kept "no hardcoded test URLs or dev flags" portion. The console-call ban was authored in this runbook's 2026-05-28 v1.0.0 split with no upstream source — not in `docs/privacy.html`, not in any LLD, not in `docs/safety.html`/`docs/threat-model.html`. Local browser-console output never leaves the user's machine, so the rule had no privacy-policy grounding. Removing it eliminates the framing that allowed an agent in a later session to mis-label two existing `service-worker.js` `console.log` calls as "privacy-relevant" and present three "disposition" options to the operator. The cross-reference to the Chrome runbook's deleted §3a.3 went with the deleted clause (Closes #691). |
 | 1.0.4 | 2026-05-29 12:57:37 AM Central | Patch: removed a redundant lead-in in §10b — a dangling "Aletheia declares:" the v1.0.3 table rewrite left in front of the new sentence; merged the two into one. Found by the §0 `Audit 10907` self-audit (Closes #689). |
 | 1.0.3 | 2026-05-29 12:41:37 AM Central | Patch: applied the §0 `Audit 10907` findings. §17c no longer passes the API secret on the command line — `web-ext` reads `WEB_EXT_API_KEY`/`WEB_EXT_API_SECRET` from the environment, keeping the secret out of argv per §17b (Closes #686). §15a now refreshes the deployment-state Current published version, the update trigger includes "on each publish," and §1 Path B / §3a.1 reference the deployment-state block as the single source so the live/pending version is not duplicated three ways (Closes #687). Cosmetics: §10b shows the single `data_collection_permissions.required` array, §16 notes `Closes #N` belongs in the PR body, §4b clarifies the 10-root-file count. |

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -115,7 +115,11 @@ module.exports = defineConfig({
                 headless: true,
                 // Remove Chrome extension args for Firefox
                 launchOptions: {
-                    args: []
+                    args: [],
+                    env: {
+                        ...process.env,
+                        MOZ_DISABLE_CONTENT_SANDBOX: '1'
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Disables the Windows content sandbox for Playwright's bundled Firefox in the `firefox-overlay` project only, resolving the local `browserContext.newPage()` hang documented in #695.
- Updates runbook `docs/runbooks/10907-runbook-amo-publish.md`: new §18 troubleshooting row, header version bump (1.0.5 → 1.0.6), §20 changelog entry.
- Adds implementation + test reports under `docs/reports/695/` per the project pre-merge gate.

## Root cause

Per Gemini investigation captured in `data/claude-firefox-fix-handoff.md`: the Windows content sandbox was silently crashing Playwright's Firefox renderer (Juggler `remoteTab is null` IPC error). The renderer died on the sandbox boundary; Playwright's `newPage()` promise never resolved because the renderer it was waiting on was already gone. CI's Linux container does not exercise the failing Windows sandbox path, which is why CI on the same commit (`06ca012`) was green.

## Scope

Test-config only. Production extension code, manifest, release notes, and `dist/aletheia-firefox-v1.1.2.zip` content are all untouched. The env var is set on the `firefox-overlay` project's `launchOptions` only; other Playwright projects are unaffected. The change is a workaround, not a root-cause fix — the underlying sandbox crash remains uninvestigated (out of scope for this issue).

## Test plan

- Pull the branch, then `npx playwright test --project=firefox-overlay`
- Expected: all 10 firefox-overlay tests pass; no hang at `newPage`
- Minimal alternate repro and verification steps are documented in `docs/reports/695/test-report.md`

Closes #695