### PR TITLE
chore(gitignore): add *.parked-* pattern for agent-parked files (Closes #733)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,9 @@ GTM/
 # Session logs — internal-only; never publish (added 2026-05-22 after exposure discovery, see #616)
 docs/session-logs/
 docs/dom-dumps/
+
+# Agent-parked files (mv $file $file.parked-{timestamp})
+# CLAUDE.md "Destroying uncommitted state" principle: agent uses
+# mv-to-bak instead of rm to preserve recoverability. *.bak is
+# already in the Logs section above; *.parked-* added per AZ #1425.
+*.parked-*


### PR DESCRIPTION
## Summary

- Adds `*.parked-*` to `.gitignore` for agent mv-to-bak artifacts.
- `*.bak` is already present in the Logs section.
- Part of AZ #1427 (fleet retrofit umbrella).

Closes #733