### PR TITLE
docs(runbook): drop pre-flight framing from 10907 (Closes #719)

### DIFF
--- a/docs/reports/719/implementation-report.md
+++ b/docs/reports/719/implementation-report.md
@@ -1,0 +1,37 @@
+# Implementation Report — Issue #719
+
+## Scope
+
+Drop "pre-flight" framing from `docs/runbooks/10907-runbook-amo-publish.md`. Operator feedback: a runbook is a checklist; the aviation metaphor sets the wrong cognitive expectation. §3 reads as "quick visual check" when it's actually 13 substantive items including a 14-second pytest run and a 1.7-minute playwright run.
+
+## Changes
+
+Four text-edits in the runbook plus a change-log entry:
+
+| Location | Before | After |
+|---|---|---|
+| Header | `Version: 1.0.8` / last-updated | `Version: 1.0.9` / last-updated |
+| §3 heading | `## 3. Pre-flight checklist` | `## 3. Verification (before §4 build)` |
+| §0 phrases table | `Run §3a pre-flight + §4 build … \| Run amo pre-flight` | `Run §3a verification + §4 build … \| Run amo prep` |
+| §0 phrases table | `Run §4 build + verify (pre-flight already passed)` | `Run §4 build + verify (§3 already passed)` |
+| "How to verify" line | `Run amo pre-flight` | `Run amo prep` |
+| §20 Change log | — | New v1.0.9 entry |
+
+## Content stays the same
+
+All 13 §3 items are unchanged. Every paste-block, build command, upload procedure, post-publish step, troubleshooting row stays exactly as worded. This PR renames; it does not edit any operational instruction.
+
+## Verification
+
+```bash
+grep -i "pre-flight\|preflight" docs/runbooks/10907-runbook-amo-publish.md \
+  | grep -v "^| 1\."
+# Expected: empty (the only remaining 'pre-flight' string is in the v1.0.9 change-log entry recording the rename)
+```
+
+Confirmed locally: zero matches outside the change log.
+
+## Out of scope
+
+- Chrome runbook 10905 still uses `Run cws pre-flight`. That's a separate runbook with its own choices; not bundled here.
+- AZ#1362 runbook standard (header reference) — if/when shipped, may have opinions on phase naming. Not waiting for it; this is a local fix to local friction.

--- a/docs/reports/719/test-report.md
+++ b/docs/reports/719/test-report.md
@@ -1,0 +1,29 @@
+# Test Report — Issue #719
+
+## What this PR changes
+
+Pure documentation. Five small string substitutions in one runbook file plus a change-log entry. No code, no config, no tests.
+
+## Verification
+
+```bash
+grep -i "pre-flight\|preflight" docs/runbooks/10907-runbook-amo-publish.md \
+  | grep -v "^| 1\."
+# Expected: empty
+```
+
+Confirmed locally.
+
+```bash
+grep -E "^> \*\*Version:" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: > **Version:** 1.0.9
+```
+
+## Regression scope
+
+None possible. Documentation rename to a runbook that is read, not executed.
+
+## What this report does NOT claim
+
+- Does not assert that the new phrase `Run amo prep` is "better" in any objective sense. It is shorter and lacks the aviation pretense.
+- Does not change the Chrome runbook 10905, which still uses its own `Run cws pre-flight` phrase. Out of scope.

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,7 +1,7 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.8
-> **Last updated:** 2026-05-30 9:50:00 AM Central
+> **Version:** 1.0.9
+> **Last updated:** 2026-05-30 10:05:57 AM Central
 > **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
 > **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
 > **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
@@ -36,7 +36,7 @@ Update this table on rebrand, ID change, slug change, **and on each publish** �
 This runbook lives at `docs/runbooks/10907-runbook-amo-publish.md` in [martymcenroe/Aletheia](https://github.com/martymcenroe/Aletheia). The **Version** and **Last updated** lines identify your revision.
 
 1. Note the version on your copy.
-2. Say `Run amo pre-flight` or `Audit 10907` (§0) — the agent reports the current `main` HEAD runbook version line.
+2. Say `Run amo prep` or `Audit 10907` (§0) — the agent reports the current `main` HEAD runbook version line.
 3. If your copy differs, re-print before continuing.
 
 ## 0. Invoke the agent (canonical phrases)
@@ -46,9 +46,9 @@ The operator types one of these to trigger the matching action. The agent recogn
 | To make the agent... | Operator says |
 |---|---|
 | Audit this runbook for gaps / drift | `Audit 10907` |
-| Run §3a pre-flight + §4 build, hand back the Firefox ZIP path | `Run amo pre-flight` |
+| Run §3a verification + §4 build, hand back the Firefox ZIP path | `Run amo prep` |
 | Run §3a only (no build) and report findings | `Run amo §3a` |
-| Run §4 build + verify (pre-flight already passed) | `Run amo build` |
+| Run §4 build + verify (§3 already passed) | `Run amo build` |
 | Sign + upload via the `web-ext` API path (§17, optional) | `Run amo sign` |
 | Comment the submission timestamp on the release issue (current Central time, or `at YYYY-MM-DD HH:MM`) | `Submitted amo` |
 | After AMO approves: run §15a — tag the commit, update release notes, comment + close the release issue | `Run amo post-publish` (listing URL defaults to the deployment-state block) |
@@ -73,7 +73,7 @@ The agent's reply includes (a) a one-line confirmation, (b) findings/follow-ups,
 
 The AMO dashboard access pattern is likely the same Chrome profile used for CWS (memory `user-cws-dashboard-access`) but is **not confirmed** — check that profile's bookmarks first.
 
-## 3. Pre-flight checklist
+## 3. Verification (before §4 build)
 
 Split by responsibility, items numbered for "§3a.N" / "§3b.N" reference.
 
@@ -443,6 +443,7 @@ Semver per AZ#1362 principle 20.
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.0.9 | 2026-05-30 10:05:57 AM Central | Patch: dropped "pre-flight" framing throughout. §3 retitled "Verification (before §4 build)" — the aviation metaphor set the wrong expectation (read as "quick visual check" when it's actually 13 substantive items including a 2-minute test run). §0 phrase `Run amo pre-flight` → `Run amo prep`; descriptions updated to "§3a verification + §4 build" and "(§3 already passed)". A runbook is a checklist; the runbook now names §3 as what it is (Closes #719). |
 | 1.0.8 | 2026-05-30 9:50:00 AM Central | Patch from `Audit 10907`: removed three references to `docs/10920-cws-listing-corrections-2026-05-27.md` (at §3b.4, §10a, §18). Canonical AMO listing text lives in §7d / §10a / §12; the references carried no information the runbook lacks and were scan-overhead. Where 10920 contributed operator-relevant guidance (the "live listing may still carry pre-audit wording" claim in §3b.4), that guidance is now inline (Closes #717). |
 | 1.0.7 | 2026-05-30 9:15:03 AM Central | Patch from `Audit 10907`: §3a.7 now states the `screenshots/amo/` directory does not exist (was "none exist" which read as "directory exists, no files"). §7c notes the byte count alongside the visible character count (129 / 131) so a naive `wc -c` reproducibility check does not surface a false discrepancy from the em-dash being 3 UTF-8 bytes (Closes #713). |
 | 1.0.6 | 2026-05-30 12:15:15 AM Central | Patch: documented the Windows sandbox Playwright hang in §18 Troubleshooting. The `MOZ_DISABLE_CONTENT_SANDBOX=1` workaround is now permanently applied in `playwright.config.js`. |


### PR DESCRIPTION
## Summary

A runbook is a checklist. §3 was named "Pre-flight checklist" — the aviation metaphor set the wrong expectation: read as "quick visual check" when it's actually 13 substantive items including a 14-second pytest run and a 1.7-minute playwright run.

Five renames in `docs/runbooks/10907-runbook-amo-publish.md`:

- §3 heading: `Pre-flight checklist` → `Verification (before §4 build)`
- §0 phrase: `Run amo pre-flight` → `Run amo prep`
- §0 description: `Run §3a pre-flight + §4 build` → `Run §3a verification + §4 build`
- §0 description: `(pre-flight already passed)` → `(§3 already passed)`
- "How to verify" line: same phrase rename

Header 1.0.8 → 1.0.9. Change-log entry retains one "pre-flight" string as honest record of the rename.

All 13 §3 items unchanged. Every paste-block, build command, upload procedure, post-publish step, troubleshooting row stays exactly as worded.

## Test plan

```bash
grep -i "pre-flight\|preflight" docs/runbooks/10907-runbook-amo-publish.md | grep -v "^| 1\."
# Expected: empty
```

Closes #719