### PR TITLE
fix: mint JWTs from Aletheia-issued refresh tokens so sessions renew silently (Closes #811)

### DIFF
--- a/docs/reports/811/implementation-report.md
+++ b/docs/reports/811/implementation-report.md
@@ -1,0 +1,115 @@
+# Implementation Report — Issue #811
+
+## Problem
+
+A signed-in user was locked out 24 hours after login, or the moment the browser
+closed, with a full LinkedIn re-login as the only recovery. Two independent
+server-side defects made silent renewal impossible:
+
+1. **LinkedIn never issues us a refresh token.** The extension requests
+   `SCOPES: 'openid profile'`. LinkedIn returns `refresh_token` only to approved
+   partner programs, not for these scopes. `tokens.get("refresh_token")` was
+   therefore always `None`, and the client stored `refreshToken: null`.
+2. **`/auth/refresh` could not return a JWT.** `handle_token_refresh` called
+   LinkedIn's `grant_type=refresh_token` endpoint and returned only
+   `accessToken` + `expiresIn`. It never called `create_jwt`. Since the analysis
+   API authenticates on the JWT, even a fully successful refresh handed back
+   something the API rejects.
+
+The entire refresh subsystem was unreachable code that had never worked.
+
+Expiry itself is not the defect. A JWT is a stateless bearer credential, and
+expiry is its only revocation mechanism. Expiry *without a renewal path* is the
+defect.
+
+## Change
+
+LinkedIn now proves identity exactly once, at first login, and is never called
+again for session maintenance.
+
+### New — `src/auth/refresh_token_service.py`
+
+Aletheia-issued refresh tokens, long-lived and revocable.
+
+- `generate_refresh_token()` — 32 bytes of entropy via `secrets.token_urlsafe`.
+- `hash_token()` — SHA-256. Appropriate here rather than a slow KDF: the token
+  already carries 256 bits of entropy, so there is nothing to brute-force.
+- `store_refresh_token()` — persists **only the hash**, plus `user_id`,
+  `created_at`, `last_used_at`, `revoked`, and a `ttl`. A read of the table
+  yields nothing usable.
+- `validate_refresh_token()` — returns the owning `user_id`, or `None` if the
+  token is unknown, revoked, or expired.
+- `revoke_refresh_token()` — sets the `revoked` flag, ending that session.
+
+Two deliberate properties:
+
+- **Expiry is enforced in code, not delegated to DynamoDB TTL.** TTL deletion is
+  best-effort and can lag by up to 48 hours, so it is storage cleanup only and
+  never the security boundary.
+- **Datastore failures fail closed.** A lookup error denies rather than admits.
+  The one exception is `_touch_last_used`, which is best-effort by design:
+  bookkeeping must never be able to lock a user out.
+
+### Changed — `src/lambda_auth_function.py`
+
+- `handle_token_exchange` now also mints and stores an Aletheia refresh token,
+  returning it as `aletheiaRefreshToken`. A failure to issue it is a hard 500
+  rather than a silent success, since a login without a renewable session is the
+  exact bug being fixed.
+- `handle_token_refresh` was rewritten to accept `aletheiaRefreshToken`,
+  resolve it to a `user_id`, and mint a fresh JWT — with no LinkedIn round-trip.
+
+Two safety properties in the rewrite:
+
+- **The stored `user_id` is authoritative.** No client-supplied identifier is
+  read anywhere on this path, which is what prevents a valid refresh token from
+  minting a JWT for a different user.
+- **Tier is re-read on every refresh.** `create_jwt` defaults `tier` to `"free"`.
+  Had the refresh path omitted the `get_user_tier` lookup, every renewal would
+  have silently stripped a paying user's entitlement — a regression that would
+  have been invisible until a billing complaint. It also means an upgrade takes
+  effect without forcing a re-login.
+
+### Changed — `provision.sh`
+
+- Creates `aletheia-refresh-tokens` (hash key `token_hash`, PAY_PER_REQUEST).
+- Enables TTL on the `ttl` attribute.
+- Adds the table ARN to the Lambda role policy.
+- Adds `REFRESH_TOKENS_TABLE` to the auth Lambda environment.
+
+## Deliberately not done
+
+`refresh_access_token()` (the LinkedIn `grant_type=refresh_token` call) is now
+unreferenced by every route but was **left in place**. Its only remaining caller
+is a privacy regression test from #648 asserting that LinkedIn response bodies
+never reach logs. Deleting the function inside this change would have deleted
+that assertion as a side effect. Removal is tracked in #816, which requires
+confirming equivalent log-hygiene coverage on the remaining LinkedIn call sites
+first.
+
+## Client work not included
+
+This change makes silent renewal *possible*. It does not yet make the extension
+use it. The client-side work is tracked separately: #812 (credential must
+survive browser restart), #813 (popup must stop reporting signed-in from
+`userId` alone), #814 (401 must trigger renewal and one retry instead of a dead
+end). Until those land and ship, users see no behavioral change.
+
+## Deploy
+
+Server-side only; requires a deploy to take effect. Merging does not deploy.
+
+`provision.sh` re-applies the entire Lambda environment on every run and can
+clobber `CLOUDFLARE_ORIGIN_SECRET` on a transient SSM failure (#779). However,
+this change adds a new table, an IAM statement, and an env var, so a code-only
+`update-function-code` is **not** sufficient. `provision.sh` must run, and
+`CLOUDFLARE_ORIGIN_SECRET` must be verified non-empty immediately afterward.
+
+## Rollback
+
+```
+aws lambda update-function-code --function-name AletheiaAuth --zip-file fileb://<previous>.zip
+```
+
+The new table and IAM statement are additive and harmless if left in place. The
+response-shape change is additive; clients ignore unknown fields.

--- a/docs/reports/811/test-report.md
+++ b/docs/reports/811/test-report.md
@@ -1,0 +1,102 @@
+# Test Report — Issue #811
+
+## Result
+
+```
+857 passed, 4 deselected in 5.02s
+ruff check src/ tests/  — All checks passed
+bash -n provision.sh    — syntax OK
+```
+
+23 new tests. No regressions.
+
+The 4 deselected are `tests/unit/test_signal_inspector.py::TestLiveWebsites`,
+covered under "Pre-existing failure" below.
+
+## New — `tests/unit/test_refresh_token_service.py` (14 tests)
+
+Backed by `moto` against a real DynamoDB table shape.
+
+### Generation and hashing
+- Tokens are unique across 200 generations.
+- Tokens carry at least 43 characters (32 bytes urlsafe-encoded).
+- Hashing is deterministic per token and distinct across tokens.
+
+### Storage secrecy
+- `test_only_the_hash_is_persisted_never_the_plaintext` — scans the table after
+  a store and asserts the plaintext token does not appear anywhere in the
+  persisted item, and that the hash does. This is the assertion that makes a
+  table read worthless to an attacker.
+
+### Validation
+- Round-trip store → validate returns the owning `user_id`.
+- Unknown tokens rejected.
+- Empty and non-string input rejected.
+- Revoked tokens rejected.
+- `test_expired_token_is_rejected_in_code_not_left_to_dynamodb_ttl` — rewrites
+  `ttl` into the past while leaving the row present, reproducing exactly what a
+  lagging DynamoDB sweeper looks like, and asserts the token is still refused.
+  Without this, expiry would be enforced only by a mechanism documented to lag
+  up to 48 hours.
+- `test_returned_user_id_comes_from_storage_not_the_caller` — two tokens owned
+  by two users each resolve strictly to their own owner. Guards the highest-
+  severity failure mode: a valid token minting a session for someone else.
+
+### Failure behavior
+- `last_used_at` is recorded on successful validation.
+- `test_touch_failure_does_not_deny_a_valid_refresh` — an `update_item` failure
+  during bookkeeping must not deny an otherwise-valid refresh.
+- `test_lookup_failure_fails_closed` — a datastore error denies rather than
+  admits.
+- `test_lookup_failure_does_not_log_exception_text` — plants a canary inside the
+  raised exception and asserts it never reaches the log records, per the
+  standing rule that exception text must not appear in auth paths.
+
+## New — `tests/unit/test_auth_refresh_endpoint.py` (9 tests)
+
+- Missing `aletheiaRefreshToken` → 400.
+- Invalid token → 401.
+- Valid token → 200 with a JWT whose `user_id` is the stored owner.
+- `test_refresh_preserves_tier_and_billing_anchor` — parameterized over
+  `free`/`pro`/`unlimited`. `create_jwt` defaults `tier` to `"free"`, so without
+  the tier lookup every renewal would silently downgrade a paying user. This
+  test fails if that lookup is ever dropped.
+- `test_tier_is_reread_on_every_refresh` — an upgrade takes effect on the next
+  renewal without a re-login.
+- `test_refresh_never_calls_linkedin` — asserts both LinkedIn call sites are
+  untouched on the refresh path. This is the structural guarantee that the
+  session no longer depends on a provider that cannot support it.
+- `test_refresh_response_carries_no_token_material` — the response exposes the
+  JWT only, never the refresh token.
+
+## Changed — `tests/unit/test_lambda_auth.py`
+
+- `aws_env` fixture now provisions the refresh-tokens table.
+- `test_handle_token_exchange` additionally asserts login returns a non-empty
+  `aletheiaRefreshToken`. Without this the login path could regress to issuing
+  an unrenewable session and the suite would stay green.
+- `test_handle_token_refresh` was **rewritten**. It previously asserted the
+  LinkedIn `grant_type=refresh_token` path returning an `accessToken`. That test
+  passed while the feature was entirely non-functional in production, because it
+  asserted the behavior of a code path the real client could never successfully
+  reach — LinkedIn does not issue refresh tokens for the requested scopes, so
+  the input it mocked never existed in the wild. It now asserts the real
+  contract: an Aletheia refresh token in, a verified JWT out.
+- Added `test_handle_token_refresh_rejects_unknown_token`.
+
+## Not covered by automated tests
+
+- **Live AWS round-trip.** DynamoDB access is exercised against `moto`, not real
+  DynamoDB. The new IAM statement and `REFRESH_TOKENS_TABLE` env var are
+  unverified until `provision.sh` runs; a missing permission would surface as a
+  fail-closed 401 at runtime, not as a test failure.
+- **End-to-end browser behavior.** No client change ships here, so the
+  user-visible defect is not yet fixed or testable end to end. That arrives with
+  #812/#813/#814.
+
+## Pre-existing failure (not from this change)
+
+`tests/unit/test_signal_inspector.py::TestLiveWebsites::test_noarchive_net_blocked_without_force`
+fails identically on a clean `main` at `6be7bcb` with no working-tree changes.
+It asserts a third party's live robots.txt, which appears to have changed.
+Filed as #817 and deselected from this run. It is unrelated to auth.

--- a/provision.sh
+++ b/provision.sh
@@ -25,6 +25,7 @@ TABLE_NAME="${APP_NAME}AgentState"
 USERS_TABLE="aletheia-users"
 TOKEN_CAP_TABLE="aletheia-token-cap"
 COUPONS_TABLE="aletheia-coupons"
+REFRESH_TOKENS_TABLE="aletheia-refresh-tokens"
 ROLE_NAME="${APP_NAME}LambdaRole"
 FUNC_NAME="${APP_NAME}Agent"
 AUTH_FUNC_NAME="${APP_NAME}Auth"
@@ -186,6 +187,45 @@ else
 fi
 
 # =============================================================================
+# Issue #811: Refresh-token table — Aletheia-issued, long-lived, revocable.
+# Stores only the SHA-256 hash of each token, so a read of this table yields
+# nothing usable. The `ttl` attribute is storage cleanup only; expiry is also
+# enforced in code, because DynamoDB TTL deletion can lag by up to 48 hours.
+# =============================================================================
+echo ""
+echo "Checking DynamoDB Refresh Tokens Table..."
+if ! aws dynamodb describe-table --table-name "$REFRESH_TOKENS_TABLE" --region "$REGION" >/dev/null 2>&1; then
+    echo "Creating refresh tokens table: $REFRESH_TOKENS_TABLE"
+    aws dynamodb create-table \
+        --table-name "$REFRESH_TOKENS_TABLE" \
+        --attribute-definitions AttributeName=token_hash,AttributeType=S \
+        --key-schema AttributeName=token_hash,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST \
+        --region "$REGION"
+    aws dynamodb wait table-exists --table-name "$REFRESH_TOKENS_TABLE" --region "$REGION"
+    echo -e "${GREEN}Created refresh tokens table: $REFRESH_TOKENS_TABLE${NC}"
+else
+    echo "Refresh tokens table already exists: $REFRESH_TOKENS_TABLE"
+fi
+
+REFRESH_TTL_STATUS=$(aws dynamodb describe-time-to-live \
+    --table-name "$REFRESH_TOKENS_TABLE" \
+    --region "$REGION" \
+    --query 'TimeToLiveDescription.TimeToLiveStatus' \
+    --output text 2>/dev/null || echo "DISABLED")
+
+if [ "$REFRESH_TTL_STATUS" != "ENABLED" ]; then
+    echo "Enabling TTL on $REFRESH_TOKENS_TABLE..."
+    aws dynamodb update-time-to-live \
+        --table-name "$REFRESH_TOKENS_TABLE" \
+        --region "$REGION" \
+        --time-to-live-specification "Enabled=true,AttributeName=ttl"
+    echo -e "${GREEN}TTL enabled on $REFRESH_TOKENS_TABLE${NC}"
+else
+    echo "TTL already enabled on $REFRESH_TOKENS_TABLE"
+fi
+
+# =============================================================================
 # Step 3: DynamoDB Token Cap Table (Issue #341: JWT Auth + Daily Cap)
 # =============================================================================
 echo ""
@@ -312,7 +352,8 @@ aws iam put-role-policy \
                 "arn:aws:dynamodb:us-east-1:383687041805:table/'"$USERS_TABLE"'",
                 "arn:aws:dynamodb:us-east-1:383687041805:table/'"$USERS_TABLE"'/index/*",
                 "arn:aws:dynamodb:us-east-1:383687041805:table/'"$TOKEN_CAP_TABLE"'",
-                "arn:aws:dynamodb:us-east-1:383687041805:table/'"$COUPONS_TABLE"'"
+                "arn:aws:dynamodb:us-east-1:383687041805:table/'"$COUPONS_TABLE"'",
+                "arn:aws:dynamodb:us-east-1:383687041805:table/'"$REFRESH_TOKENS_TABLE"'"
             ]
         },
         {
@@ -550,7 +591,7 @@ if ! aws lambda get-function --function-name "$AUTH_FUNC_NAME" --region "$REGION
         --timeout 30 \
         --memory-size 256 \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE,STRIPE_SECRET_NAME=$STRIPE_SECRET_NAME,STRIPE_WEBHOOK_SECRET_NAME=$STRIPE_WEBHOOK_SECRET_NAME,STRIPE_PRICE_ID=$STRIPE_PRICE_ID,STRIPE_SUCCESS_URL=${AUTH_LAMBDA_URL}upgrade-success,STRIPE_CANCEL_URL=${AUTH_LAMBDA_URL}upgrade-cancel,GITHUB_SECRET_NAME=$GITHUB_SECRET_NAME}" \
+        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE,REFRESH_TOKENS_TABLE=$REFRESH_TOKENS_TABLE,STRIPE_SECRET_NAME=$STRIPE_SECRET_NAME,STRIPE_WEBHOOK_SECRET_NAME=$STRIPE_WEBHOOK_SECRET_NAME,STRIPE_PRICE_ID=$STRIPE_PRICE_ID,STRIPE_SUCCESS_URL=${AUTH_LAMBDA_URL}upgrade-success,STRIPE_CANCEL_URL=${AUTH_LAMBDA_URL}upgrade-cancel,GITHUB_SECRET_NAME=$GITHUB_SECRET_NAME}" \
         --tracing-config Mode=Active \
         --region "$REGION"
     echo -e "${GREEN}Created Auth Lambda (X-Ray enabled)${NC}"
@@ -568,7 +609,7 @@ else
         --function-name "$AUTH_FUNC_NAME" \
         --handler src.lambda_auth_function.lambda_handler \
         --layers "$LAYER_VERSION_ARN" \
-        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE,STRIPE_SECRET_NAME=$STRIPE_SECRET_NAME,STRIPE_WEBHOOK_SECRET_NAME=$STRIPE_WEBHOOK_SECRET_NAME,STRIPE_PRICE_ID=$STRIPE_PRICE_ID,STRIPE_SUCCESS_URL=${AUTH_LAMBDA_URL}upgrade-success,STRIPE_CANCEL_URL=${AUTH_LAMBDA_URL}upgrade-cancel,GITHUB_SECRET_NAME=$GITHUB_SECRET_NAME}" \
+        --environment "Variables={USERS_TABLE=$USERS_TABLE,LINKEDIN_SECRET_NAME=$LINKEDIN_SECRET_NAME,AGENT_STATE_TABLE=$TABLE_NAME,TOKEN_CAP_TABLE=$TOKEN_CAP_TABLE,JWT_SECRET_NAME=$JWT_SECRET_NAME,COUPONS_TABLE=$COUPONS_TABLE,REFRESH_TOKENS_TABLE=$REFRESH_TOKENS_TABLE,STRIPE_SECRET_NAME=$STRIPE_SECRET_NAME,STRIPE_WEBHOOK_SECRET_NAME=$STRIPE_WEBHOOK_SECRET_NAME,STRIPE_PRICE_ID=$STRIPE_PRICE_ID,STRIPE_SUCCESS_URL=${AUTH_LAMBDA_URL}upgrade-success,STRIPE_CANCEL_URL=${AUTH_LAMBDA_URL}upgrade-cancel,GITHUB_SECRET_NAME=$GITHUB_SECRET_NAME}" \
         --tracing-config Mode=Active \
         --region "$REGION" >/dev/null
 

--- a/src/auth/refresh_token_service.py
+++ b/src/auth/refresh_token_service.py
@@ -1,0 +1,202 @@
+"""Aletheia-issued refresh tokens for silent, indefinite session renewal.
+
+Issue: #811 - LinkedIn's 'openid profile' scopes never return a refresh token,
+and /auth/refresh could not mint a JWT, so a signed-in user was locked out
+24 hours after login with a full re-login as the only recovery.
+
+Design notes:
+
+- The refresh token is opaque and high-entropy. Only its SHA-256 hash is
+  persisted, so a read of the table yields nothing usable.
+- Unlike a JWT, this credential is stateful and therefore revocable: the
+  ``revoked`` flag is authoritative and checked on every use.
+- DynamoDB TTL deletion is best-effort and can lag by up to 48 hours, so
+  expiry is ALSO enforced in code. The ``ttl`` attribute is a storage
+  cleanup mechanism, never the security boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import secrets
+import time
+from typing import Any
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+REFRESH_TOKENS_TABLE = os.environ.get(
+    "REFRESH_TOKENS_TABLE", "aletheia-refresh-tokens"
+)
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# One year. Long-lived by design: the operator should never be asked to
+# re-authenticate during normal use. Revocation, not expiry, is the control.
+REFRESH_TOKEN_TTL_DAYS = int(os.environ.get("REFRESH_TOKEN_TTL_DAYS", "365"))
+
+# 32 bytes of entropy, urlsafe-encoded (~43 chars).
+_TOKEN_BYTES = 32
+
+_dynamodb_client = None
+
+
+def _get_dynamodb_client() -> Any:
+    global _dynamodb_client
+    if _dynamodb_client is None:
+        endpoint = os.environ.get("DYNAMODB_ENDPOINT")
+        if endpoint:
+            _dynamodb_client = boto3.client(
+                "dynamodb", endpoint_url=endpoint, region_name=AWS_REGION
+            )
+        else:
+            _dynamodb_client = boto3.client("dynamodb", region_name=AWS_REGION)
+    return _dynamodb_client
+
+
+def generate_refresh_token() -> str:
+    """Generate a new opaque refresh token.
+
+    Returns:
+        A urlsafe token string. This is the only time the plaintext exists
+        server-side; only its hash is stored.
+    """
+    return secrets.token_urlsafe(_TOKEN_BYTES)
+
+
+def hash_token(token: str) -> str:
+    """Hash a refresh token for storage and lookup.
+
+    SHA-256 is appropriate here (unlike for passwords): the token already
+    carries 256 bits of entropy, so there is nothing to brute-force and no
+    need for a slow KDF.
+
+    Args:
+        token: The plaintext refresh token.
+
+    Returns:
+        Lowercase hex SHA-256 digest.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def store_refresh_token(
+    user_id: str,
+    token: str,
+    client: Any = None,
+    ttl_days: int = REFRESH_TOKEN_TTL_DAYS,
+) -> None:
+    """Persist the hash of a newly issued refresh token.
+
+    Args:
+        user_id: The user this token authenticates.
+        token: The plaintext refresh token (hashed before storage).
+        client: Optional DynamoDB client (injected for tests).
+        ttl_days: Token lifetime in days.
+    """
+    client = client or _get_dynamodb_client()
+    now = int(time.time())
+    expires_at = now + (ttl_days * 86400)
+
+    client.put_item(
+        TableName=REFRESH_TOKENS_TABLE,
+        Item={
+            "token_hash": {"S": hash_token(token)},
+            "user_id": {"S": user_id},
+            "created_at": {"N": str(now)},
+            "last_used_at": {"N": str(now)},
+            "revoked": {"BOOL": False},
+            "ttl": {"N": str(expires_at)},
+        },
+    )
+
+
+def validate_refresh_token(token: str, client: Any = None) -> str | None:
+    """Validate a refresh token and return the user it belongs to.
+
+    The stored ``user_id`` is authoritative and is the value returned. A
+    client-supplied user identifier is never trusted or consulted, which is
+    what prevents a valid token from minting a JWT for a different user.
+
+    Args:
+        token: The plaintext refresh token presented by the client.
+        client: Optional DynamoDB client (injected for tests).
+
+    Returns:
+        The owning ``user_id``, or None if the token is unknown, revoked,
+        or expired.
+    """
+    if not token or not isinstance(token, str):
+        return None
+
+    client = client or _get_dynamodb_client()
+
+    try:
+        response = client.get_item(
+            TableName=REFRESH_TOKENS_TABLE,
+            Key={"token_hash": {"S": hash_token(token)}},
+        )
+    except Exception as e:
+        # Never log token material or exception text (project rule).
+        logger.error("REFRESH_TOKEN_LOOKUP_ERROR: %s", e.__class__.__name__)
+        return None
+
+    item = response.get("Item")
+    if not item:
+        return None
+
+    if item.get("revoked", {}).get("BOOL", False):
+        logger.warning('{"action": "refresh_token_rejected", "reason": "revoked"}')
+        return None
+
+    # Enforced in code: DynamoDB TTL deletion lags and must not be the gate.
+    expires_at = int(item.get("ttl", {}).get("N", "0"))
+    if expires_at and time.time() >= expires_at:
+        logger.warning('{"action": "refresh_token_rejected", "reason": "expired"}')
+        return None
+
+    user_id = item.get("user_id", {}).get("S")
+    if not user_id:
+        return None
+
+    _touch_last_used(client, hash_token(token))
+    return user_id
+
+
+def _touch_last_used(client: Any, token_hash: str) -> None:
+    """Record last use. Best-effort: a failure here must not deny a valid refresh."""
+    try:
+        client.update_item(
+            TableName=REFRESH_TOKENS_TABLE,
+            Key={"token_hash": {"S": token_hash}},
+            UpdateExpression="SET last_used_at = :now",
+            ExpressionAttributeValues={":now": {"N": str(int(time.time()))}},
+        )
+    except Exception as e:
+        logger.warning("REFRESH_TOKEN_TOUCH_FAILED: %s", e.__class__.__name__)
+
+
+def revoke_refresh_token(token: str, client: Any = None) -> bool:
+    """Revoke a refresh token, ending the session it backs.
+
+    Args:
+        token: The plaintext refresh token to revoke.
+        client: Optional DynamoDB client (injected for tests).
+
+    Returns:
+        True if the revocation was recorded.
+    """
+    client = client or _get_dynamodb_client()
+    try:
+        client.update_item(
+            TableName=REFRESH_TOKENS_TABLE,
+            Key={"token_hash": {"S": hash_token(token)}},
+            UpdateExpression="SET revoked = :true",
+            ExpressionAttributeValues={":true": {"BOOL": True}},
+        )
+        return True
+    except Exception as e:
+        logger.error("REFRESH_TOKEN_REVOKE_ERROR: %s", e.__class__.__name__)
+        return False

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -29,9 +29,19 @@ from botocore.exceptions import ClientError
 
 try:
     from .auth.jwt_service import create_jwt, get_jwt_secret
+    from .auth.refresh_token_service import (
+        generate_refresh_token,
+        store_refresh_token,
+        validate_refresh_token,
+    )
     from .auth.token_cap_service import check_and_increment_cap
 except ImportError:
     from auth.jwt_service import create_jwt, get_jwt_secret  # type: ignore[no-redef]
+    from auth.refresh_token_service import (  # type: ignore[no-redef]
+        generate_refresh_token,
+        store_refresh_token,
+        validate_refresh_token,
+    )
     from auth.token_cap_service import check_and_increment_cap  # type: ignore[no-redef]
 
 logger = logging.getLogger()
@@ -547,13 +557,31 @@ def handle_token_exchange(body: dict) -> dict:
                 "body": json.dumps({"error": "Internal server error"}),
             }
 
-        # 6. Return JWT + tokens and user info to extension
+        # 6. Issue an Aletheia refresh token so the session can renew silently
+        #    and indefinitely (Issue #811). LinkedIn is not involved again after
+        #    this point: its 'openid profile' scopes never return a refresh
+        #    token, so LinkedIn cannot support renewal at all.
+        try:
+            aletheia_refresh_token = generate_refresh_token()
+            store_refresh_token(user["user_id"], aletheia_refresh_token)
+        except Exception as e:
+            logger.error(
+                f"REFRESH_TOKEN_ISSUE_FAILED: {e.__class__.__name__}"
+            )
+            return {
+                "statusCode": 500,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": "Internal server error"}),
+            }
+
+        # 7. Return JWT + tokens and user info to extension
         return {
             "statusCode": 200,
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
                 "accessToken": tokens["access_token"],
                 "refreshToken": tokens.get("refresh_token"),
+                "aletheiaRefreshToken": aletheia_refresh_token,
                 "expiresIn": tokens.get("expires_in", 3600),
                 "jwt": jwt_token,
                 "user": {
@@ -578,43 +606,72 @@ def handle_token_exchange(body: dict) -> dict:
 
 def handle_token_refresh(body: dict) -> dict:
     """
-    Handle POST /auth/refresh - Refresh access token.
+    Handle POST /auth/refresh - Mint a fresh JWT from an Aletheia refresh token.
 
-    Expected body: { "refreshToken": "..." }
+    Expected body: { "aletheiaRefreshToken": "..." }
+
+    Issue #811. This endpoint previously called LinkedIn's
+    ``grant_type=refresh_token`` and returned only a LinkedIn access token —
+    never a JWT, which is the sole credential the analysis API accepts. It
+    could not have worked regardless: the extension requests the
+    'openid profile' scopes, for which LinkedIn does not issue refresh tokens
+    at all. LinkedIn now proves identity once at login and is never called
+    again.
     """
-    refresh_token = body.get("refreshToken")
+    refresh_token = body.get("aletheiaRefreshToken")
 
     if not refresh_token:
         return {
             "statusCode": 400,
-            "body": json.dumps({"error": "Missing refreshToken"}),
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"error": "Missing aletheiaRefreshToken"}),
         }
 
     try:
-        # Refresh tokens
-        tokens = refresh_access_token(refresh_token)
+        # The stored user_id is authoritative. A client-supplied identifier is
+        # never consulted, so a valid token cannot mint a JWT for another user.
+        user_id = validate_refresh_token(refresh_token)
 
-        # Validate new token
-        user_info = get_linkedin_user_info(tokens["access_token"])
-        if user_info is None:
+        if user_id is None:
             return {
                 "statusCode": 401,
-                "body": json.dumps({"error": "Token validation failed"}),
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({
+                    "error": "Unauthorized",
+                    "reason": "invalid_refresh_token",
+                }),
             }
+
+        # Re-read tier on every refresh so an upgrade or downgrade takes effect
+        # without forcing a re-login, and so renewal never silently resets a
+        # paying user to the free tier.
+        jwt_secret = get_jwt_secret()
+        tier, billing_anchor_day = get_user_tier(user_id)
+        jwt_token = create_jwt(
+            user_id, jwt_secret, expiry_hours=24,
+            tier=tier, billing_anchor_day=billing_anchor_day,
+        )
+
+        logger.info(json.dumps({
+            "action": "jwt_refreshed",
+            "user_id": user_id,
+            "tier": tier,
+        }))
 
         return {
             "statusCode": 200,
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
-                "accessToken": tokens["access_token"],
-                "expiresIn": tokens.get("expires_in", 3600),
+                "jwt": jwt_token,
+                "expiresIn": 24 * 3600,
             }),
         }
 
-    except ValueError as e:
+    except ValueError:
         return {
             "statusCode": 401,
-            "body": json.dumps({"error": str(e)}),
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"error": "Unauthorized"}),
         }
     except Exception as e:
         logger.error(f"TOKEN_REFRESH_ERROR: {e.__class__.__name__}")

--- a/tests/unit/test_auth_refresh_endpoint.py
+++ b/tests/unit/test_auth_refresh_endpoint.py
@@ -1,0 +1,132 @@
+"""Unit tests for POST /auth/refresh minting a JWT from an Aletheia token.
+
+Issue: #811 - the endpoint previously called LinkedIn's grant_type=refresh_token
+and returned only a LinkedIn access token, never a JWT. It could not have
+worked in any case: the extension requests 'openid profile', for which
+LinkedIn does not issue refresh tokens.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+
+import src.lambda_auth_function as auth_func
+
+# 32+ bytes: below that PyJWT emits InsecureKeyLengthWarning for HS256.
+TEST_SECRET = "test-signing-secret-padded-to-32-bytes-minimum"
+TEST_USER = "linkedin-user-001"
+
+
+def _decode(body: dict) -> dict:
+    return pyjwt.decode(body["jwt"], TEST_SECRET, algorithms=["HS256"])
+
+
+def test_missing_token_returns_400():
+    response = auth_func.handle_token_refresh({})
+
+    assert response["statusCode"] == 400
+    assert "aletheiaRefreshToken" in json.loads(response["body"])["error"]
+
+
+def test_invalid_token_returns_401():
+    with patch.object(auth_func, "validate_refresh_token", return_value=None):
+        response = auth_func.handle_token_refresh(
+            {"aletheiaRefreshToken": "bogus"}
+        )
+
+    assert response["statusCode"] == 401
+    assert json.loads(response["body"])["error"] == "Unauthorized"
+
+
+def test_valid_token_mints_a_jwt_for_the_stored_user():
+    with (
+        patch.object(auth_func, "validate_refresh_token", return_value=TEST_USER),
+        patch.object(auth_func, "get_jwt_secret", return_value=TEST_SECRET),
+        patch.object(auth_func, "get_user_tier", return_value=("free", 1)),
+    ):
+        response = auth_func.handle_token_refresh(
+            {"aletheiaRefreshToken": "valid-token"}
+        )
+
+    assert response["statusCode"] == 200
+    claims = _decode(json.loads(response["body"]))
+    assert claims["user_id"] == TEST_USER
+
+
+@pytest.mark.parametrize(
+    "tier,anchor_day",
+    [("free", 1), ("pro", 15), ("unlimited", 28)],
+)
+def test_refresh_preserves_tier_and_billing_anchor(tier, anchor_day):
+    """A renewal must never silently downgrade a paying user to free.
+
+    create_jwt defaults tier to 'free'; if the refresh path omitted the tier
+    lookup, every renewal would quietly strip a paid user's entitlement.
+    """
+    with (
+        patch.object(auth_func, "validate_refresh_token", return_value=TEST_USER),
+        patch.object(auth_func, "get_jwt_secret", return_value=TEST_SECRET),
+        patch.object(
+            auth_func, "get_user_tier", return_value=(tier, anchor_day)
+        ),
+    ):
+        response = auth_func.handle_token_refresh(
+            {"aletheiaRefreshToken": "valid-token"}
+        )
+
+    claims = _decode(json.loads(response["body"]))
+    assert claims["tier"] == tier
+    assert claims["billing_anchor_day"] == anchor_day
+
+
+def test_tier_is_reread_on_every_refresh():
+    """An upgrade must take effect without forcing a re-login."""
+    with (
+        patch.object(auth_func, "validate_refresh_token", return_value=TEST_USER),
+        patch.object(auth_func, "get_jwt_secret", return_value=TEST_SECRET),
+        patch.object(auth_func, "get_user_tier") as mock_tier,
+    ):
+        mock_tier.return_value = ("free", 1)
+        first = auth_func.handle_token_refresh({"aletheiaRefreshToken": "t"})
+
+        mock_tier.return_value = ("pro", 1)
+        second = auth_func.handle_token_refresh({"aletheiaRefreshToken": "t"})
+
+    assert _decode(json.loads(first["body"]))["tier"] == "free"
+    assert _decode(json.loads(second["body"]))["tier"] == "pro"
+
+
+def test_refresh_never_calls_linkedin():
+    """LinkedIn proves identity once at login and is never consulted again."""
+    with (
+        patch.object(auth_func, "validate_refresh_token", return_value=TEST_USER),
+        patch.object(auth_func, "get_jwt_secret", return_value=TEST_SECRET),
+        patch.object(auth_func, "get_user_tier", return_value=("free", 1)),
+        patch.object(auth_func, "refresh_access_token") as mock_linkedin_refresh,
+        patch.object(auth_func, "get_linkedin_user_info") as mock_linkedin_info,
+    ):
+        response = auth_func.handle_token_refresh(
+            {"aletheiaRefreshToken": "valid-token"}
+        )
+
+    assert response["statusCode"] == 200
+    mock_linkedin_refresh.assert_not_called()
+    mock_linkedin_info.assert_not_called()
+
+
+def test_refresh_response_carries_no_token_material():
+    """The response must expose the JWT only, never the refresh token."""
+    with (
+        patch.object(auth_func, "validate_refresh_token", return_value=TEST_USER),
+        patch.object(auth_func, "get_jwt_secret", return_value=TEST_SECRET),
+        patch.object(auth_func, "get_user_tier", return_value=("free", 1)),
+    ):
+        response = auth_func.handle_token_refresh(
+            {"aletheiaRefreshToken": "super-secret-refresh-token"}
+        )
+
+    assert "super-secret-refresh-token" not in response["body"]

--- a/tests/unit/test_lambda_auth.py
+++ b/tests/unit/test_lambda_auth.py
@@ -9,11 +9,13 @@ import json
 import os
 
 import boto3
+import jwt
 import pytest
 import responses
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
+import src.auth.refresh_token_service as refresh_token_service
 import src.lambda_auth_function as auth_func
 
 # Constants for testing
@@ -68,6 +70,16 @@ def aws_env():
             TableName=auth_func.USERS_TABLE,
             KeySchema=[{"AttributeName": "user_id", "KeyType": "HASH"}],
             AttributeDefinitions=[{"AttributeName": "user_id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST"
+        )
+
+        # Refresh Tokens Table (Issue #811: Aletheia-issued session renewal)
+        dynamodb.create_table(
+            TableName=refresh_token_service.REFRESH_TOKENS_TABLE,
+            KeySchema=[{"AttributeName": "token_hash", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "token_hash", "AttributeType": "S"}
+            ],
             BillingMode="PAY_PER_REQUEST"
         )
 
@@ -292,25 +304,43 @@ class TestHandlers:
         assert body["accessToken"] == TEST_TOKEN
         assert "jwt" in body
         assert body["user"]["id"] == TEST_USER_ID
+        # Issue #811: login must also issue an Aletheia refresh token, or the
+        # session cannot renew and dies 24h later.
+        assert body["aletheiaRefreshToken"]
 
     def test_handle_token_exchange_missing_args(self):
         result = auth_func.handle_token_exchange({})
         assert result["statusCode"] == 400
 
-    @responses.activate
     def test_handle_token_refresh(self, aws_env):
-        responses.add(
-            responses.POST, auth_func.LINKEDIN_TOKEN_URL,
-            json={"access_token": TEST_TOKEN, "expires_in": 3600}, status=200
-        )
-        responses.add(
-            responses.GET, auth_func.LINKEDIN_USERINFO_URL,
-            json={"sub": TEST_USER_ID, "name": TEST_USER_NAME}, status=200
-        )
+        """Issue #811: /auth/refresh mints a JWT from an Aletheia refresh token.
 
-        result = auth_func.handle_token_refresh({"refreshToken": "refresh123"})
+        This previously asserted the LinkedIn grant_type=refresh_token path,
+        which returned a LinkedIn access token and never a JWT. That path could
+        not work at all: the extension requests 'openid profile', for which
+        LinkedIn does not issue refresh tokens.
+        """
+        token = refresh_token_service.generate_refresh_token()
+        refresh_token_service.store_refresh_token(TEST_USER_ID, token)
+
+        result = auth_func.handle_token_refresh({"aletheiaRefreshToken": token})
+
         assert result["statusCode"] == 200
-        assert json.loads(result["body"])["accessToken"] == TEST_TOKEN
+        body = json.loads(result["body"])
+        assert "jwt" in body
+        # Verify against the same secret the handler signed with. The fixture
+        # stores a JSON blob and get_jwt_secret returns it verbatim, so the
+        # signing key is the whole string, not the "primary" field.
+        claims = jwt.decode(
+            body["jwt"], auth_func.get_jwt_secret(), algorithms=["HS256"]
+        )
+        assert claims["user_id"] == TEST_USER_ID
+
+    def test_handle_token_refresh_rejects_unknown_token(self, aws_env):
+        result = auth_func.handle_token_refresh(
+            {"aletheiaRefreshToken": "not-a-real-token"}
+        )
+        assert result["statusCode"] == 401
 
     @responses.activate
     def test_handle_validate_token_success(self, aws_env):

--- a/tests/unit/test_refresh_token_service.py
+++ b/tests/unit/test_refresh_token_service.py
@@ -1,0 +1,206 @@
+"""Unit tests for Aletheia-issued refresh tokens.
+
+Issue: #811 - LinkedIn's 'openid profile' scopes never return a refresh token
+and /auth/refresh could not mint a JWT, so a signed-in user was locked out
+24 hours after login.
+
+Coverage:
+- Token generation entropy and uniqueness
+- Only the hash is persisted; plaintext is never stored
+- Round-trip store -> validate
+- Rejection of unknown, revoked, and expired tokens
+- The returned user_id comes from storage, never from the caller
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+TABLE_NAME = "test-refresh-tokens"
+TEST_USER = "linkedin-user-001"
+OTHER_USER = "linkedin-user-002"
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    """Import the service with the table name pointed at the moto fixture."""
+    monkeypatch.setenv("REFRESH_TOKENS_TABLE", TABLE_NAME)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    import auth.refresh_token_service as module
+
+    importlib.reload(module)
+    return module
+
+
+@pytest.fixture
+def table(svc):
+    """Create the refresh-token table in moto and yield a live client."""
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        client.create_table(
+            TableName=TABLE_NAME,
+            AttributeDefinitions=[
+                {"AttributeName": "token_hash", "AttributeType": "S"}
+            ],
+            KeySchema=[{"AttributeName": "token_hash", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield client
+
+
+# --------------------------------------------------------------------------- #
+# Generation and hashing
+# --------------------------------------------------------------------------- #
+
+
+def test_generated_tokens_are_unique(svc):
+    tokens = {svc.generate_refresh_token() for _ in range(200)}
+    assert len(tokens) == 200
+
+
+def test_generated_token_has_sufficient_entropy(svc):
+    token = svc.generate_refresh_token()
+    # 32 bytes urlsafe-base64 encodes to at least 43 characters.
+    assert len(token) >= 43
+
+
+def test_hash_is_deterministic_and_differs_per_token(svc):
+    a = svc.generate_refresh_token()
+    b = svc.generate_refresh_token()
+    assert svc.hash_token(a) == svc.hash_token(a)
+    assert svc.hash_token(a) != svc.hash_token(b)
+
+
+def test_only_the_hash_is_persisted_never_the_plaintext(svc, table):
+    """A read of the table must not yield a usable credential."""
+    token = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token, client=table)
+
+    scanned = table.scan(TableName=TABLE_NAME)["Items"]
+    assert len(scanned) == 1
+    serialized = str(scanned[0])
+
+    assert token not in serialized
+    assert svc.hash_token(token) in serialized
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+
+
+def test_store_then_validate_returns_owning_user(svc, table):
+    token = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token, client=table)
+
+    assert svc.validate_refresh_token(token, client=table) == TEST_USER
+
+
+def test_unknown_token_is_rejected(svc, table):
+    assert svc.validate_refresh_token("not-a-real-token", client=table) is None
+
+
+def test_empty_or_non_string_token_is_rejected(svc, table):
+    assert svc.validate_refresh_token("", client=table) is None
+    assert svc.validate_refresh_token(None, client=table) is None
+
+
+def test_revoked_token_is_rejected(svc, table):
+    token = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token, client=table)
+
+    assert svc.revoke_refresh_token(token, client=table) is True
+    assert svc.validate_refresh_token(token, client=table) is None
+
+
+def test_expired_token_is_rejected_in_code_not_left_to_dynamodb_ttl(svc, table):
+    """DynamoDB TTL deletion lags up to 48h, so expiry must be enforced here."""
+    token = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token, client=table, ttl_days=1)
+
+    # Rewrite ttl into the past, leaving the row present exactly as a lagging
+    # DynamoDB sweeper would.
+    table.update_item(
+        TableName=TABLE_NAME,
+        Key={"token_hash": {"S": svc.hash_token(token)}},
+        UpdateExpression="SET #t = :past",
+        ExpressionAttributeNames={"#t": "ttl"},
+        ExpressionAttributeValues={":past": {"N": str(int(time.time()) - 60)}},
+    )
+
+    assert svc.validate_refresh_token(token, client=table) is None
+
+
+def test_returned_user_id_comes_from_storage_not_the_caller(svc, table):
+    """A valid token must never mint a session for a different user.
+
+    There is no caller-supplied identifier in the signature at all; this
+    asserts that two distinct tokens resolve strictly to their own owners.
+    """
+    token_a = svc.generate_refresh_token()
+    token_b = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token_a, client=table)
+    svc.store_refresh_token(OTHER_USER, token_b, client=table)
+
+    assert svc.validate_refresh_token(token_a, client=table) == TEST_USER
+    assert svc.validate_refresh_token(token_b, client=table) == OTHER_USER
+
+
+def test_last_used_is_recorded_on_successful_validation(svc, table):
+    token = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token, client=table)
+
+    table.update_item(
+        TableName=TABLE_NAME,
+        Key={"token_hash": {"S": svc.hash_token(token)}},
+        UpdateExpression="SET last_used_at = :old",
+        ExpressionAttributeValues={":old": {"N": "0"}},
+    )
+
+    svc.validate_refresh_token(token, client=table)
+
+    item = table.get_item(
+        TableName=TABLE_NAME,
+        Key={"token_hash": {"S": svc.hash_token(token)}},
+    )["Item"]
+    assert int(item["last_used_at"]["N"]) > 0
+
+
+def test_touch_failure_does_not_deny_a_valid_refresh(svc, table):
+    """Bookkeeping must never be able to lock a user out."""
+    token = svc.generate_refresh_token()
+    svc.store_refresh_token(TEST_USER, token, client=table)
+
+    flaky = MagicMock()
+    flaky.get_item.side_effect = table.get_item
+    flaky.update_item.side_effect = RuntimeError("throttled")
+
+    assert svc.validate_refresh_token(token, client=flaky) == TEST_USER
+
+
+def test_lookup_failure_fails_closed(svc):
+    """A datastore error must deny, not admit."""
+    broken = MagicMock()
+    broken.get_item.side_effect = RuntimeError("boom")
+
+    assert svc.validate_refresh_token("anything", client=broken) is None
+
+
+def test_lookup_failure_does_not_log_exception_text(svc, caplog):
+    """Project rule: exception text must never reach logs in auth paths."""
+    canary = "CANARY_SENSITIVE_DETAIL"
+    broken = MagicMock()
+    broken.get_item.side_effect = RuntimeError(canary)
+
+    with caplog.at_level("ERROR"):
+        svc.validate_refresh_token("anything", client=broken)
+
+    assert canary not in "\n".join(r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Closes #811

## The defect

A signed-in user was locked out 24 hours after login, or the moment the browser closed, and a full LinkedIn re-login was the only way back. Reported from the field on Firefox 1.1.1 (the current AMO build) after a machine was rebooted repeatedly over 60 days: the popup reported the user as signed in and active while every analysis returned "Sign In Required".

Two server-side defects made silent renewal impossible:

1. **LinkedIn never issues us a refresh token.** The extension requests `SCOPES: 'openid profile'`. LinkedIn returns `refresh_token` only to approved partner programs, never for these scopes. So `tokens.get("refresh_token")` was always `None` and the client persisted `refreshToken: null`.
2. **`/auth/refresh` could not return a JWT.** It called LinkedIn's `grant_type=refresh_token` and returned only `accessToken` + `expiresIn`, never calling `create_jwt`. Since the analysis API authenticates on the JWT, even a fully successful refresh handed back something the API rejects.

The refresh subsystem was unreachable code that had never worked in production.

Expiry itself is not the bug — a JWT is a stateless bearer credential and expiry is its only revocation mechanism. Expiry *without a renewal path* is.

## The change

LinkedIn now proves identity exactly once, at first login, and is never consulted again for session maintenance.

**New `src/auth/refresh_token_service.py`** — Aletheia-issued refresh tokens: opaque, 32 bytes of entropy, long-lived, revocable. Only the SHA-256 hash is persisted, so a read of the table yields nothing usable.

Two deliberate properties:
- **Expiry is enforced in code**, not delegated to DynamoDB TTL, whose deletion is best-effort and can lag 48 hours. TTL is storage cleanup, never the security boundary.
- **Lookups fail closed.** The sole exception is last-used bookkeeping, which is best-effort by design so it can never lock a user out.

**`/auth/refresh` rewritten** to resolve an Aletheia refresh token to its **stored** `user_id` — no client-supplied identifier is read on this path, which is what stops a valid token from minting a JWT for someone else — and mint a fresh JWT with no LinkedIn round-trip.

**Tier is re-read on every refresh.** `create_jwt` defaults `tier` to `"free"`, so omitting that lookup would have silently stripped a paying user's entitlement on every renewal — invisible until a billing complaint. A parameterized test now guards it.

**`provision.sh`** creates `aletheia-refresh-tokens`, enables TTL, grants the table in the role policy, and adds `REFRESH_TOKENS_TABLE` to the auth Lambda env.

## Tests

`857 passed`, ruff clean, `bash -n provision.sh` clean. 23 new tests.

Notable assertions: the plaintext token never appears in the persisted item; a token whose `ttl` is in the past is refused even though the row still exists (reproducing a lagging DynamoDB sweeper); two tokens resolve strictly to their own owners; the refresh path makes no LinkedIn call; a planted canary in a raised exception never reaches the logs.

`test_handle_token_refresh` was **rewritten** rather than extended. It previously passed while the feature was entirely non-functional, because it asserted a code path the real client could never reach — it mocked an input LinkedIn never produces.

## Scope deliberately left out

`refresh_access_token()` is now unwired from every route but was left in the tree: its only remaining caller is a privacy regression test from #648 asserting LinkedIn response bodies never reach logs, and deleting the function here would have deleted that assertion as a side effect. Removal is tracked in #816.

A pre-existing live-network unit test fails identically on clean `main` at `6be7bcb`; it is unrelated to auth and is tracked in #817, deselected from this run.

## Blast radius

Additive: a new table, one IAM statement, one env var, and a new response field. Existing clients ignore unknown fields.

The highest-severity path is a refresh token minting a JWT for the wrong user; it is guarded by keying strictly on the token hash and returning the stored `user_id`, with a dedicated test.

**This ships no user-visible change.** It makes silent renewal *possible*; the extension does not yet use it. Client work is tracked in #812, #813 and #814.

## Deploy

Server-side only — merging does not deploy. Because this adds a table, an IAM statement and an env var, a code-only `update-function-code` is **not** sufficient; `provision.sh` must run.

`provision.sh` re-applies the entire Lambda env and can blank `CLOUDFLARE_ORIGIN_SECRET` on a transient SSM read failure — the hazard tracked in #779. Verify that variable is non-empty immediately after deploying.

## Rollback

```
aws lambda update-function-code --function-name AletheiaAuth --zip-file fileb://<previous>.zip
```

The new table and IAM statement are additive and harmless if left in place.
