### PR TITLE
docs(runbook): restructure 10907 as flat operator checklist v2.0.0 (Closes #726)

### DIFF
--- a/docs/reports/726/implementation-report.md
+++ b/docs/reports/726/implementation-report.md
@@ -1,0 +1,123 @@
+# Implementation Report — Issue #726
+
+## Scope
+
+Major restructure of `docs/runbooks/10907-runbook-amo-publish.md` per the operator's end-to-end test audit. The prior runbook was a checklist wrapped in maintainer commentary, redundant steps, and nebulous directions. This version is a flat numbered procedure with explicit URLs, clicks, what-to-look-for, and what-to-do-if-it-fails on every step.
+
+Major version bump: **1.0.10 → 2.0.0** because section numbers move. Listing field content (the paste-blocks) is unchanged in text; only its position and numbering shifted.
+
+## Structural changes
+
+**Old structure (1.0.x):**
+
+- Front matter with 4 lines of maintainer references (Tracking issue, Versioning, Standard, Chrome cross-reference)
+- Deployment-state table with a lead-in and post-commentary
+- "Throughout this runbook" definitions
+- "How to verify you have the latest copy"
+- Agent invocation phrases (reference)
+- §1 Reading paths (Path A/B/C table)
+- §2 Account check
+- §3 Verification (split into §3a agent, §3b operator with 5 items each)
+- §4 Build (split into §4a build, §4b verify)
+- §5 First submission upload (historical, but wedged mid-procedure)
+- §6 Subsequent update upload
+- §7–§13 listing fields
+- §14 Submit
+- §15 Post-publish (split into §15a agent, §15b operator, §15c smoke-test-fail)
+- §16 Version bump
+- §17 Web-ext API path
+- §18 Troubleshooting
+- §19 Related docs
+- §20 Change log
+
+**New structure (2.0.0):**
+
+- Front matter: 3 lines (Version, Last updated, Applies to)
+- Aletheia AMO deployment state (table only, no commentary)
+- Agent invocation phrases (reference)
+- **§1–§10 numbered procedure** (flat, for the update path):
+  1. Sign in to AMO Developer Hub
+  2. Confirm the new version is not already uploaded
+  3. Agent: verify build prerequisites
+  4. Agent: build and verify the ZIP
+  5. Diff the live listing against §11 listing content
+  6. Upload the new ZIP
+  7. Overwrite drifted listing fields (only if §5 found drift)
+  8. Submit for review
+  9. AMO approves — operator action
+  10. Agent: post-publish
+- §11 Listing field content (paste-ready) + smoke-test
+- §12 First submission (Path A — historical, brief)
+- §13 Version bump procedure
+- §14 Web-ext API signing (optional)
+- §15 Troubleshooting
+- §16 Related documents
+- §17 Change log
+
+## Specific audit findings addressed
+
+Each finding from the issue body:
+
+| Finding | Resolution |
+|---|---|
+| §3b.1 redundant with §2 | §2 happens once in the new §1 (sign in). No restated "account check passes" item. |
+| §1 Path B reads §13 twice | Procedure is linear §1–§10; no path table needed for the normal case. |
+| §3a.5 includes `web-ext lint` (runs DURING §4 build, not before) | §3 verify covers pytest + playwright only. Lint stays in §4 build where it actually runs. |
+| §3a.8 is output, not verification | Dropped. The agent reports as part of its normal output, not as a verification item. |
+| §3a.7 + §8b duplicate screenshot prep | §11f makes screenshots a no-op for updates by default. No cross-references needed. |
+| §3b.3 references nonexistent screenshot set on updates | Same — folded into §11f conditional. |
+| §3b.4 "review for changes" is nebulous | §5 is now a per-field comparison table: which live field, compare to which §11 subsection, what to look for. |
+| §3b.5 "printed-copy version matches" assumes paper | Dropped. Use `Audit 10907` if you want to verify the runbook version. |
+| §2 line 74 hedge about Chrome profile | Dropped. §1 has the concrete signin procedure. |
+| §3a.6 "see §18" misleading pointer (§18 doesn't explain release notes) | §3 step 6 just says the release notes file must exist. |
+| §6 doesn't say how to overwrite listing fields | §7 is the new step with explicit dashboard surfaces per field. |
+| §14 "the release issue" undefined | §8 says "the release tracking issue for this version" — clearer; the tracking issue is per-release per §13. |
+| Front matter padding (Tracking, Versioning, Standard, Chrome) | Dropped. Title says it's the AMO runbook. |
+| Deployment-state lead-in + post-commentary | Dropped. Just the table. |
+| §3 line 78 "Split by responsibility..." | Dropped. The new §3 is flatly "Agent: verify build prerequisites". |
+| §4 anecdote about a cleanup-agent incident | Dropped. The "don't include docs/tests/ in the ZIP" reminder is implicit in §4 step 3's "no unexpected files" check. |
+| §4a "Known hardening gap" bug commentary | Dropped. Belongs in a separate issue if it's a real gap. |
+| §7d Maintainer note | Dropped. |
+| §7e Categories rationale history | Dropped. §11e just says `Other`. |
+| §11 license rationale | Dropped. §11k says PolyForm + how to use AMO's Custom License field. |
+| §12 "Why fewer than Chrome" | Dropped. §11l says "5 permissions + host". The reader doesn't need to know why Chrome is different. |
+| §16 version bump 200 words for one-line action | §13 is 6 steps, tightly worded. |
+
+## What stays the same
+
+- Listing field content (now §11a–§11l): byte-identical to the prior runbook's §7–§13.
+- Deployment-state identifiers (slug, gecko ID, URLs, account, version state).
+- Agent invocation phrases (the table). Phrase descriptions updated to match new section numbers.
+- Change log entries 1.0.0 through 1.0.10 (history doesn't change).
+
+## Verification
+
+```bash
+# Anti-patterns from the audit gone (or only in change-log entries as historical record):
+grep -F "Split by responsibility" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: empty
+
+grep -F "Maintainer note" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: empty
+
+# "Known hardening gap" and "pre-flight" appear only in historical change-log entries:
+grep -nF "Known hardening gap" docs/runbooks/10907-runbook-amo-publish.md
+grep -nE "pre-flight|preflight" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: both match only in the change-log section (lines ~400+)
+
+# Section structure flat 1-17:
+grep -n "^# \|^## [0-9]" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: §1 through §17 contiguous
+
+# Version header:
+grep -E "^> \*\*Version:" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: 2.0.0
+```
+
+Confirmed locally.
+
+## Out of scope
+
+- Chrome runbook 10905. Different document.
+- The 200-word version-bump cross-reference in 10905 §16 — that runbook has its own restructure decisions to make if any.
+- The `build_release.py` "Known hardening gap" (stale-zip auto-clean). If that's worth fixing, it's a separate issue against `tools/build_release.py`, not runbook commentary.

--- a/docs/reports/726/test-report.md
+++ b/docs/reports/726/test-report.md
@@ -1,0 +1,54 @@
+# Test Report — Issue #726
+
+## What this PR changes
+
+One runbook file restructured top-to-bottom. Pure documentation. No code, no config, no tests.
+
+## Regression scope
+
+None possible. Documentation rewrite to a runbook that is read, not executed.
+
+## Verification
+
+```bash
+# Version bump:
+grep -E "^> \*\*Version:" docs/runbooks/10907-runbook-amo-publish.md
+# Expected: > **Version:** 2.0.0
+
+# Section structure is flat §1–§17:
+grep -n "^# \|^## [0-9]" docs/runbooks/10907-runbook-amo-publish.md
+
+# Anti-patterns from the audit are gone from operational text
+# (matches in the change-log block are historical record-keeping):
+grep -F "Split by responsibility" docs/runbooks/10907-runbook-amo-publish.md
+grep -F "Maintainer note" docs/runbooks/10907-runbook-amo-publish.md
+# Expected for both: empty
+
+# Listing paste-blocks preserved byte-for-byte in their new §11 home:
+grep -F "We do not enumerate, retain, transmit, or analyze data from tabs" \
+  docs/runbooks/10907-runbook-amo-publish.md
+# Expected: one match (the §11d Description block)
+
+grep -F "https://aletheia.study/privacy.html" \
+  docs/runbooks/10907-runbook-amo-publish.md
+# Expected: at least two matches (§11i + §5 diff table + §16 related docs)
+```
+
+All confirmed locally during write.
+
+## Operator end-to-end test plan
+
+After merge, the operator can re-run the test that drove this restructure:
+
+1. Open the runbook from the start.
+2. Try to follow §1–§10 top-to-bottom for the AMO 1.1.2 update they have ready.
+3. At each step, the URL, click, what-to-look-for, and what-to-do-if-it-fails should be on the page. No "see also" pointers to other sections except for the listing paste-blocks at §11.
+4. The §5 diff step should produce a concrete list of fields to overwrite (or "no drift, skip §7"). §7 should name the exact dashboard surface for each field.
+
+If the operator hits another structural gap during the actual upload, file a follow-up issue. This PR addresses every gap identified in the 2026-05-30 audit; future audits may surface more.
+
+## What this report does NOT claim
+
+- Does not assert the runbook is "complete" — runbooks accumulate gaps over time as AMO's dashboard surfaces evolve.
+- Does not assert §11 paste-block content is correct. That was validated by the prior audit corrections (#663 / #670–#672 / #673); this PR moves the blocks, doesn't rewrite their text.
+- Does not change Chrome runbook 10905. It has its own structure and decisions.

--- a/docs/runbooks/10907-runbook-amo-publish.md
+++ b/docs/runbooks/10907-runbook-amo-publish.md
@@ -1,199 +1,187 @@
 # 10907 — Firefox AMO Publishing (Aletheia)
 
-> **Version:** 1.0.10
-> **Last updated:** 2026-05-30 10:28:40 AM Central
-> **Applies to:** Aletheia Firefox extension, every submission to Firefox Add-ons (addons.mozilla.org / "AMO")
-> **Tracking issue:** [martymcenroe/Aletheia#678](https://github.com/martymcenroe/Aletheia/issues/678)
-> **Versioning:** semver per [AssemblyZero#1362](https://github.com/martymcenroe/AssemblyZero/issues/1362) principle 20 — major.minor.patch. See §20 change log.
-> **Standard:** built to the AZ#1362 runbook standard. That standard doc is not yet shipped (the issue holds the full spec); [Clio 30002](https://github.com/martymcenroe/Clio/blob/main/docs/runbooks/30002-chrome-web-store-publish.md) is the reference implementation (Chrome), and the companion [`10905-runbook-cws-publish.md`](./10905-runbook-cws-publish.md) is the Aletheia Chrome runbook.
-> **Chrome / CWS:** Chrome Web Store publishing is in [`10905-runbook-cws-publish.md`](./10905-runbook-cws-publish.md). This runbook is Firefox AMO only.
+> **Version:** 2.0.0
+> **Last updated:** 2026-05-30 10:49:19 AM Central
+> **Applies to:** Aletheia Firefox extension submissions to AMO (`addons.mozilla.org`)
 
 ## Aletheia AMO deployment state
-
-Durable identifiers for the live Aletheia Firefox listing. Agent commands (see *Agent invocation phrases* below) reference these.
 
 | Item | Value |
 |---|---|
 | Add-on slug | `aletheia-ai` |
 | Gecko (add-on) ID | `extension@aletheia.study` |
-| Listing URL | `https://addons.mozilla.org/en-US/firefox/addon/aletheia-ai/` |
+| Listing URL (public) | `https://addons.mozilla.org/en-US/firefox/addon/aletheia-ai/` |
 | Developer Hub | `https://addons.mozilla.org/developers/` |
-| Manage Versions | `https://addons.mozilla.org/developers/addon/aletheia-ai/versions/` |
+| Manage Versions URL | `https://addons.mozilla.org/developers/addon/aletheia-ai/versions/` |
 | Account | `cto@thrivetech.ai` (forwards to `cto.thrivetech.ai@gmail.com`) |
-| Current published version | `1.1.1` (live on AMO; updated 2026-03-06). `1.1.2` is built + release-noted but never went live — it is the pending upload. |
-| Minimum Firefox | `140.0` desktop / `142.0` Android (`browser_specific_settings.gecko`) |
-| License (must be) | **PolyForm Noncommercial 1.0.0** — NOT MIT (recurring error; see §11) |
-
-Update this table on rebrand, ID change, slug change, **and on each publish** — §15a refreshes the Current published version after AMO approves. **Do not change the slug** once published — it's baked into the listing URL.
-
-## Throughout this runbook
-
-- **Operator** — the human running the publishing process at the AMO Developer Hub. Can perform any step.
-- **Agent** — a Claude Code session with this repo's working tree available. Performs any step marked agent. Invoked by the canonical phrases listed below.
-
-## How to verify you have the latest copy
-
-This runbook lives at `docs/runbooks/10907-runbook-amo-publish.md` in [martymcenroe/Aletheia](https://github.com/martymcenroe/Aletheia). The **Version** and **Last updated** lines identify your revision.
-
-1. Note the version on your copy.
-2. Say `Run amo prep` or `Audit 10907` — the agent reports the current `main` HEAD runbook version line.
-3. If your copy differs, re-print before continuing.
+| Current published version | `1.1.1` (live since 2026-03-06) |
+| Pending upload | `1.1.2` (built, release-noted, never published) |
+| Minimum Firefox | `140.0` desktop / `142.0` Android |
+| License (must be) | `PolyForm Noncommercial 1.0.0` (NOT MIT) |
 
 ## Agent invocation phrases (reference)
 
-The operator types one of these to trigger the matching action. The agent recognizes minor punctuation variation and asks for clarification on ambiguity. Phrases are **prefixed `amo`** to disambiguate from the Chrome runbook ([10905](./10905-runbook-cws-publish.md)) — `Run amo build` is Firefox, `Run cws build` is Chrome.
+The operator types one of these to trigger the matching agent action.
 
-| To make the agent... | Operator says |
+| Phrase | What the agent does |
 |---|---|
-| Audit this runbook for gaps / drift | `Audit 10907` |
-| Run §3a verification + §4 build, hand back the Firefox ZIP path | `Run amo prep` |
-| Run §3a only (no build) and report findings | `Run amo §3a` |
-| Run §4 build + verify (§3 already passed) | `Run amo build` |
-| Sign + upload via the `web-ext` API path (§17, optional) | `Run amo sign` |
-| Comment the submission timestamp on the release issue (current Central time, or `at YYYY-MM-DD HH:MM`) | `Submitted amo` |
-| After AMO approves: run §15a — tag the commit, update release notes, comment + close the release issue | `Run amo post-publish` (listing URL defaults to the deployment-state block) |
+| `Audit 10907` | Audit this runbook for gaps / drift; report findings + current `main` HEAD version line |
+| `Run amo prep` | Run §3 verify + §4 build, hand back the Firefox ZIP path |
+| `Run amo §3` | Run §3 verify only; report findings |
+| `Run amo build` | Run §4 build + verify (assumes §3 already passed) |
+| `Run amo sign` | Sign + upload via §14 web-ext API path (optional, automation only) |
+| `Submitted amo` | Comment the current Central-time submission timestamp on the release issue (or `at YYYY-MM-DD HH:MM`) |
+| `Run amo post-publish` | Run §10 post-publish: tag commit, update release notes, comment + close release issue, update the deployment-state table |
 
-The agent's reply includes (a) a one-line confirmation, (b) findings/follow-ups, (c) the current `main` HEAD runbook version line.
+---
 
-## 1. Where to start (reading paths)
+# Procedure
 
-| Situation | Read sections |
-|-----------|--------------|
-| **Path A — First AMO submission** (add-on not yet in the Developer Hub) | §2 → §3 → §4 → §5 → §7 → §8 → §9 → §10 → §11 → §12 → §13 → §14 → §15 |
-| **Path B — Subsequent update** (Aletheia already in My Add-ons — the normal case; for the live vs pending version, see the deployment-state block) | §2 → §3 → §4 → §6 → (review §7–§13 if listing copy changed) → §13 source check → §14 → §15 |
-| **Path C — New machine or new AMO account** | Stop. Confirm the `cto@thrivetech.ai` AMO login (2FA) and, if automating, regenerate API credentials (§17). Then return as Path A or Path B. |
+## 1. Sign in to AMO Developer Hub
 
-§16 Version bump, §17 API/`web-ext` path, §18 Troubleshooting, §19 Related documents, §20 Change log are reference material.
+1. Open `https://addons.mozilla.org/developers/` in your browser.
+2. Sign in as `cto@thrivetech.ai`. Complete 2FA prompt.
+3. Verify the account chip in the top-right reads `cto@thrivetech.ai`. If a different Mozilla identity is active, sign out fully at `https://accounts.google.com/Logout`, close the tab, return to step 1.
+4. Confirm the **My Add-ons** list shows **Aletheia** at slug `aletheia-ai`.
 
-## 2. Account check (every submission)
+## 2. Confirm the new version is not already uploaded
 
-1. Sign in to `https://addons.mozilla.org/developers/` as `cto@thrivetech.ai` (mail forwards to `cto.thrivetech.ai@gmail.com`); complete 2FA.
-2. Confirm the **My Add-ons** list shows **Aletheia** at slug `aletheia-ai`.
-3. If a different Mozilla identity is active, sign out and back in as `cto@thrivetech.ai`.
+1. Open `https://addons.mozilla.org/developers/addon/aletheia-ai/versions/`.
+2. Scan the version history table.
+3. Confirm the version you intend to upload (e.g. `1.1.2`) does NOT appear. AMO refuses duplicate version numbers at upload.
+4. If the version already exists (typically from a prior partial upload), STOP. Bump both manifests to the next patch version per §13 and rebuild before continuing.
 
-The AMO dashboard access pattern is likely the same Chrome profile used for CWS (memory `user-cws-dashboard-access`) but is **not confirmed** — check that profile's bookmarks first.
+## 3. Agent: verify build prerequisites
 
-## 3. Verification (before §4 build)
+Say `Run amo §3`. The agent performs items 1–6 and reports.
 
-Split by responsibility, items numbered for "§3a.N" / "§3b.N" reference.
+1. `extensions/firefox/manifest.json` declares the new `version`, monotonic from the current live version (deployment-state block above). The Chrome manifest matches (`build_release.py` enforces parity on `name`, `version`, `description`, `icons`).
+2. Firefox `permissions` is exactly `activeTab`, `tabs`, `scripting`, `contextMenus`, `storage`. `host_permissions` is exactly `["https://api.aletheia.study/*"]`. Every permission has a justification at §11l.
+3. `browser_specific_settings.gecko` is intact: `id = "extension@aletheia.study"`, `strict_min_version = "140.0"`, `gecko_android.strict_min_version = "142.0"`. `data_collection_permissions.required = ["authenticationInfo", "websiteContent"]`, `optional = []`.
+4. No hardcoded test URLs or dev flags. All API traffic targets `https://api.aletheia.study/*`.
+5. `poetry run pytest` passes. `npx playwright test` passes.
+6. `docs/releases/firefox-vX.Y.Z.md` exists for the target version.
 
-### 3a. Agent does (in the repo, before producing the ZIP)
+If any check fails, the agent surfaces it. Fix and re-run `Run amo §3` before proceeding.
 
-1. `extensions/firefox/manifest.json` has the new `version`, monotonic from the last published AMO version (see the deployment-state block for the current live and pending versions), and **matching `extensions/chrome/manifest.json`** (`build_release.py` enforces parity on `name`, `version`, `description`, `icons`).
-2. Firefox `permissions` is exactly `activeTab`, `tabs`, `scripting`, `contextMenus`, `storage` — **five, not seven**. Firefox does NOT request `identity` (it uses a tabs-based OAuth flow, not `chrome.identity`) or `notifications`. `host_permissions` is exactly `["https://api.aletheia.study/*"]`. Every permission has a §12 paste-block.
-3. `browser_specific_settings.gecko` is intact: `id` = `extension@aletheia.study`, `strict_min_version` = `140.0`, `gecko_android.strict_min_version` = `142.0`. The `data_collection_permissions` block declares `required: ["authenticationInfo", "websiteContent"]`, `optional: []` — this must match the §10 data-collection disclosure.
-4. No hardcoded test URLs or dev flags; all API traffic goes to `https://api.aletheia.study/*`.
-5. All tests pass: `poetry run pytest` + `npx playwright test`. `web-ext lint` is clean — `build_release.py` Step 3 runs it automatically and fails on errors (warnings are reported but non-blocking).
-6. Release notes file `docs/releases/firefox-vX.Y.Z.md` written before the §4 build — see §18.
-7. Listing screenshots exist at `screenshots/amo/amo-image-N-<slug>.png`. **Current state: directory does not exist; it will be created on first AMO screenshot upload.** AMO accepts up to 10 screenshots with no strict dimension requirement, but use high-resolution images; produce them with [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) (it has an AMO output convention and `--width/--height` flags). The CWS 1280×800 images can be reused.
-8. Agent reports the current `main` HEAD SHA and this runbook's `> **Version:**` line.
+## 4. Agent: build and verify the ZIP
 
-### 3b. Operator does
+Say `Run amo build`. The agent performs items 1–4.
 
-1. §2 Account check passes.
-2. The version isn't already uploaded — check Manage Versions history. (AMO refuses a duplicate version number.)
-3. Approve the agent's screenshot set, or flag privacy/embarrassing content.
-4. Review §7–§13 paste-blocks for changes — canonical source, no second document. **The live AMO listing may carry the old false "cannot see your browsing history" wording** from earlier versions of the description — verify in private browsing and overwrite §7d Description if so. Where the listing disagrees with §7/§10/§11/§12, overwrite it.
-5. Operator's printed-copy version matches §3a.8.
+1. Delete stale `dist/aletheia-firefox-*.zip` files by exact name. Never glob-delete. If the listing contains anything unrecognized, the agent STOPS and surfaces it.
+2. Run `poetry run python tools/build_release.py`. The script runs `web-ext lint` as Step 3; it fails the build on lint errors.
+3. Verify the produced `dist/aletheia-firefox-vX.Y.Z.zip`:
+   - `manifest.json` at archive root, with `manifest_version: 3` and `browser_specific_settings.gecko.id` present.
+   - `icons/` contains the 4 sizes (16, 32, 48, 128).
+   - 10 source files at root: `service-worker.js`, `popup.html`, `popup.js`, `popup.css`, `overlay.js`, `content-check.js`, `content-safety.js`, `article-extractor.js`, `auth.js`, `manifest.json`. 14 entries total.
+   - All paths use forward slashes. No unexpected files.
+4. The agent hands the operator the ZIP path.
 
-## 4. Build & verify the ZIP (agent does this)
-
-**Agent runs §4a + §4b. Operator receives the ZIP path and uploads it at §5/§6 (or the agent signs via §17).**
-
-**CRITICAL:** use `build_release.py` (Python `ZipFile`, forward slashes) or `zip` from MSYS2 / Git Bash — **never** PowerShell `Compress-Archive` (AMO rejects backslash separators). **CRITICAL:** `extensions/firefox/` must contain only extension files — no `docs/`, session logs, `tests/`. (A cleanup agent once wrote `extensions/firefox/docs/session-logs/` and it got packaged into the ZIP — see memory.)
-
-### 4a. Build (agent does this)
-
-```bash
-cd /c/Users/mcwiz/Projects/Aletheia
-# Clear stale artifacts safely — never glob-delete. List first, inspect, then delete by name:
-ls -1 dist/aletheia-firefox-*.zip 2>/dev/null || echo "(none present)"
-#   If an older-version zip is listed, delete that file BY NAME (e.g. rm dist/aletheia-firefox-v1.1.1.zip).
-#   If the list shows anything you do not recognize, STOP and investigate before deleting.
-poetry run python tools/build_release.py
-```
-
-Produces `dist/aletheia-firefox-v{version}.zip` (and the Chrome ZIP). `build_release.py` runs `web-ext lint` on the Firefox source as Step 3.
-
-> **Known hardening gap (principle 17):** `build_release.py` does not auto-clean stale `dist/*.zip`. Do the list-inspect-delete-by-name step above until that is fixed (same gap noted in [10905](./10905-runbook-cws-publish.md) §4a; follow-up: have the script remove prior Aletheia zips by exact name, never a glob).
-
-Fallback if the build tool is broken:
+**Fallback if `build_release.py` is broken:**
 
 ```bash
 cd /c/Users/mcwiz/Projects/Aletheia/extensions/firefox
 zip -r ../../dist/aletheia-firefox-vX.Y.Z.zip . -x '.*' -x '*/.*' -x 'node_modules/*'
 ```
 
-### 4b. Verify (agent does this)
+Never use PowerShell `Compress-Archive` — AMO rejects backslash separators.
 
-```bash
-cd /c/Users/mcwiz/Projects/Aletheia
-unzip -l dist/aletheia-firefox-vX.Y.Z.zip
-```
+## 5. Diff the live listing against §11 listing content
 
-Confirm:
+1. Open the public AMO listing in a **private / incognito** browser window: `https://addons.mozilla.org/en-US/firefox/addon/aletheia-ai/`.
+2. For each field below, compare the live listing text against §11. Note any field where the live text differs.
 
-- Forward slashes in all paths.
-- `manifest.json` at the archive root, with `manifest_version: 3` and `browser_specific_settings.gecko.id` present.
-- `icons/` with four icons: 16, 32, 48, 128.
-- Expected files at root: `manifest.json` plus the 9 source files `service-worker.js`, `popup.html`, `popup.js`, `popup.css`, `overlay.js`, `content-check.js`, `content-safety.js`, `article-extractor.js`, `auth.js` (10 root files total + 4 icons = 14 entries).
-- No unexpected files.
+| Live listing field | Compare to | Look for |
+|---|---|---|
+| Description (the long marketing text) | §11d | Live should contain "We do not enumerate, retain, transmit, or analyze data from tabs..." If it contains "We cannot see your browsing history" or "We use the ActiveTab permission model", the field has drifted. |
+| Privacy Policy link | §11i | Click the "Privacy Policy" link. It should resolve to `https://aletheia.study/privacy.html`. If it resolves to `https://martymcenroe.github.io/Aletheia/` or 404s, the field has drifted. |
+| Permissions list with justifications | §11l | The listing should show all 5 permissions (`activeTab`, `tabs`, `scripting`, `contextMenus`, `storage`) plus the host permission `https://api.aletheia.study/*`, each with a justification matching §11l. Missing or differing justifications = drift. |
+| License | §11k | Should show `PolyForm Noncommercial 1.0.0`. If it shows `MIT` or any other license, the field has drifted. |
 
-Sanity-check the version and gecko ID inside the ZIP:
+Record the list of drifted fields. You'll fix them in §7.
 
-```bash
-unzip -p dist/aletheia-firefox-vX.Y.Z.zip manifest.json | grep -E '"version"|"id"|strict_min_version'
-```
+If no fields drifted, skip §7.
 
-The agent hands the operator the path to `dist/aletheia-firefox-vX.Y.Z.zip`.
+## 6. Upload the new ZIP
 
-## 5. First submission upload (Path A — add-on not yet in the Developer Hub)
-
-Historical — Aletheia is already published; this applies only on a from-scratch resubmission.
-
-1. Developer Hub → **Submit a New Add-on**.
-2. Distribution channel: **On this site** (listed on AMO). (The other option, "On your own," produces a self-distributed signed XPI — not what we use.)
-3. Upload `dist/aletheia-firefox-vX.Y.Z.zip`. Automated validation runs (seconds).
-4. Answer the source-code question (§13), then fill listing metadata (§7–§12) and submit.
-
-## 6. Subsequent update upload (Path B — Aletheia already listed)
-
-The normal case.
-
-1. Developer Hub → **My Add-ons** → **Aletheia** → **Manage** → left nav **Manage Status & Versions** (or go straight to the Manage Versions URL in the deployment-state block).
+1. From the Developer Hub, click **Aletheia** → left nav **Manage Status & Versions** (or go to `https://addons.mozilla.org/developers/addon/aletheia-ai/versions/`).
 2. Click **Upload a New Version**.
-3. Choose `dist/aletheia-firefox-vX.Y.Z.zip` and upload. Automated validation runs.
-4. Answer the source-code question (§13). On success the new version enters review; the previously-approved version stays live until this one is approved.
+3. Choose the ZIP path the agent handed you in §4 (`dist/aletheia-firefox-vX.Y.Z.zip`). Upload.
+4. AMO runs automated validation (seconds). If validation fails, read the error, fix, rebuild, return to step 2.
+5. AMO asks "Do you use tools that make your code hard to read?" → answer **No**. Provide the repo as a reviewer reference: `https://github.com/martymcenroe/Aletheia`. Aletheia ships plain readable JavaScript; the ZIP files ARE the source.
 
-## 7. Listing details
+The new version now enters review. The previously-approved version stays live until this one is approved.
 
-Paste-ready; copy into the matching AMO field. AMO's listing form differs from CWS — fields below are in AMO order.
+## 7. Overwrite drifted listing fields (only if §5 found drift)
 
-### 7a. Name
+For each field §5 identified as drifted, navigate to its editor and paste the canonical text from §11.
+
+1. Developer Hub → **Aletheia** → **Edit Product Page** (or **Manage Listing**).
+2. For each drifted field:
+
+| Field | Editor location | Paste from |
+|---|---|---|
+| Description | Listing tab → Description field | §11d |
+| Privacy Policy URL | Privacy practices tab → Privacy Policy URL | §11i |
+| Permission Justifications | Privacy practices tab → Permission Justification(s) | §11l (one per permission) |
+| License | Listing tab → License → "Custom License" → name `PolyForm Noncommercial 1.0.0`, URL `https://polyformproject.org/licenses/noncommercial/1.0.0/` | §11k |
+
+3. Save each tab after editing.
+4. Verify in private browsing (`https://addons.mozilla.org/en-US/firefox/addon/aletheia-ai/`) that the updates appear on the public listing.
+
+## 8. Submit for review
+
+1. Click **Submit Version** on the upload flow.
+2. Say `Submitted amo` to the agent. The agent comments the current Central-time submission timestamp on the release tracking issue for this version.
+3. Wait. AMO automated validation is instant; human review for a listed update typically takes hours to a few days.
+
+## 9. AMO approves — operator action
+
+When AMO emails approval:
+
+1. Say `Run amo post-publish` to the agent.
+2. The agent runs §10.
+3. Then perform the §11.smoke-test below.
+
+## 10. Agent: post-publish
+
+The agent performs items 1–5 on `Run amo post-publish`:
+
+1. Verify the Firefox install link in `docs/index.html` and `docs/demos.html` points at the AMO listing URL. Fix via the docs-on-main edit flow if stale.
+2. Tag the released commit: `git tag firefox-vX.Y.Z-published && git push origin firefox-vX.Y.Z-published`.
+3. Comment on the release tracking issue with the approval date and the listing URL. Close the issue.
+4. Update `docs/releases/firefox-vX.Y.Z.md` — fill `Submission date:` and add an `Approval date:` line.
+5. Update the deployment-state table at the top of this runbook: set **Current published version** to the just-approved version; clear **Pending upload** unless another version is already in flight.
+
+---
+
+# 11. Listing field content (paste-ready)
+
+Canonical text for every AMO form field. When the operator overwrites a drifted field at §7, paste from here.
+
+### 11a. Name
 
 ```
 Aletheia
 ```
 
-### 7b. Add-on slug (one-time — do not change)
+### 11b. Add-on slug (one-time — never change)
 
 ```
 aletheia-ai
 ```
 
-Baked into the listing URL (`…/addon/aletheia-ai/`). Changing it breaks every existing link. Set once; never edit.
+Baked into the listing URL. Changing it breaks every existing link.
 
-### 7c. Summary
+### 11c. Summary (250 char limit)
 
-*AMO summary limit: 250 characters. Same copy as the CWS short description (129 characters / 131 bytes UTF-8 — the em-dash is 3 bytes).*
+129 characters / 131 bytes UTF-8 (the em-dash is 3 bytes):
 
 ```
 Instant AI analysis for selected text. Understand context, detect nuance, and verify facts—while maintaining strict data privacy.
 ```
 
-### 7d. Description
-
-*AMO listing description. Use the audit-corrected copy — the "Privacy by Design" line MUST read "we do not enumerate…", never "we cannot see your browsing history."*
+### 11d. Description
 
 ```
 Aletheia: The Privacy-First Context Analyzer
@@ -215,191 +203,160 @@ Why Aletheia?
 Source-available and transparent. Your data stays yours.
 ```
 
-> **Maintainer note:** same "Open Source" → "Source-available" correction as the Chrome runbook §7c, for the same PolyForm-Noncommercial reason.
+### 11e. Category
 
-### 7e. Categories
+```
+Other
+```
 
-AMO categories differ from CWS. Aletheia's current listing uses **Other**. Confirm against the live listing before changing. Rationale (preserved):
-- `Other` (current) — safe catch-all; what the listing ships with today.
-- `Privacy & Security` (candidate) — defensible given the privacy-first framing; consider if deliberately re-categorizing.
-- `Language Support` (rejected) — Aletheia analyzes meaning in context, it is not a translation/locale tool.
+### 11f. Screenshots
 
-A category change is a deliberate decision, not a routine-update step.
+If you are NOT changing screenshots this submission (the typical case for an update), no action — existing AMO screenshots remain.
 
-## 8. Graphic assets
+If you are changing screenshots: produce per `docs/runbooks/10906-runbook-cws-image-pad.md` (CWS 1280×800 images can be reused). Output to `screenshots/amo/amo-image-N-<slug>.png`. Upload at §6 step 5 alongside the ZIP, or via the Listing tab after submission.
 
-### 8a. Add-on icon
-
-AMO uses the icon from the manifest (`icons.128` → `extensions/firefox/icons/icon128.png`). No separate upload needed unless you want a distinct listing icon.
-
-### 8b. Screenshots
-
-Upload from `screenshots/amo/amo-image-N-<slug>.png` (none exist yet — see §3a.7; produce via [10906](./10906-runbook-cws-image-pad.md)). AMO shows them on the listing page; high-resolution preferred, no hard dimension limit.
-
-## 9. Additional listing fields
-
-### 9a. Homepage URL
+### 11g. Homepage URL
 
 ```
 https://aletheia.study
 ```
 
-### 9b. Support site / email
+### 11h. Support site / email
 
+Support site:
 ```
 https://github.com/martymcenroe/Aletheia/issues
 ```
 
+Support email:
 ```
 cto@thrivetech.ai
 ```
 
-### 9c. Tags (optional)
-
-Leave as-is for a routine update. Tags aid discovery; not load-bearing.
-
-## 10. Privacy & data collection
-
-### 10a. Privacy Policy URL
+### 11i. Privacy Policy URL
 
 ```
 https://aletheia.study/privacy.html
 ```
 
-Confirm it's this, **not** the stale `https://martymcenroe.github.io/Aletheia/`. Verify in private browsing that the listing's policy link resolves and shows the current policy.
+NOT `https://martymcenroe.github.io/Aletheia/` (stale; may 404).
 
-### 10b. Data collection disclosure
+### 11j. Data collection disclosure (Firefox 140+ Manage Data Collection form)
 
-Firefox 140+ surfaces data-collection consent from the manifest's `data_collection_permissions`. Aletheia declares `required: ["authenticationInfo", "websiteContent"]` and `optional: []`. Each required value maps to one AMO disclosure:
+Match these to the manifest's `data_collection_permissions`:
 
-| `required` array value | AMO disclosure |
+| Disclosed type | Detail |
 |---|---|
-| `authenticationInfo` | **Authentication information** — the LinkedIn OAuth token. Stored locally, cleared on browser close. |
-| `websiteContent` | **Website content** — the selected text + surrounding context, on user-initiated analysis only. |
-| (`optional: []`) | No additional data types. |
+| Authentication information | LinkedIn OAuth token. Stored locally, cleared on browser close. |
+| Website content | The selected text + surrounding context, on user-initiated analysis only. |
+| (none other) | — |
 
-The AMO "Manage Data Collection" / data-disclosure form must match this exactly. No "cannot see browsing history" claims; no data type beyond authentication info + website content.
+No "cannot see browsing history" claims. No data type beyond these two.
 
-### 10c. Per-permission notes
+### 11k. License (Custom — AMO does not have PolyForm in its dropdown)
 
-If AMO requests free-text permission notes, reuse the §12 justifications (the five Firefox permissions + the host).
+Choose **"Custom License"** in the AMO dropdown.
 
-## 11. License
+License name:
+```
+PolyForm Noncommercial 1.0.0
+```
 
-**CRITICAL — verify every submission.** The license is **PolyForm Noncommercial 1.0.0**, matching the repo [LICENSE](../../LICENSE). It has been wrongly set to **MIT** on AMO before (memory: "AMO listing was incorrectly set to MIT").
+License URL:
+```
+https://polyformproject.org/licenses/noncommercial/1.0.0/
+```
 
-AMO's license dropdown does **not** include PolyForm. Choose **"Custom License"** and provide:
+Or paste the full text of the repo `LICENSE` file into the custom-license text box.
 
-- License name: `PolyForm Noncommercial 1.0.0`
-- License URL: `https://polyformproject.org/licenses/noncommercial/1.0.0/`
-- (Or paste the full text of the repo `LICENSE` file into the custom-license text box.)
+### 11l. Permission justifications (5 permissions + host)
 
-Rationale: MIT would (a) misrepresent the project's actual license and (b) silently waive the noncommercial restriction PolyForm exists to assert. Picking a permissive default from the dropdown is the exact mistake to avoid.
-
-## 12. Permission justifications (Firefox — five permissions + host)
-
-Firefox requests **five** permissions (no `identity`, no `notifications`). Paste-ready:
-
-### 12a. `activeTab`
-
+**`activeTab`:**
 ```
 Used to read the text of the currently active tab only when the user explicitly invokes Aletheia (right-click "Explain with AI"). The extension does not access any other tab.
 ```
 
-### 12b. `tabs`
-
+**`tabs`:**
 ```
 Used to detect page navigation for overlay lifecycle management, to inject the content script on the active tab, and — on Firefox specifically — to detect the OAuth callback during the tabs-based LinkedIn sign-in flow. The extension does NOT enumerate or read content from any tab other than the one the user explicitly invokes Aletheia on.
 ```
 
-### 12c. `scripting`
-
+**`scripting`:**
 ```
 Used to execute the content script (reading the selection's surrounding context) on the active tab during "Explain with AI", and as a recovery path to re-inject the content script into a tab opened before the extension was loaded. Only the active tab, only the extension's own bundled scripts.
 ```
 
-### 12d. `contextMenus`
-
+**`contextMenus`:**
 ```
 Provides the primary trigger: the right-click "Explain with AI" menu item on selected text.
 ```
 
-### 12e. `storage`
-
+**`storage`:**
 ```
 Saves user preferences, the authentication token, and the domain allowlist locally on the user's device. Nothing is stored on a remote server.
 ```
 
-### 12f. Host permission: `https://api.aletheia.study/*`
-
+**Host permission `https://api.aletheia.study/*`:**
 ```
 The single remote endpoint the extension communicates with: the selected text and its surrounding context are sent here for analysis and the result is returned. No other network requests, no third-party analytics or tracking host.
 ```
 
-> **Why fewer than Chrome:** the Firefox build authenticates with a tabs-based OAuth flow rather than `chrome.identity`, so it needs neither the `identity` permission nor `notifications`. If AMO shows only these five, that is correct — do not copy the Chrome runbook's seven.
+### 11.smoke-test (operator does after AMO approves)
 
-## 13. Source-code submission
+1. Install / update Aletheia in Firefox from the AMO listing.
+2. **Core flow:** select text on any page → right-click → "Explain with AI" → overlay appears with context-aware analysis.
+3. **Auth flow:** click extension icon → "Log in with LinkedIn" → tabs-based OAuth completes (a callback tab opens and closes) → popup shows logged-in state.
+4. Verify the version in `about:addons` matches what was uploaded.
 
-AMO requires a source-code upload **only if** the add-on contains minified, concatenated, obfuscated, or transpiled code that the reviewer cannot read directly. **Aletheia ships plain, readable JavaScript with no build/minify step** — the ZIP files *are* the source.
+If a smoke test fails: do NOT delist. File a `launch-blocker` issue, reproduce in Firefox dev mode (`about:debugging` → Load Temporary Add-on), ship a patch version. A patch must go through AMO review again; do not pull the working version.
 
-- When AMO asks "Do you use tools that make your code hard to read?" → answer **No**.
-- Provide the repository as a reviewer reference: `https://github.com/martymcenroe/Aletheia`.
-- If AMO's validator ever flags a specific file as needing source (e.g. a future bundling step), upload a source ZIP plus build instructions (`poetry run python tools/build_release.py`).
+---
 
-## 14. Submit for review
+# 12. First submission (Path A — historical)
 
-1. Operator clicks **Submit Version** (Path B) or completes the new-add-on flow (Path A).
-2. AMO automated validation is instant; human review for a listed update typically takes hours to a few days (a minor update is usually fast; a first submission or a permission change can take longer).
-3. Operator says `Submitted amo`. The agent comments the current Central-time submission timestamp on the release issue.
+Aletheia is already published. This applies only to a from-scratch resubmission (new add-on entry).
 
-## 15. Post-publish
+1. Developer Hub → **Submit a New Add-on**.
+2. Distribution channel: **On this site** (listed on AMO).
+3. Upload `dist/aletheia-firefox-vX.Y.Z.zip`.
+4. Answer the source-code question per §6 step 5. Fill listing metadata from §11 (Name, Slug, Summary, Description, Category, Homepage URL, Support URL/email, Privacy Policy URL, Permission Justifications, License). Submit.
 
-After AMO approves and emails the operator, the operator says `Run amo post-publish`.
+---
 
-### 15a. Agent does (`Run amo post-publish`)
+# 13. Version bump procedure
 
-1. Verify the Firefox install link in `docs/index.html` / `docs/demos.html` points at the AMO listing URL; fix via the docs-on-main edit flow if stale.
-2. Tag the released commit: `git tag firefox-vX.Y.Z-published && git push origin firefox-vX.Y.Z-published`.
-3. Comment on the release issue with the approval date and the listing URL; close the issue.
-4. Update `docs/releases/firefox-vX.Y.Z.md` — fill `Submission date:` and add an `Approval date:` line.
-5. Update this runbook's deployment-state **Current published version** row to the just-approved version (e.g. `1.1.2` once it is live), so the live/pending pin does not go stale.
+Shared with the Chrome runbook 10905. Aletheia ships both browsers from one version line.
 
-### 15b. Operator does (smoke test)
+1. Open a tracking issue for the release.
+2. Bump both manifests to the same `X.Y.Z`:
+   - `extensions/chrome/manifest.json`
+   - `extensions/firefox/manifest.json`
+3. Write `docs/releases/chrome-vX.Y.Z.md` and `docs/releases/firefox-vX.Y.Z.md`.
+4. Commit + PR: `chore: bump extension versions to X.Y.Z (Closes #N)`. Put `Closes #N` in the PR body too — pr-sentinel validates the body, not the commit message.
+5. Merge to `main`.
+6. Then proceed with §4 → §6 of this runbook for AMO; parallel work for CWS in 10905.
 
-1. Install/update Aletheia in Firefox from the AMO listing.
-2. **Core flow:** select text → right-click → "Explain with AI" → overlay appears with context-aware analysis.
-3. **Auth flow:** click the extension icon → "Log in with LinkedIn" → the **tabs-based** OAuth flow completes (a callback tab opens and closes; the `response.pending` state is handled) → popup shows logged-in state.
-4. Verify the version in `about:addons`.
+# 14. Web-ext API signing (optional, automation only)
 
-### 15c. If a smoke test fails
+The manual §6 dashboard upload is Aletheia's primary path. Use this only when automating.
 
-Do **not** delist. File a `launch-blocker` issue, reproduce in Firefox dev mode (`about:debugging` → Load Temporary Add-on), ship a patch version. A patch must go through AMO review again, so don't pull the working version.
+### 14a. Generate API credentials (one-time)
 
-## 16. Version bump procedure
+1. Open `https://addons.mozilla.org/developers/addon/api/key/` while signed in as `cto@thrivetech.ai`.
+2. Generate credentials. AMO shows a **JWT issuer** and a **JWT secret** (shown once).
 
-Shared with the Chrome runbook — Aletheia ships both browsers from one version line. See [10905](./10905-runbook-cws-publish.md) §16. In short: bump **both** `extensions/chrome/manifest.json` and `extensions/firefox/manifest.json` to the same `X.Y.Z` (the Chrome manifest is `build_release.py`'s source of truth; parity is enforced), write both release-notes files, commit `chore: bump extension versions to X.Y.Z (Closes #N)`, merge to `main`, then §4 → §6. Put `Closes #N` in the **PR body** too — pr-sentinel validates the body, not the commit message.
+### 14b. Secret handling
 
-## 17. Optional: API-key / `web-ext` signing path
+The JWT secret is a long-lived credential:
 
-CWS uploads are dashboard-only; AMO additionally supports programmatic upload/signing via API credentials and Mozilla's `web-ext` tool. This is **optional** — the manual §6 dashboard upload is Aletheia's primary path. Use this only when automating.
+- Operator stores the issuer and secret as environment variables `WEB_EXT_API_KEY` and `WEB_EXT_API_SECRET`. Not in a OneDrive-synced path. Not in shell history (leading space, or a `.env` the agent never reads).
+- Pass via environment, never as a command-line argument (argv is readable by same-user processes).
+- The agent NEVER prints, echoes, logs, or commits the secret.
+- If exposed: revoke at the AMO API key page and regenerate.
 
-### 17a. Generate API credentials (operator, one-time)
+### 14c. Sign + upload (`Run amo sign`)
 
-1. Operator opens `https://addons.mozilla.org/developers/addon/api/key/` while signed in as `cto@thrivetech.ai`.
-2. Generate credentials → AMO shows a **JWT issuer** (e.g. `user:12345:67`) and a **JWT secret** (shown once).
-
-### 17b. Secret handling (mandatory — the secret is a credential)
-
-The JWT secret is a long-lived credential that can submit/sign add-ons under this account. Treat it per the root CLAUDE.md secret-handling hygiene:
-
-- **The agent NEVER prints, echoes, logs, or commits the secret**, and never reads it back from a file into chat.
-- Operator stores it **outside the repo** as environment variables (`WEB_EXT_API_KEY` = issuer, `WEB_EXT_API_SECRET` = secret) — not in a OneDrive-synced path, not in shell history (use a leading space or a `.env` the agent never cats).
-- Pass via **environment**, never as a command-line argument (argv is readable by same-user processes).
-- If the secret is ever exposed, the operator revokes it at the same AMO page and regenerates.
-
-### 17c. Sign + upload (agent, `Run amo sign`)
-
-With the env vars exported by the operator in the same shell:
+With env vars exported in the same shell:
 
 ```bash
 cd /c/Users/mcwiz/Projects/Aletheia
@@ -409,48 +366,47 @@ npx web-ext sign \
   --artifacts-dir dist
 ```
 
-`web-ext` reads `WEB_EXT_API_KEY` and `WEB_EXT_API_SECRET` from the environment directly, so the secret is **never passed on the command line** — do NOT add `--api-key`/`--api-secret` flags, which would put it in argv (the leak §17b forbids). `--channel listed` submits to AMO and queues the public-listing review (equivalent to §6 upload); `--channel unlisted` would instead return a self-distributed signed XPI — not what we publish. The agent confirms `$WEB_EXT_API_KEY`/`$WEB_EXT_API_SECRET` are present in the environment **without printing their values**, and refuses to run if they're unset.
+`web-ext` reads `WEB_EXT_API_KEY` / `WEB_EXT_API_SECRET` from the environment. Do NOT add `--api-key`/`--api-secret` flags — that puts the secret in argv. `--channel listed` queues the public-listing review (equivalent to §6 upload).
 
-## 18. Troubleshooting
+The agent verifies the env vars are set without printing their values; refuses to run if unset.
+
+# 15. Troubleshooting
 
 | Problem | Diagnosis | Action |
-|---------|-----------|--------|
-| AMO rejects ZIP with backslash-path error | Built with PowerShell `Compress-Archive` | Rebuild with `build_release.py` or `zip` (MSYS2 / Git Bash) |
-| "Version already exists" | Forgot to bump both manifests | Bump both, rebuild (parity is enforced) |
-| License shows MIT on the listing | Recurring AMO default-picker error | Set to Custom License → PolyForm Noncommercial 1.0.0 (§11) |
-| AMO asks for source code | Validator flagged code as hard-to-read | Aletheia is not minified — answer No and link the repo; if a specific file is flagged, upload source + build steps (§13) |
-| Data-collection disclosure mismatch | AMO form drifted from the manifest | Make the AMO disclosure match `data_collection_permissions` (auth info + website content only) (§10b) |
-| `web-ext lint` errors on build | A manifest or file issue | Read the lint output; `build_release.py` fails the build on errors |
-| `npx playwright test` hangs on Firefox | Windows sandbox crashes the renderer (Juggler `remoteTab is null`) | Workaround applied in `playwright.config.js` (`MOZ_DISABLE_CONTENT_SANDBOX=1`). If running standalone reproduction scripts, export that env var first. |
-| Gecko ID mismatch / "add-on ID changed" | `browser_specific_settings.gecko.id` edited | Restore `extension@aletheia.study` — changing it creates a *new* add-on, orphaning the listing |
-| `strict_min_version` rejected | Set below a feature's availability | Keep `140.0` desktop / `142.0` Android unless a feature requires higher |
-| Listing still shows "cannot see your browsing history" | Pre-audit text | Overwrite §7d Description; verify in private browsing |
+|---|---|---|
+| AMO rejects ZIP with backslash-path error | Built with PowerShell `Compress-Archive` | Rebuild with `build_release.py` or `zip` from MSYS2 / Git Bash |
+| "Version already exists" at upload | Forgot to bump one or both manifests | Bump both per §13, rebuild |
+| License shows MIT on the listing | AMO default-picker error | Set to Custom License → PolyForm Noncommercial 1.0.0 (§11k) |
+| AMO asks for source code | Validator flagged code as hard-to-read | Aletheia is not minified — answer No and link the repo. If a specific file is flagged, upload the repo as a source ZIP with build instructions |
+| Data-collection disclosure mismatch | AMO form drifted from the manifest | Make the AMO form match §11j |
+| `web-ext lint` errors on build | Manifest or file issue | Read the lint output; `build_release.py` fails the build on errors |
+| `npx playwright test` hangs on Firefox | Windows sandbox crashes the renderer (Juggler `remoteTab is null`) | `MOZ_DISABLE_CONTENT_SANDBOX=1` workaround is permanently applied in `playwright.config.js`. Export it manually if running standalone reproduction scripts. |
+| Gecko ID mismatch / "add-on ID changed" | `browser_specific_settings.gecko.id` was edited | Restore `extension@aletheia.study`. Changing it creates a new add-on, orphaning the listing. |
+| `strict_min_version` rejected | Set below a Firefox feature's availability | Keep `140.0` desktop / `142.0` Android unless a feature requires higher |
+| Listing still shows "cannot see your browsing history" | Pre-audit text | Overwrite §11d at §7. Verify in private browsing. |
 
-## 19. Related documents
+# 16. Related documents
 
-- [`10905-runbook-cws-publish.md`](./10905-runbook-cws-publish.md) — the parallel Chrome Web Store publishing runbook (shared §16 version bump).
-- [`10906-runbook-cws-image-pad.md`](./10906-runbook-cws-image-pad.md) — produce listing screenshots (`screenshots/amo/…`) without cropping.
-- `docs/releases/` — per-version release notes (`firefox-vX.Y.Z.md`).
-- `docs/lld/done/10051-store-compliance.md` — original store-listing text (provenance; canonical copy now inline here).
-- `docs/privacy.html` — published privacy policy (`https://aletheia.study/privacy.html`).
+- `docs/runbooks/10905-runbook-cws-publish.md` — parallel Chrome Web Store publishing runbook.
+- `docs/runbooks/10906-runbook-cws-image-pad.md` — produce listing screenshots without cropping.
+- `docs/releases/firefox-vX.Y.Z.md` — per-version release notes.
+- `docs/privacy.html` — published privacy policy at `https://aletheia.study/privacy.html`.
 - `docs/legal/eula.html` — End User License Agreement.
-- `extensions/firefox/manifest.json` — ground-truth permissions, gecko settings, and `data_collection_permissions`.
-- Memory `user-cws-dashboard-access` — login pattern (CWS-confirmed; AMO likely shares the profile).
+- `extensions/firefox/manifest.json` — ground-truth permissions, gecko settings, data collection.
 
-## 20. Change log
-
-Semver per AZ#1362 principle 20.
+# 17. Change log
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.0.10 | 2026-05-30 10:28:40 AM Central | Patch: dropped the §0 section number. The agent-invocation-phrases table read as "step 0, do this first" when it is reference material, not a procedure step. Heading is now `Agent invocation phrases (reference)` with no number; in-text `(§0)` cross-references at the deployment-state lead-in, "Throughout this runbook" Agent definition, and "How to verify" line 2 are reworded to point at the reference block by name (Closes #721). |
-| 1.0.9 | 2026-05-30 10:05:57 AM Central | Patch: dropped "pre-flight" framing throughout. §3 retitled "Verification (before §4 build)" — the aviation metaphor set the wrong expectation (read as "quick visual check" when it's actually 13 substantive items including a 2-minute test run). §0 phrase `Run amo pre-flight` → `Run amo prep`; descriptions updated to "§3a verification + §4 build" and "(§3 already passed)". A runbook is a checklist; the runbook now names §3 as what it is (Closes #719). |
-| 1.0.8 | 2026-05-30 9:50:00 AM Central | Patch from `Audit 10907`: removed three references to `docs/10920-cws-listing-corrections-2026-05-27.md` (at §3b.4, §10a, §18). Canonical AMO listing text lives in §7d / §10a / §12; the references carried no information the runbook lacks and were scan-overhead. Where 10920 contributed operator-relevant guidance (the "live listing may still carry pre-audit wording" claim in §3b.4), that guidance is now inline (Closes #717). |
-| 1.0.7 | 2026-05-30 9:15:03 AM Central | Patch from `Audit 10907`: §3a.7 now states the `screenshots/amo/` directory does not exist (was "none exist" which read as "directory exists, no files"). §7c notes the byte count alongside the visible character count (129 / 131) so a naive `wc -c` reproducibility check does not surface a false discrepancy from the em-dash being 3 UTF-8 bytes (Closes #713). |
-| 1.0.6 | 2026-05-30 12:15:15 AM Central | Patch: documented the Windows sandbox Playwright hang in §18 Troubleshooting. The `MOZ_DISABLE_CONTENT_SANDBOX=1` workaround is now permanently applied in `playwright.config.js`. |
-| 1.0.5 | 2026-05-29 11:26:54 AM Central | Patch: removed the "no live debug-tier console calls" clause from §3a.4. The §3a.4 item now reads only the kept "no hardcoded test URLs or dev flags" portion. The console-call ban was authored in this runbook's 2026-05-28 v1.0.0 split with no upstream source — not in `docs/privacy.html`, not in any LLD, not in `docs/safety.html`/`docs/threat-model.html`. Local browser-console output never leaves the user's machine, so the rule had no privacy-policy grounding. Removing it eliminates the framing that allowed an agent in a later session to mis-label two existing `service-worker.js` `console.log` calls as "privacy-relevant" and present three "disposition" options to the operator. The cross-reference to the Chrome runbook's deleted §3a.3 went with the deleted clause (Closes #691). |
-| 1.0.4 | 2026-05-29 12:57:37 AM Central | Patch: removed a redundant lead-in in §10b — a dangling "Aletheia declares:" the v1.0.3 table rewrite left in front of the new sentence; merged the two into one. Found by the §0 `Audit 10907` self-audit (Closes #689). |
-| 1.0.3 | 2026-05-29 12:41:37 AM Central | Patch: applied the §0 `Audit 10907` findings. §17c no longer passes the API secret on the command line — `web-ext` reads `WEB_EXT_API_KEY`/`WEB_EXT_API_SECRET` from the environment, keeping the secret out of argv per §17b (Closes #686). §15a now refreshes the deployment-state Current published version, the update trigger includes "on each publish," and §1 Path B / §3a.1 reference the deployment-state block as the single source so the live/pending version is not duplicated three ways (Closes #687). Cosmetics: §10b shows the single `data_collection_permissions.required` array, §16 notes `Closes #N` belongs in the PR body, §4b clarifies the 10-root-file count. |
-| 1.0.2 | 2026-05-29 12:18:55 AM Central | Patch: corrected timestamps that were UTC mislabeled as Central — the v1.0.0/v1.0.1 dates and the header were produced with `TZ='America/Chicago' date`, which Git Bash returns as UTC. Re-derived to true Central (CDT, UTC-5) with plain `date` (Closes #684). |
-| 1.0.1 | 2026-05-28 08:05:10 PM Central | Patch: corrected the deployment-state, §1 Path B, and §3a.1 to state the live AMO version is `1.1.1` (1.1.2 was release-noted but never published — it is the pending upload) (Closes #682); replaced the `rm -f <glob>` artifact-clean step in §4a with a list → inspect → delete-by-name procedure (Closes #681). |
-| 1.0.0 | 2026-05-28 06:49:42 PM Central | New runbook, built to the AZ#1362 standard, split out of `10905-runbook-extension-store-publish.md` (which became the Chrome-only [10905](./10905-runbook-cws-publish.md)). Firefox-AMO-specific coverage the Chrome runbook lacks: §10b manifest `data_collection_permissions` disclosure (authenticationInfo + websiteContent), §11 PolyForm-Noncommercial custom-license trap (was wrongly MIT), §12 five-permission set (no `identity`/`notifications`; tabs-based OAuth), §13 source-code-submission question, §17 AMO API-key + `web-ext sign` path with secret-handling discipline. Lifted the audit-corrected Description, Privacy Policy URL, and permission justifications from `docs/10920-cws-listing-corrections-2026-05-27.md` and `docs/lld/done/10051-store-compliance.md`. Closes #678 (with [10905](./10905-runbook-cws-publish.md)). |
+| 2.0.0 | 2026-05-30 10:49:19 AM Central | **Major restructure** per operator end-to-end test (#726). The runbook was a checklist wrapped in maintainer commentary, redundant steps, and nebulous directions; this version is a flat numbered procedure (§1–§10 for the update path) with explicit URLs, clicks, what-to-look-for, and what-to-do-if-it-fails on every step. Major changes: dropped redundant `§2 Account check passes` operator item (§2 happens once, in §1); separated `web-ext lint` from §3 verify (it runs during §4 build, can't be verified pre-build); split the §3b.4 "review §7–§13 for changes" lump into §5 ("Diff the live listing") with a per-field comparison table; added §7 "Overwrite drifted listing fields" with explicit dashboard surfaces (the prior runbook directed operators to "overwrite at §6 upload" without saying how); made screenshots a no-op for updates by default (§11f); moved first-submission flow to §12 with a "historical" label; removed front-matter padding (Tracking issue, Versioning, Standard reference, Chrome cross-reference); removed §4 anecdote about a cleanup-agent incident; removed §4a "Known hardening gap" bug-commentary; removed §7e category-rationale history, §11 license-rationale restating its own warning, §12 "Why fewer than Chrome" cross-runbook commentary. Listing paste-blocks (now §11) are unchanged in content; only their position and numbering moved (Closes #726). |
+| 1.0.10 | 2026-05-30 10:28:40 AM Central | Patch: dropped the §0 section number. The agent-invocation-phrases table read as "step 0, do this first" when it is reference material, not a procedure step (Closes #721). |
+| 1.0.9 | 2026-05-30 10:05:57 AM Central | Patch: dropped "pre-flight" framing throughout. §3 retitled "Verification (before §4 build)"; `Run amo pre-flight` → `Run amo prep` (Closes #719). |
+| 1.0.8 | 2026-05-30 9:50:00 AM Central | Patch from `Audit 10907`: removed three references to `docs/10920-cws-listing-corrections-2026-05-27.md` (at §3b.4, §10a, §18) (Closes #717). |
+| 1.0.7 | 2026-05-30 9:15:03 AM Central | Patch from `Audit 10907`: §3a.7 says directory does not exist; §7c notes byte/char count (Closes #713). |
+| 1.0.6 | 2026-05-30 12:15:15 AM Central | Patch: documented the Windows sandbox Playwright hang in §18 Troubleshooting. `MOZ_DISABLE_CONTENT_SANDBOX=1` workaround applied in `playwright.config.js`. |
+| 1.0.5 | 2026-05-29 11:26:54 AM Central | Patch: removed the "no live debug-tier console calls" clause from §3a.4 (Closes #691). |
+| 1.0.4 | 2026-05-29 12:57:37 AM Central | Patch: removed a redundant lead-in in §10b (Closes #689). |
+| 1.0.3 | 2026-05-29 12:41:37 AM Central | Patch: applied `Audit 10907` findings. §17c no longer passes the API secret on the command line. §15a refreshes the deployment-state version. §1 Path B / §3a.1 reference the deployment-state block (Closes #686, #687). |
+| 1.0.2 | 2026-05-29 12:18:55 AM Central | Patch: corrected timestamps that were UTC mislabeled as Central (Closes #684). |
+| 1.0.1 | 2026-05-28 08:05:10 PM Central | Patch: corrected deployment-state to state the live AMO version is `1.1.1`. Replaced `rm -f <glob>` artifact-clean with list-inspect-delete-by-name (Closes #682, #681). |
+| 1.0.0 | 2026-05-28 06:49:42 PM Central | New runbook, built to the AZ#1362 standard, split out of `10905-runbook-extension-store-publish.md` (Closes #678). |


### PR DESCRIPTION
## Summary

Major restructure of the AMO publishing runbook per operator end-to-end test. Three days of friction were caused by the runbook's structure, not by AMO. This rewrites it as a flat numbered checklist with explicit URLs, clicks, what-to-look-for, and what-to-do-if-it-fails on every step.

**Version bump 1.0.10 → 2.0.0** because section numbers move.

## New structure

| Section | Purpose |
|---|---|
| Front matter | Version, Last updated, Applies to. Three lines. |
| Deployment-state table | Just the table. |
| Agent invocation phrases | Reference. |
| §1–§10 | Flat numbered procedure for an update submission. |
| §11 | Listing field content (paste-ready). Byte-identical to former §7–§13. |
| §12 | First submission (Path A) — historical, brief. |
| §13–§17 | Reference: version bump, web-ext, troubleshooting, related, change log. |

## §1–§10 procedure

1. Sign in to AMO Developer Hub
2. Confirm the new version is not already uploaded
3. Agent: verify build prerequisites
4. Agent: build and verify the ZIP
5. Diff the live listing against §11 listing content
6. Upload the new ZIP
7. Overwrite drifted listing fields (only if §5 found drift)
8. Submit for review
9. AMO approves — operator action
10. Agent: post-publish

Every step names the URL, the click, what to look for, and what to do if it fails. §5 is a per-field comparison table. §7 names the dashboard editor surface for each field that might need overwriting.

## What's removed

Operator items that just say "you did the prior step" (former §3b.1, §3b.5). Misleading cross-references (former §3a.6 → §18 for release notes). Mis-categorized items (former §3a.5 web-ext lint runs in §4 build, not pre-build; former §3a.8 is output, not verification). Front-matter padding. §3 "Split by responsibility..." meta-procedural comment. §4 cleanup-agent anecdote. §4a "Known hardening gap" bug-commentary. Various Maintainer notes and decision-rationale histories.

## What stays the same

Listing paste-blocks (now §11a–§11l) byte-identical to former §7–§13. Deployment-state identifiers. Agent invocation phrases (descriptions updated to new section numbers).

## Test plan

```bash
grep -E "^> \*\*Version:" docs/runbooks/10907-runbook-amo-publish.md
# Expected: > **Version:** 2.0.0

grep -n "^# \|^## [0-9]" docs/runbooks/10907-runbook-amo-publish.md
# Expected: flat §1-§17

grep -F "Split by responsibility" docs/runbooks/10907-runbook-amo-publish.md
grep -F "Maintainer note" docs/runbooks/10907-runbook-amo-publish.md
# Expected: empty for both

grep -F "We do not enumerate, retain, transmit, or analyze data from tabs" \
  docs/runbooks/10907-runbook-amo-publish.md
# Expected: one match (the §11d Description paste-block, preserved)
```

Closes #726