### PR TITLE
chore: drop edge Playwright project and supersede LLD 10263 (Closes #705)

### DIFF
--- a/docs/lld/done/10263-edge-e2e-test-matrix.md
+++ b/docs/lld/done/10263-edge-e2e-test-matrix.md
@@ -1,5 +1,7 @@
 # 10263 - Test: Add Edge/Chromium Browser E2E Test Matrix
 
+> **SUPERSEDED 2026-05-30 by Aletheia #697 and follow-up #705.** The Edge E2E test matrix this LLD designed is no longer maintained. Aletheia is not distributed through Edge Add-ons and the FAQ (`Aletheia.wiki/FAQ.md:20`) explicitly disclaims Edge support: *"Edge and other Chromium-based browsers may work but are not officially supported."* The CI job that ran this matrix (`.github/workflows/e2e-edge.yml`) was deleted in PR #698; the `edge` Playwright project block was removed in the PR closing #705. This file is preserved for historical reference only — do not treat its design as live.
+
 ## 1. Context & Goal
 * **Issue:** #263
 * **Objective:** Add Microsoft Edge to the Playwright E2E test matrix to verify Chrome extension compatibility.

--- a/docs/reports/705/implementation-report.md
+++ b/docs/reports/705/implementation-report.md
@@ -1,0 +1,43 @@
+# Implementation Report — Issue #705
+
+## Scope
+
+Close the loop on #697 by removing the residual source-tree references to the now-deleted Edge E2E test path. #697 was auto-closed when PR #698 deleted `.github/workflows/e2e-edge.yml`, but the companion source items called for in #697's body were deferred to this issue because the workflow YAML half required GitHub web UI (PAT scope restriction) while these items go through the standard PR procedure.
+
+## Changes
+
+### `playwright.config.js`
+
+Removed the `edge` project block (formerly lines 97–108):
+
+```js
+{
+    // Issue #263: Edge E2E test matrix
+    // Visual baselines: Edge shares Chromium rendering engine;
+    // separate baselines not needed (ref #458)
+    name: 'edge',
+    use: {
+        channel: 'msedge',
+        // Extensions require headed mode
+        headless: false
+        // Inherits launchOptions from global use block (extension loading)
+    }
+},
+```
+
+With `.github/workflows/e2e-edge.yml` deleted in #698, this block was dead config — no CI procedure invoked it. The `projects` array now contains `chromium` and `firefox-overlay` only.
+
+### `docs/lld/done/10263-edge-e2e-test-matrix.md`
+
+Added a SUPERSEDED notice immediately under the title, citing #697 and #705, naming the FAQ that disclaims Edge support, and pointing at the two PRs that effected the removal (#698 for the YAML, this PR for the residual). The body of the LLD is preserved for historical reference. No other lines changed.
+
+## Verified absent
+
+- `tests/e2e/edge/` — directory does not exist; nothing to delete.
+- Saved-memory entries about `test-edge` / accepted-flaky — `grep` of `C:\Users\mcwiz\.claude\projects\C--Users-mcwiz-Projects-Aletheia\memory\` returns no matches. The "accepted-flaky" framing lived only in session handoffs, not in long-term memory. No memory file edits required.
+
+## Out of scope
+
+- The other half of the `mergeable_state == unstable` problem (`integration-tests` failure tracked as #680) is unchanged by this PR.
+- The FAQ wording stands as-is; this PR does not edit `Aletheia.wiki/FAQ.md`.
+- No CI procedure files (`.github/workflows/*.yml`) are touched by this PR. The companion YAML deletion was #698.

--- a/docs/reports/705/test-report.md
+++ b/docs/reports/705/test-report.md
@@ -1,0 +1,48 @@
+# Test Report — Issue #705
+
+## What this PR changes
+
+Two source files, neither executable code:
+
+- `playwright.config.js` — removes a configuration block (the `edge` project). Other Playwright projects (`chromium`, `firefox-overlay`) are unaffected.
+- `docs/lld/done/10263-edge-e2e-test-matrix.md` — adds a documentation notice. No executable change.
+
+## Verification
+
+### Static — `playwright.config.js` parses
+
+```bash
+cd /c/Users/mcwiz/Projects/Aletheia
+node -e "require('./playwright.config.js'); console.log('parsed OK')"
+```
+
+Expected: `parsed OK`. Pre-commit ESLint will also run against the file; any syntax regression surfaces there.
+
+### Dynamic — `chromium` and `firefox-overlay` projects still discoverable
+
+```bash
+cd /c/Users/mcwiz/Projects/Aletheia
+npx playwright test --list --project=chromium | head -3
+npx playwright test --list --project=firefox-overlay | head -3
+```
+
+Expected: both list tests. Negative check:
+
+```bash
+npx playwright test --list --project=edge 2>&1 | grep -i "no project"
+```
+
+Expected: Playwright reports the `edge` project is not in the config (because it no longer is).
+
+### No CI procedure changes
+
+`.github/workflows/*.yml` are not touched by this PR. The companion deletion of `e2e-edge.yml` already landed in #698 and is at HEAD of `main` (commit `cdfb828`). This PR neither adds nor modifies any file under `.github/workflows/`.
+
+## Regression scope
+
+The `edge` Playwright project was the only consumer of `tests/e2e/edge/` (which does not exist) and the only target of the deleted CI procedure (gone since #698). No other config block, test spec, doc, or CI procedure references the `edge` project. Removing it cannot regress code that does not call into it.
+
+## What this report does NOT claim
+
+- Does not claim the LLD's design is "wrong" — it was correct for its 2026-01-10 scope. The supersede notice records that the decision was reversed, not that the original design was defective.
+- Does not assert anything about future browser support. If Aletheia ever ships to Edge Add-ons, the matrix can be rebuilt; this PR just clears the dead-config state in the meantime.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -95,18 +95,6 @@ module.exports = defineConfig({
             }
         },
         {
-            // Issue #263: Edge E2E test matrix
-            // Visual baselines: Edge shares Chromium rendering engine;
-            // separate baselines not needed (ref #458)
-            name: 'edge',
-            use: {
-                channel: 'msedge',
-                // Extensions require headed mode
-                headless: false
-                // Inherits launchOptions from global use block (extension loading)
-            }
-        },
-        {
             name: 'firefox-overlay',
             testMatch: /firefox\/.*\.spec\.js/,
             use: {


### PR DESCRIPTION
## Summary

Closes the loop on #697 by removing the residual source-tree references to the now-deleted Edge E2E test path.

- `playwright.config.js` — drops the `edge` project block (was lines 97–108). Dead config since #698 deleted the workflow YAML that drove it; `tests/e2e/edge/` is also absent, so even running Playwright locally produced no tests under this project. The `projects` array now contains `chromium` and `firefox-overlay` only.
- `docs/lld/done/10263-edge-e2e-test-matrix.md` — adds a SUPERSEDED notice citing #697, #705, the FAQ (`Aletheia.wiki/FAQ.md:20`) that disclaims Edge support, and the two PRs (#698 + this) that effected the removal. The body of the LLD is preserved for historical reference.

## Why split from #698

`llm-restricting` (the day-to-day fine-grained PAT) is intentionally blocked from `.github/workflows/*` write — that's the architecture-protects-itself property the operator named in conversation. The workflow YAML had to go through the GitHub web UI's Delete-file button (browser session auth, not PAT auth). These two files are normal source files that the PAT can edit, so they go through the standard PR procedure here.

## Test plan

- [ ] Pre-commit ESLint passes against `playwright.config.js` (verified at commit time)
- [ ] `node -e "require('./playwright.config.js'); console.log('parsed OK')"` returns `parsed OK`
- [ ] `npx playwright test --list --project=chromium` and `--project=firefox-overlay` both list tests
- [ ] `npx playwright test --list --project=edge` errors with "project not found" (because it no longer is)
- [ ] No `.github/workflows/*.yml` files touched by this PR

Closes #705