### PR TITLE
docs(runbook): clarify 10907 §3a.7 screenshots + §7c byte/char count (Closes #713)

### DIFF
--- a/docs/reports/713/implementation-report.md
+++ b/docs/reports/713/implementation-report.md
@@ -1,0 +1,26 @@
+# Implementation Report — Issue #713
+
+## Scope
+
+Two precision nits surfaced by today's `Audit 10907` self-audit. Both are pure operational clarity in `docs/runbooks/10907-runbook-amo-publish.md`; no semantic change to the publishing procedure.
+
+## Changes
+
+### `docs/runbooks/10907-runbook-amo-publish.md`
+
+- **Header:** version bump `1.0.6` → `1.0.7`, last-updated stamp refreshed.
+- **§3a.7:** *"Current state: none exist"* → *"Current state: directory does not exist; it will be created on first AMO screenshot upload."* The directory itself (`screenshots/amo/`) does not exist; the previous wording read as "directory exists, no files" which would leave an operator wondering whether `ls screenshots/amo/` returning "no such file or directory" was a problem.
+- **§7c:** *"(129 chars)"* → *"(129 characters / 131 bytes UTF-8 — the em-dash is 3 bytes)."* AMO's 250-char limit is by visible character, which is what 129 measures. A naive reproducibility check with `wc -c` returns 131 because the em-dash in the copy is 3 UTF-8 bytes — operator should not have to think about why.
+- **§20 Change log:** new v1.0.7 entry, one line, describing the two text changes.
+
+## What this does NOT change
+
+- §3a.5 — gate text. Both sub-conditions (`poetry run pytest` and `npx playwright test`) are now genuinely satisfiable on `main` HEAD as of today (after #680/#712 and #695/#696), but the gate's *text* always made the right ask. Per operator preference, the runbook is for getting through the work — adding a "no-text-change archival" change-log entry to record when the underlying state became aligned would be cognitive overhead for the reader at scan time without operational payoff. Deliberately omitted.
+- Deployment-state block — `Current published version: 1.1.1` is still accurate; 1.1.2 is still the pending upload.
+- All paste-blocks (§7–§13) — unchanged.
+- All canonical phrases (§0), reading paths (§1), build commands (§4), upload procedures (§5/§6), post-publish flow (§15), version-bump procedure (§16), web-ext API path (§17), troubleshooting (§18), and related documents (§19) — unchanged.
+
+## Out of scope
+
+- §3a.7's "create the directory on first upload" wording is precise but does not document HOW to create it. The runbook elsewhere implies `mkdir -p screenshots/amo/` would be the operator's step; this PR doesn't add that detail because the runbook is not a screenshot-creation guide ([10906](../runbooks/10906-runbook-cws-image-pad.md) is).
+- §7c could grow into a generic "Unicode + byte counts" note, but every paste-block having a byte-count footnote is operator-hostile. The em-dash in §7c is the only multi-byte character in any paste-block; surfacing it once at the location of confusion is sufficient.

--- a/docs/reports/713/test-report.md
+++ b/docs/reports/713/test-report.md
@@ -1,0 +1,49 @@
+# Test Report — Issue #713
+
+## What this PR changes
+
+Pure documentation. Three small text changes in one file (`docs/runbooks/10907-runbook-amo-publish.md`): header version line, §3a.7 wording, §7c parenthetical. No code, no config, no tests.
+
+## Verification
+
+### Pre-commit hooks
+
+The repo's pre-commit gate runs on every commit and includes (per memory): trailing whitespace, end-of-file, ESLint (JS), ruff/mypy (Python), private-key detection, hardcoded-secret detection, project-policy compliance, and the pre-merge-gate "reports required" check. For a docs-only change, the relevant gates are the project-policy and pre-merge-gate checks (the rest skip when there are no JS/Python files in the diff).
+
+### Manual smoke
+
+The three text changes are self-contained:
+
+```bash
+cd /c/Users/mcwiz/Projects/Aletheia
+grep -E "^> \*\*Version:" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: > **Version:** 1.0.7
+
+grep -F "directory does not exist; it will be created on first AMO screenshot upload" \
+  docs/runbooks/10907-runbook-amo-publish.md
+# Expected: one match in §3a.7
+
+grep -F "129 characters / 131 bytes UTF-8 — the em-dash is 3 bytes" \
+  docs/runbooks/10907-runbook-amo-publish.md
+# Expected: one match in §7c
+
+grep "^| 1.0.7" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: the new change-log entry
+```
+
+### Cross-reference integrity
+
+The audit verified that all of §19 Related documents resolve to real files on `main` HEAD: `10905-runbook-cws-publish.md`, `10906-runbook-cws-image-pad.md`, `docs/releases/`, `docs/lld/done/10051-store-compliance.md`, `docs/privacy.html`, `docs/legal/eula.html`, `extensions/firefox/manifest.json`. This PR does not change any of those references; no link rot introduced.
+
+### `Audit 10907` re-run
+
+Running `Audit 10907` again after this PR merges should report v1.0.7 from `main` HEAD with the two findings now closed. The audit's other verified-accurate items (manifest version parity, permission set, gecko settings, release-notes presence, companion-doc existence) are unchanged by this PR and continue to hold.
+
+## Regression scope
+
+None possible. Documentation-only patch to a runbook that is read, not executed. The runbook's canonical phrases (`Run amo pre-flight`, `Run amo build`, etc.) trigger agent actions that read other files; those files are unchanged.
+
+## What this report does NOT claim
+
+- Does not assert that the `screenshots/amo/` directory will exist at any particular future date. The wording change predicts an event ("created on first upload") without committing to a timeline.
+- Does not assert that the byte/character count of the §7c summary will remain at 129 / 131 if the copy is ever edited. The annotation describes the current copy.

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,7 +1,7 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.6
-> **Last updated:** 2026-05-30 12:15:15 AM Central
+> **Version:** 1.0.7
+> **Last updated:** 2026-05-30 9:15:03 AM Central
 > **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -85,7 +85,7 @@ Split by responsibility, items numbered for "§3a.N" / "§3b.N" reference.
 4. No hardcoded test URLs or dev flags; all API traffic goes to `https://api.aletheia.study/*`.
 5. All tests pass: `poetry run pytest` + `npx playwright test`. `web-ext lint` is clean — `build_release.py` Step 3 runs it automatically and fails on errors (warnings are reported but non-blocking).
 6. Release notes file `docs/releases/firefox-vX.Y.Z.md` written before the §4 build — see §18.
-7. Listing screenshots exist at `screenshots/amo/amo-image-N-<slug>.png`. **Current state: none exist.** AMO accepts up to 10 screenshots with no strict dimension requirement, but use high-resolution images; produce them with [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) (it has an AMO output convention and `--width/--height` flags). The CWS 1280×800 images can be reused.
+7. Listing screenshots exist at `screenshots/amo/amo-image-N-<slug>.png`. **Current state: directory does not exist; it will be created on first AMO screenshot upload.** AMO accepts up to 10 screenshots with no strict dimension requirement, but use high-resolution images; produce them with [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) (it has an AMO output convention and `--width/--height` flags). The CWS 1280×800 images can be reused.
 8. Agent reports the current `main` HEAD SHA and this runbook's `> **Version:**` line.
 
 ### 3b. Operator does
@@ -185,7 +185,7 @@ Baked into the listing URL (`…/addon/aletheia-ai/`). Changing it breaks every 
 
 ### 7c. Summary
 
-*AMO summary limit: 250 characters. Same copy as the CWS short description (129 chars).*
+*AMO summary limit: 250 characters. Same copy as the CWS short description (129 characters / 131 bytes UTF-8 — the em-dash is 3 bytes).*
 
 ```
 Instant AI analysis for selected text. Understand context, detect nuance, and verify facts—while maintaining strict data privacy.
@@ -443,6 +443,7 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.7 | 2026-05-30 9:15:03 AM Central | Patch from `Audit 10907`: §3a.7 now states the `screenshots/amo/` directory does not exist (was "none exist" which read as "directory exists, no files"). §7c notes the byte count alongside the visible character count (129 / 131) so a naive `wc -c` reproducibility check does not surface a false discrepancy from the em-dash being 3 UTF-8 bytes (Closes #713). |
 | 1.0.6 | 2026-05-30 12:15:15 AM Central | Patch: documented the Windows sandbox Playwright hang in §18 Troubleshooting. The `MOZ_DISABLE_CONTENT_SANDBOX=1` workaround is now permanently applied in `playwright.config.js`. |
 | 1.0.5 | 2026-05-29 11:26:54 AM Central | Patch: removed the "no live debug-tier console calls" clause from §3a.4. The §3a.4 item now reads only the kept "no hardcoded test URLs or dev flags" portion. The console-call ban was authored in this runbook's 2026-05-28 v1.0.0 split with no upstream source — not in `docs/privacy.html`, not in any LLD, not in `docs/safety.html`/`docs/threat-model.html`. Local browser-console output never leaves the user's machine, so the rule had no privacy-policy grounding. Removing it eliminates the framing that allowed an agent in a later session to mis-label two existing `service-worker.js` `console.log` calls as "privacy-relevant" and present three "disposition" options to the operator. The cross-reference to the Chrome runbook's deleted §3a.3 went with the deleted clause (Closes #691). |
 | 1.0.4 | 2026-05-29 12:57:37 AM Central | Patch: removed a redundant lead-in in §10b — a dangling "Aletheia declares:" the v1.0.3 table rewrite left in front of the new sentence; merged the two into one. Found by the §0 `Audit 10907` self-audit (Closes #689). |


### PR DESCRIPTION
## Summary

Two precision nits surfaced by today's `Audit 10907` self-audit. Pure operational clarity in `docs/runbooks/10907-runbook-amo-publish.md` — no semantic change to the publishing procedure.

- **§3a.7:** *"Current state: none exist"* → *"Current state: directory does not exist; it will be created on first AMO screenshot upload."* The directory itself does not exist. Prior wording would have surprised an operator who runs `ls screenshots/amo/`.
- **§7c:** *"(129 chars)"* → *"(129 characters / 131 bytes UTF-8 — the em-dash is 3 bytes)."* AMO's 250-character limit is by visible character. A naive `wc -c` returns 131. Pre-empts the brief reproducibility confusion.
- Header version 1.0.6 → 1.0.7. New change-log entry.

## Deliberately omitted

The same audit also noted that §3a.5's two gate conditions became operationally satisfiable today (after #680/#712 fixed the integration tests and #695/#696 fixed the playwright hang). That's a fact about the repo state, not the runbook text. Adding a "no-text-change archival" entry to the change log would be operator-hostile cognitive overhead at scan time. The runbook is for getting through the work; it is not a record of work done.

## Test plan

```bash
grep -E "^> \*\*Version:" docs/runbooks/10907-runbook-amo-publish.md
# Expected: > **Version:** 1.0.7

grep -F "directory does not exist" docs/runbooks/10907-runbook-amo-publish.md
grep -F "131 bytes UTF-8" docs/runbooks/10907-runbook-amo-publish.md
grep "^| 1.0.7" docs/runbooks/10907-runbook-amo-publish.md
```

Closes #713