### PR TITLE
chore(GEMINI.md): remove blocking session-handshake/ACK

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,11 +1,5 @@
 # Gemini Operational Protocols
 
-## 1. Session Initialization (The Handshake)
-**CRITICAL:** When a session begins via `docs/GUIDE.md`:
-1.  **Analyze:** Silently parse the provided `git status` or issue context.
-2.  **Wait:** Do not proceed until the user replies (e.g., "3.0 Pro").
-3.  **Update Identity:** Incorporate the version into your Metadata Tag (e.g., `[Gemini 3.0 Pro...]`) for all future turns.
-
 ## 2. Execution Rules
 - **Authority:** `AgentOS:standards/0002-coding-standards` is the law for Git workflows.
 - **One Step Per Turn:** Provide one distinct step, then wait for confirmation.


### PR DESCRIPTION
Removes the `## Session Initialization (The Handshake)` section from GEMINI.md. It instructs the agent to emit an `ACK` and HALT until the user replies, which blocks the Antigravity CLI (`agy`) on auto-load. Operator-confirmed by direct test.

No-Issue: remove the blocking Gemini session-handshake/ACK from GEMINI.md -- it halts Antigravity CLI (agy) on auto-load. Operator-confirmed by direct test that agy prompts the ACK in repos that still carry it. Fleet consistency cleanup.