### PR TITLE
fix: persist the session and renew it silently so the extension stops locking users out (Closes #812, Closes #813, Closes #814)

### DIFF
--- a/docs/reports/812/implementation-report.md
+++ b/docs/reports/812/implementation-report.md
@@ -1,0 +1,102 @@
+# Implementation Report — Issues #812, #813, #814
+
+## Problem
+
+Field report on Firefox 1.1.1 (the current AMO build), on a machine rebooted
+repeatedly over 60 days: the popup showed the user signed in and Aletheia
+"ACTIVE", while every analysis on the page returned "Sign In Required". The only
+recovery was a manual logout and re-login, and it recurred.
+
+Three client defects combined to produce that.
+
+**#812 — the credential did not survive a restart.** `storeTokens` wrote the JWT
+to `storage.session`, which the browser clears on close, while identity
+(`userId`, `displayName`) went to `storage.local`, which persists forever.
+Closing the browser destroyed the only credential the API accepts and left
+every field the popup inspects intact.
+
+**#813 — the popup reported a session that did not exist.** `getAuthState`
+returned "signed in" whenever `userId` was present. That value never expires and
+has no relationship to whether any request can succeed, so the popup asserted an
+active session indefinitely. This is what made the failure undiagnosable from
+the UI: the thing that was broken was reported as fine.
+
+**#814 — a recoverable condition was presented as terminal.** `getAuthHeaders`
+read the JWT, found nothing, and dispatched the request anyway with no
+`Authorization` header — a request it knew would fail. No 401 handler attempted
+renewal. The 401 mapped straight to a terminal "Sign In Required".
+
+## Change
+
+Applied to both `extensions/chrome/` and `extensions/firefox/`.
+
+### Persistence (#812)
+
+The Aletheia refresh token from #811 is stored in `storage.local`, so it
+survives restarts and reboots. The JWT remains in `storage.session`: it is
+short-lived, and with the refresh token persisted a cold start simply re-mints
+it. `jwtExpiresAt` is now stored alongside the JWT — without it, freshness is
+unknowable and every request path has to guess.
+
+`storeTokens` only overwrites a stored refresh token when a new one was actually
+issued, so a re-login that omits it cannot silently strip renewal ability.
+
+### Honest auth state (#813)
+
+`getAuthState` now requires `userId` **and** a stored refresh token. Being
+authenticated means "a credential is obtainable", not "a name is remembered".
+Added `isSessionUnrecoverable()` so the UI can distinguish "signed out" from
+"identity remembered but the session is dead" and say so honestly.
+
+### Renewal and recovery (#814)
+
+- `getValidJwt()` is the only accessor a request path may use. It returns the
+  cached JWT while fresh, otherwise renews silently.
+- `renewJwt()` shares one in-flight promise across concurrent callers. Several
+  extension contexts hit this simultaneously on a cold start; N parallel
+  renewals would multiply load on the auth Lambda for no benefit.
+- `getAuthHeaders()` returns `null` when no credential is obtainable, and
+  callers must not dispatch. It no longer sends a request known to 401.
+- `authedPost()` retries **exactly once** after renewing on a 401. No loop, no
+  recursion — a renewal storm would turn a transient failure into an outage.
+  It forwards caller fetch options (Chrome's 30s abort signal) to both the
+  initial request and the retry, so a caller's timeout still governs the retry.
+
+### Failure handling
+
+A 401 from `/auth/refresh` means the refresh token is revoked or expired:
+renewal can never succeed again, so the token is dropped and a real sign-in is
+required. **Any other outcome — 5xx, or a thrown network error — retains the
+token.** Discarding it on a transient blip would force a re-login over a
+momentary outage, which is the class of failure this work exists to remove.
+
+## Migration
+
+An existing signed-in user upgrading to this build has a JWT but no
+`jwtExpiresAt` and no refresh token. A strict freshness check would have logged
+out every current user.
+
+`getValidJwt` therefore falls back to the cached JWT when renewal is impossible
+and a JWT is present: its validity is unknown but plausible, so it is used and
+the 401 path decides. That converts a guaranteed forced re-login into one that
+happens only if the token has genuinely expired.
+
+## Version
+
+Both manifests bumped to **1.1.3**.
+
+## Not included
+
+- **#815** (opaque 401 discriminator) is server-side and tracked separately.
+  The client currently infers intent from the 401 status alone, which is
+  sufficient because renewal is attempted before any sign-in prompt.
+- The Firefox and Chrome service workers cannot import `auth.js`, so each
+  carries its own copy of the renewal logic. The shared contract is the
+  `/auth/refresh` payload. This duplication is a known cost of the MV3 worker
+  boundary, not an oversight.
+
+## Deploy
+
+Extension-only; requires no AWS change. The server half (#811) is already
+deployed and verified in production. Reaching users requires a store upload —
+AMO is tracked in #559.

--- a/docs/reports/812/test-report.md
+++ b/docs/reports/812/test-report.md
@@ -1,0 +1,104 @@
+# Test Report — Issues #812, #813, #814
+
+## Result
+
+```
+379 passed | 4 skipped (383)
+npx eslint extensions/ tests/unit/ tests/mocks/  — clean
+node --check on all 6 modified extension files  — clean
+```
+
+Up from 357 passing before this change. No regressions.
+
+## New — `tests/unit/chrome/session-persistence.test.js` (10 tests)
+
+### Persistence (#812)
+- `survives a simulated browser restart with no user interaction` — clears
+  session storage exactly as a restart does, leaves local storage intact, and
+  asserts a JWT is obtained with no user action. This is the reported defect,
+  reproduced and pinned.
+- `persists the refresh token to LOCAL storage, not session storage` — asserts
+  the credential is recoverable after session storage is emptied.
+
+### Honest auth state (#813)
+- `does NOT report a session when identity remains but renewal is impossible` —
+  seeds precisely the field-reported state (display name present, credential
+  gone) and asserts `getAuthState()` is null, `isAuthenticated()` is false, and
+  `isSessionUnrecoverable()` is true. This is the assertion that fails if the
+  popup ever again claims a session it cannot back.
+- `reports a session when identity AND a refresh token are present`.
+
+### Renewal and failure handling (#814)
+- `issues ONE renewal when several callers race on a cold start` — three
+  concurrent `getValidJwt()` calls produce exactly one network round-trip and
+  all three receive the same JWT.
+- `drops the refresh token on 401 so a revoked session stops retrying`.
+- `KEEPS the refresh token on a transient failure` (503) — discarding it would
+  force a re-login over a momentary outage.
+- `KEEPS the refresh token when the network throws`.
+- `sends the Aletheia refresh token, never LinkedIn's` — asserts the request
+  body carries `aletheiaRefreshToken` and no `refreshToken`. LinkedIn cannot
+  refresh the `openid profile` scopes, so sending its token would 401.
+- `logout clears the refresh token so the session cannot resurrect`.
+
+## New — in `tests/unit/firefox/service-worker.test.js`
+
+- `dispatches NO request when no credential can be obtained` — pins the #814
+  guarantee directly. Previously the worker sent the request with no
+  `Authorization` header, guaranteeing a 401, and surfaced that as terminal.
+
+## Changed — test doubles
+
+`tests/mocks/chrome-api.mock.js` and `firefox-api.mock.js`: the
+`authenticated: true` fixture now includes `aletheiaRefreshToken` in local
+storage and `jwt` + `jwtExpiresAt` in session storage. The previous fixture
+modelled a user who *looked* signed in but held nothing that could authenticate
+a request — the defective state itself, used as the definition of "authenticated"
+across the suite.
+
+## Changed — tests that encoded the old contract
+
+These asserted the behavior being fixed and were **rewritten, not deleted**:
+
+- `isAuthenticated returns true when userId exists` (chrome + firefox) — the
+  literal statement of the #813 defect. Now requires a renewable session.
+- `getAccessToken returns token when valid`, `returns cached token when not
+  expired`, `attempts refresh when token is expired`, `getAccessToken returns
+  null when no refresh token` — all four targeted the LinkedIn access-token
+  refresh path, which #811 established has never worked (LinkedIn issues no
+  refresh token for `openid profile`). Retargeted at `getValidJwt`, and the
+  expired-token case now additionally asserts the renewal request carries
+  `aletheiaRefreshToken` and that the caller receives the renewed credential.
+- `exports required auth functions` — `getAccessToken` removed; `getValidJwt`,
+  `renewJwt`, `isSessionUnrecoverable` asserted instead.
+
+### One vacuous test repaired
+
+`includes X-Aletheia-Client-Version header in API requests` wrapped its
+assertion in `if (fetchCall)`. When no request was dispatched, the test passed
+having asserted nothing — so it would not have caught this change breaking the
+request path. It now asserts unconditionally that a request was made, that the
+version header is present, and that an `Authorization` header was attached.
+
+## Not covered by automated tests
+
+- **A real browser restart.** The restart is simulated by clearing the session
+  storage double. Nothing here proves Firefox's `storage.session` behaves as
+  modelled, or that `storage.local` survives on this machine. That is the one
+  thing only a manual test can establish, and it is the exact scenario reported.
+- **End-to-end against production.** The tests mock `fetch`; no test exercises
+  the deployed `/auth/refresh`. The endpoint was verified live by hand during
+  the #811 deploy (`{"error": "Unauthorized", "reason": "invalid_refresh_token"}`
+  for a garbage token), but the client-to-server round-trip on a real login is
+  unverified until the build is installed.
+- **Chrome parity is asserted structurally, not behaviorally.** The dedicated
+  session tests run against `extensions/chrome/auth.js`. The Firefox module is
+  a `browser.*` transliteration and its own suite passes, but the ten new
+  assertions execute only against the Chrome copy.
+
+## Pre-existing failures (not from this change)
+
+- `npx eslint tests/e2e/` reports 9 `no-unused-vars` errors identically on clean
+  `main`. Filed as #820. Files not touched here.
+- `tests/unit/test_signal_inspector.py::TestLiveWebsites` fails locally against
+  live `noarchive.net`; filed as #817. Passes in CI.

--- a/extensions/chrome/auth.js
+++ b/extensions/chrome/auth.js
@@ -39,33 +39,62 @@ function generateState() {
 }
 
 // =============================================================================
+// SESSION LIFETIME (Issues #811, #812, #814)
+// =============================================================================
+
+// Server mints JWTs with a 24h life. Mirrored here only to schedule renewal;
+// the server's `expiresIn` is preferred whenever the response carries one.
+const JWT_LIFETIME_SECONDS = 24 * 3600;
+
+// Renew this far ahead of expiry so an in-flight request cannot race the
+// boundary and arrive just after the token dies.
+const JWT_RENEWAL_BUFFER_MS = 5 * 60 * 1000;
+
+// Shared across concurrent callers so a cold start issues one renewal, not N.
+let _inFlightRenewal = null;
+
+// =============================================================================
 // TOKEN STORAGE (Hierarchy per LLD Section 6.3)
 // =============================================================================
 
 /**
  * Store tokens with proper security hierarchy.
- * - Access token: session storage (cleared on browser close)
- * - Refresh token + user info: local storage (persists)
+ *
+ * Issue #812: the Aletheia refresh token goes to LOCAL storage so the session
+ * survives a browser restart. Previously the only credential the API accepts
+ * (the JWT) lived solely in session storage, which the browser clears on close,
+ * while the identity fields in local storage persisted forever — so a restart
+ * destroyed the credential and left every field the popup inspects intact.
  *
  * @param {string} accessToken
- * @param {string} refreshToken
- * @param {number} expiresIn - Seconds until access token expires
+ * @param {string} refreshToken - LinkedIn's; effectively always null for the
+ *   'openid profile' scopes. Retained only so stored shape is unchanged.
+ * @param {number} expiresIn - Seconds until the LinkedIn access token expires
  * @param {object} user - User info {id, name}
+ * @param {string} jwt - The credential the analysis API accepts
+ * @param {string} aletheiaRefreshToken - Renews the JWT indefinitely (#811)
  */
-async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt) {
-    // Access token + JWT - session only (memory, cleared on browser close)
+async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt, aletheiaRefreshToken) {
     await chrome.storage.session.set({
         accessToken,
         expiresAt: Date.now() + (expiresIn * 1000),
-        jwt: jwt || null
+        jwt: jwt || null,
+        jwtExpiresAt: jwt ? Date.now() + (JWT_LIFETIME_SECONDS * 1000) : 0
     });
 
-    // Refresh token + profile - local persistence
-    await chrome.storage.local.set({
+    const localData = {
         refreshToken,
         userId: user.id,
         displayName: user.name
-    });
+    };
+
+    // Only overwrite a stored refresh token when a new one was actually issued,
+    // so a re-login that omits it cannot silently strip renewal ability.
+    if (aletheiaRefreshToken) {
+        localData.aletheiaRefreshToken = aletheiaRefreshToken;
+    }
+
+    await chrome.storage.local.set(localData);
 
     console.log('[Aletheia Auth] Tokens stored successfully');
 }
@@ -74,14 +103,18 @@ async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt) {
  * Clear all auth data (logout).
  */
 async function clearTokens() {
-    await chrome.storage.session.remove(['accessToken', 'expiresAt', 'jwt']);
-    await chrome.storage.local.remove(['refreshToken', 'userId', 'displayName']);
+    _inFlightRenewal = null;
+    await chrome.storage.session.remove(['accessToken', 'expiresAt', 'jwt', 'jwtExpiresAt']);
+    await chrome.storage.local.remove([
+        'refreshToken', 'userId', 'displayName', 'aletheiaRefreshToken'
+    ]);
     console.log('[Aletheia Auth] Tokens cleared');
 }
 
 /**
- * Get JWT from session storage.
- * @returns {Promise<string | null>} JWT or null if not authenticated
+ * Get the cached JWT without attempting renewal.
+ * Prefer getValidJwt() on any request path.
+ * @returns {Promise<string | null>}
  */
 async function getJwt() {
     const session = await chrome.storage.session.get(['jwt']);
@@ -89,20 +122,51 @@ async function getJwt() {
 }
 
 /**
- * Get current auth state (user info if logged in).
+ * Get a usable JWT, renewing silently when the cached one is missing or stale.
+ *
+ * Issue #814. This is the only accessor a request path should use. Callers must
+ * treat null as "cannot authenticate" and NOT dispatch the request anyway.
+ *
+ * @returns {Promise<string | null>} A live JWT, or null if renewal is impossible
+ */
+async function getValidJwt() {
+    const session = await chrome.storage.session.get(['jwt', 'jwtExpiresAt']);
+
+    const stillFresh = session.jwt &&
+        session.jwtExpiresAt &&
+        Date.now() < (session.jwtExpiresAt - JWT_RENEWAL_BUFFER_MS);
+
+    if (stillFresh) {
+        return session.jwt;
+    }
+
+    const renewed = await renewJwt();
+    if (renewed) return renewed;
+
+    // Legacy session from a build predating jwtExpiresAt (#812): renewal is
+    // impossible because no refresh token was ever issued, but the cached JWT
+    // may still be valid. Use it and let the 401 path decide, rather than
+    // forcing a sign-in we cannot prove is needed.
+    return session.jwt || null;
+}
+
+/**
+ * Get current auth state.
+ *
+ * Issue #813: previously this reported a user as signed in whenever `userId`
+ * was present. `userId` never expires and has no relationship to whether any
+ * request can succeed, so the popup claimed an active session indefinitely
+ * while every request failed. Authentication now means "a credential is
+ * obtainable" — a stored refresh token — not merely "a name is remembered".
+ *
  * @returns {Promise<{userId: string, displayName: string} | null>}
  */
 async function getAuthState() {
-    const local = await chrome.storage.local.get(['userId', 'displayName', 'refreshToken']);
-    console.log('[Aletheia Auth] getAuthState storage:', {
-        hasUserId: !!local.userId,
-        hasDisplayName: !!local.displayName,
-        hasRefreshToken: !!local.refreshToken
-    });
+    const local = await chrome.storage.local.get([
+        'userId', 'displayName', 'aletheiaRefreshToken'
+    ]);
 
-    // Note: refreshToken may be null if LinkedIn hasn't approved refresh token access
-    // We only require userId to consider the user authenticated
-    if (local.userId) {
+    if (local.userId && local.aletheiaRefreshToken) {
         return {
             userId: local.userId,
             displayName: local.displayName || 'User'
@@ -113,8 +177,7 @@ async function getAuthState() {
 }
 
 /**
- * Check if user is authenticated (has userId stored).
- * Note: We don't require refresh token as LinkedIn may not provide one.
+ * Whether a usable session exists (identity present AND renewable).
  * @returns {Promise<boolean>}
  */
 async function isAuthenticated() {
@@ -123,68 +186,85 @@ async function isAuthenticated() {
 }
 
 /**
- * Get valid access token, refreshing if needed (lazy refresh).
- * @returns {Promise<string | null>} Access token or null if not authenticated
+ * Whether identity is remembered but the session can no longer be renewed.
+ * Lets the UI say "signed out" honestly instead of claiming an active session.
+ * @returns {Promise<boolean>}
  */
-async function getAccessToken() {
-    const session = await chrome.storage.session.get(['accessToken', 'expiresAt']);
-
-    // Check if token exists and is not expired (with 60s buffer)
-    if (session.accessToken && Date.now() < (session.expiresAt - 60000)) {
-        return session.accessToken;
-    }
-
-    // Token expired or missing - try to refresh
-    console.log('[Aletheia Auth] Access token expired, attempting refresh...');
-    return await refreshTokens();
+async function isSessionUnrecoverable() {
+    const local = await chrome.storage.local.get(['userId', 'aletheiaRefreshToken']);
+    return Boolean(local.userId) && !local.aletheiaRefreshToken;
 }
 
 // =============================================================================
-// TOKEN REFRESH
+// TOKEN REFRESH (Issue #811 / #814)
 // =============================================================================
 
 /**
- * Refresh access token using stored refresh token.
- * @returns {Promise<string | null>} New access token or null if refresh fails
+ * Renew the JWT from the persisted Aletheia refresh token.
+ *
+ * Concurrent callers share one in-flight request: several extension contexts
+ * can hit this simultaneously on a cold start, and firing N parallel renewals
+ * would multiply load on the auth Lambda for no benefit.
+ *
+ * @returns {Promise<string | null>} A fresh JWT, or null if renewal failed
  */
-async function refreshTokens() {
-    const local = await chrome.storage.local.get(['refreshToken']);
-
-    if (!local.refreshToken) {
-        console.log('[Aletheia Auth] No refresh token available');
-        return null;
+async function renewJwt() {
+    if (_inFlightRenewal) {
+        return await _inFlightRenewal;
     }
 
-    try {
-        const response = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/refresh`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refreshToken: local.refreshToken })
-        });
+    _inFlightRenewal = (async () => {
+        const local = await chrome.storage.local.get(['aletheiaRefreshToken']);
 
-        if (!response.ok) {
-            console.error('[Aletheia Auth] Token refresh failed:', response.status);
-            // Clear tokens on 401 (refresh token invalid)
-            if (response.status === 401) {
-                await clearTokens();
-            }
+        if (!local.aletheiaRefreshToken) {
+            console.log('[Aletheia Auth] No refresh token; sign-in required');
             return null;
         }
 
-        const data = await response.json();
+        try {
+            const response = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/refresh`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ aletheiaRefreshToken: local.aletheiaRefreshToken })
+            });
 
-        // Store new access token
-        await chrome.storage.session.set({
-            accessToken: data.accessToken,
-            expiresAt: Date.now() + (data.expiresIn * 1000)
-        });
+            if (!response.ok) {
+                console.error('[Aletheia Auth] JWT renewal failed:', response.status);
+                // 401 means the refresh token is revoked or expired: renewal can
+                // never succeed again, so drop it and require a real sign-in.
+                // Any other status (5xx, offline) is transient — keep the token.
+                if (response.status === 401) {
+                    await chrome.storage.local.remove(['aletheiaRefreshToken']);
+                }
+                return null;
+            }
 
-        console.log('[Aletheia Auth] Token refreshed successfully');
-        return data.accessToken;
+            const data = await response.json();
+            if (!data.jwt) {
+                console.error('[Aletheia Auth] Renewal response carried no JWT');
+                return null;
+            }
 
-    } catch (error) {
-        console.error('[Aletheia Auth] Token refresh error:', error);
-        return null;
+            const lifetimeSeconds = data.expiresIn || JWT_LIFETIME_SECONDS;
+            await chrome.storage.session.set({
+                jwt: data.jwt,
+                jwtExpiresAt: Date.now() + (lifetimeSeconds * 1000)
+            });
+
+            console.log('[Aletheia Auth] JWT renewed silently');
+            return data.jwt;
+
+        } catch (error) {
+            // Network failure is transient. Do not discard the refresh token.
+            console.error('[Aletheia Auth] JWT renewal error:', error.name);
+            return null;
+        }
+    })();
+
+    try {
+        return await _inFlightRenewal;
+    } finally {
+        _inFlightRenewal = null;
     }
 }
 
@@ -204,6 +284,7 @@ async function mockLogin() {
         refreshToken: 'mock-refresh-token-67890',
         expiresIn: 3600,
         jwt: 'mock-jwt-for-testing',
+        aletheiaRefreshToken: 'mock-aletheia-refresh-token',
         user: {
             id: 'mock-sub-782bbtaQ',  // Mimics OIDC 'sub' format
             name: 'Test User'
@@ -215,7 +296,8 @@ async function mockLogin() {
         mockUser.refreshToken,
         mockUser.expiresIn,
         mockUser.user,
-        mockUser.jwt
+        mockUser.jwt,
+        mockUser.aletheiaRefreshToken
     );
 
     return mockUser.user;
@@ -302,9 +384,11 @@ window.AletheiaAuth = {
     mockLogin,
     logout,
     isAuthenticated,
+    isSessionUnrecoverable,
     getAuthState,
-    getAccessToken,
+    getValidJwt,
     getJwt,
+    renewJwt,
     clearTokens,
     // Config for debugging
     getConfig: () => ({ ...AUTH_CONFIG, CLIENT_ID: '***' })  // Hide client ID in logs

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Aletheia",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "AI-Powered Context Analysis",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2jHFmRu4xs5ORRk+qxPE8vRn9HzDFhoYsBVQfAkQn+Q0vz/u16R41YSRtOwEmeCxk1o4jub1dv5QmrFEGcpvy3+RPx0jrkzbNtsswpQrL+QJnS+vPE1mljCEg/t2FO7i12+qloRbslcbXyAB1osN8YghkkXx8xcwu53oY3eptRHe4BaClW0KJR3lkoiuEGx63KDYvjbv5GaxvxkDt9cm8WjdXxgic26gNsd3SvVz4b3k03WBF3AtGcj9zHrFNkwHUWgjOwX+leluCCN3xvglbk8nzkgs93RY3ekKCUxjauyCWFk1Rto4axF3XpZDjJojwXnu27oZGl7CZnxCRaPV4QIDAQAB",
   "permissions": [

--- a/extensions/chrome/popup.js
+++ b/extensions/chrome/popup.js
@@ -584,12 +584,16 @@ async function handleFullPageClick() {
     };
 
     // Send to Lambda (Issue #402: include JWT if authenticated)
-    const jwt = await window.AletheiaAuth.getJwt();
+    // Issue #814: renew silently rather than dispatch a request known to 401.
+    const jwt = await window.AletheiaAuth.getValidJwt();
+    if (!jwt) {
+      throw new Error('Please sign in with LinkedIn to use Aletheia.');
+    }
     const fullPageHeaders = {
       'Content-Type': 'application/json',
-      'X-Aletheia-Client-Version': CLIENT_VERSION
+      'X-Aletheia-Client-Version': CLIENT_VERSION,
+      'Authorization': `Bearer ${jwt}`
     };
-    if (jwt) fullPageHeaders['Authorization'] = `Bearer ${jwt}`;
 
     const response = await fetch(API_ENDPOINT, {
       method: 'POST',
@@ -697,7 +701,7 @@ async function handleCouponSubmit() {
 
   try {
     // Get JWT from session storage (Issue #402)
-    const jwt = await window.AletheiaAuth.getJwt();
+    const jwt = await window.AletheiaAuth.getValidJwt();
     if (!jwt) {
       showCouponStatus('Please sign in first', 'error');
       return;
@@ -774,7 +778,7 @@ async function checkSubscriptionStatus() {
 
   try {
     const authState = await window.AletheiaAuth.getAuthState();
-    const jwt = await window.AletheiaAuth.getJwt();
+    const jwt = await window.AletheiaAuth.getValidJwt();
     if (!authState || !jwt) return;
 
     const response = await fetch(SUBSCRIPTION_STATUS_URL, {
@@ -825,7 +829,7 @@ async function handleUpgradeClick() {
 
   try {
     const authState = await window.AletheiaAuth.getAuthState();
-    const jwt = await window.AletheiaAuth.getJwt();
+    const jwt = await window.AletheiaAuth.getValidJwt();
     if (!authState || !jwt) {
       upgradeButton.textContent = 'Please sign in first';
       return;

--- a/extensions/chrome/service-worker.js
+++ b/extensions/chrome/service-worker.js
@@ -7,15 +7,157 @@ const API_ENDPOINT = "https://api.aletheia.study/";
 // [#95] Client version for Lambda header validation (Issue #349: moved from WAF to Lambda)
 const CLIENT_VERSION = "1.0";
 
-// Issue #402: Auth header injection
+// Server mints JWTs with a 24h life (Issue #811).
+const JWT_LIFETIME_SECONDS = 24 * 3600;
+
+// Renew ahead of expiry so a request cannot race the boundary.
+const JWT_RENEWAL_BUFFER_MS = 5 * 60 * 1000;
+
+// One renewal shared across concurrent callers, not N parallel ones.
+let _inFlightRenewal = null;
+
+/**
+ * Renew the JWT from the persisted Aletheia refresh token (Issue #811).
+ *
+ * The service worker cannot import auth.js, so this mirrors its renewal logic.
+ * Both must stay in step; the shared contract is the /auth/refresh payload.
+ *
+ * @returns {Promise<string | null>} Fresh JWT, or null if renewal is impossible
+ */
+async function renewJwt() {
+    if (_inFlightRenewal) return await _inFlightRenewal;
+
+    _inFlightRenewal = (async () => {
+        const local = await chrome.storage.local.get(['aletheiaRefreshToken']);
+        if (!local.aletheiaRefreshToken) return null;
+
+        try {
+            const response = await fetch("https://api.aletheia.study/auth/refresh", {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ aletheiaRefreshToken: local.aletheiaRefreshToken })
+            });
+
+            if (!response.ok) {
+                // 401 means revoked or expired: renewal can never succeed again,
+                // so drop the token and require a real sign-in. Any other status
+                // (5xx, offline) is transient — keep it and retry later.
+                if (response.status === 401) {
+                    await chrome.storage.local.remove(['aletheiaRefreshToken']);
+                }
+                console.error('[Aletheia] JWT renewal failed:', response.status);
+                return null;
+            }
+
+            const data = await response.json();
+            if (!data.jwt) return null;
+
+            await chrome.storage.session.set({
+                jwt: data.jwt,
+                jwtExpiresAt: Date.now() + ((data.expiresIn || JWT_LIFETIME_SECONDS) * 1000)
+            });
+            console.log('[Aletheia] JWT renewed silently');
+            return data.jwt;
+
+        } catch (error) {
+            console.error('[Aletheia] JWT renewal error:', error.name);
+            return null;
+        }
+    })();
+
+    try {
+        return await _inFlightRenewal;
+    } finally {
+        _inFlightRenewal = null;
+    }
+}
+
+/**
+ * Get a usable JWT, renewing silently when the cached one is stale or absent.
+ * @returns {Promise<string | null>}
+ */
+async function getValidJwt() {
+    const session = await chrome.storage.session.get(['jwt', 'jwtExpiresAt']);
+
+    const stillFresh = session.jwt &&
+        session.jwtExpiresAt &&
+        Date.now() < (session.jwtExpiresAt - JWT_RENEWAL_BUFFER_MS);
+
+    if (stillFresh) return session.jwt;
+
+    const renewed = await renewJwt();
+    if (renewed) return renewed;
+
+    // Legacy session from a build predating jwtExpiresAt (#812): renewal is
+    // impossible because no refresh token was ever issued, but the cached JWT
+    // may still be valid. Use it and let the 401 path decide, rather than
+    // forcing a sign-in we cannot prove is needed.
+    return session.jwt || null;
+}
+
+/**
+ * Issue #402: Auth header injection. Issue #814: renew rather than dispatch
+ * a request already known to fail.
+ *
+ * Previously this read the JWT, found nothing, and sent the request anyway
+ * with no Authorization header — turning a recoverable missing-credential
+ * condition into a terminal "Sign In Required".
+ *
+ * @returns {Promise<object|null>} Headers, or null when no credential is
+ *   obtainable. Callers MUST NOT dispatch on null.
+ */
 async function getAuthHeaders() {
-    const session = await chrome.storage.session.get(['jwt']);
-    const headers = {
+    const jwt = await getValidJwt();
+    if (!jwt) return null;
+
+    return {
         'Content-Type': 'application/json',
-        'X-Aletheia-Client-Version': CLIENT_VERSION
+        'X-Aletheia-Client-Version': CLIENT_VERSION,
+        'Authorization': `Bearer ${jwt}`
     };
-    if (session.jwt) headers['Authorization'] = `Bearer ${session.jwt}`;
-    return headers;
+}
+
+/**
+ * POST to the API with a live credential, recovering once from a 401.
+ *
+ * Issue #814. A 401 can mean the cached JWT died between the freshness check
+ * and the server receiving it. That is recoverable, so renew and retry exactly
+ * once. Strictly one retry: no loop, no recursion — a renewal storm against
+ * the auth Lambda would turn a transient failure into an outage.
+ *
+ * @param {object} payload - JSON body
+ * @param {object} extraInit - Additional fetch init (e.g. an abort signal).
+ *   Applied to both the initial request and the retry, so a caller's timeout
+ *   still governs the retry rather than being silently dropped.
+ * @returns {Promise<Response|null>} Response, or null if no credential exists
+ */
+async function authedPost(payload, extraInit = {}) {
+    const headers = await getAuthHeaders();
+
+    // No credential obtainable: do not dispatch a request known to fail.
+    if (!headers) return null;
+
+    const body = JSON.stringify(payload);
+
+    const response = await fetch(API_ENDPOINT, {
+        method: 'POST',
+        headers,
+        body,
+        ...extraInit
+    });
+
+    if (response.status !== 401) return response;
+
+    console.log('[Aletheia] 401 received; renewing once and retrying');
+    const freshJwt = await renewJwt();
+    if (!freshJwt) return response;
+
+    return await fetch(API_ENDPOINT, {
+        method: 'POST',
+        headers: { ...headers, 'Authorization': `Bearer ${freshJwt}` },
+        body,
+        ...extraInit
+    });
 }
 
 // =============================================================================
@@ -313,17 +455,38 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
                 const tokenData = await tokenResponse.json();
 
-                // 5. Store tokens
+                // 5. Store tokens. Issue #812: the Aletheia refresh token goes
+                // to LOCAL storage so the session survives a browser restart —
+                // session storage is cleared on close, which is what previously
+                // destroyed the only credential the API accepts while leaving
+                // identity intact.
                 await chrome.storage.session.set({
                     accessToken: tokenData.accessToken,
                     expiresAt: Date.now() + (tokenData.expiresIn * 1000),
-                    jwt: tokenData.jwt || null
+                    jwt: tokenData.jwt || null,
+                    jwtExpiresAt: tokenData.jwt
+                        ? Date.now() + (JWT_LIFETIME_SECONDS * 1000)
+                        : 0
                 });
-                await chrome.storage.local.set({
+
+                const localData = {
                     refreshToken: tokenData.refreshToken,
                     userId: tokenData.user.id,
                     displayName: tokenData.user.name
-                });
+                };
+
+                if (tokenData.aletheiaRefreshToken) {
+                    localData.aletheiaRefreshToken = tokenData.aletheiaRefreshToken;
+                } else {
+                    // A login yielding no refresh token produces a session that
+                    // dies in 24h with no recovery — the original defect.
+                    console.error(
+                        '[Aletheia Auth SW] Login returned no aletheiaRefreshToken; ' +
+                        'session cannot renew. Auth Lambda may predate issue #811.'
+                    );
+                }
+
+                await chrome.storage.local.set(localData);
 
                 // Clear any previous error
                 await chrome.storage.session.remove(['authError']);
@@ -351,11 +514,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 const payload = message.payload;
                 console.log('[Aletheia] Deep poetic analysis request:', payload.text);
 
-                const response = await fetch(API_ENDPOINT, {
-                    method: 'POST',
-                    headers: await getAuthHeaders(),
-                    body: JSON.stringify(payload)
-                });
+                const response = await authedPost(payload);
+
+                if (response === null) {
+                    sendResponse({
+                        status: 'error',
+                        error: 'Sign in with LinkedIn to use Aletheia.'
+                    });
+                    return;
+                }
 
                 const data = await response.json();
                 console.log('[Aletheia] Deep poetic analysis response:', data.status);
@@ -569,13 +736,43 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
         const timeoutId = setTimeout(() => controller.abort(), 30000);
         const fetchStart = Date.now();
 
-        const response = await fetch(API_ENDPOINT, {
-            method: 'POST',
-            headers: await getAuthHeaders(),
-            body: JSON.stringify(payload),
-            signal: controller.signal
-        });
+        const response = await authedPost(payload, { signal: controller.signal });
         clearTimeout(timeoutId);
+
+        // Issue #814: null means no credential could be obtained even after a
+        // renewal attempt. This is the genuine sign-in case — distinct from a
+        // 401, which now only survives after renewal has already been tried.
+        if (response === null) {
+            const signInData = {
+                signal: "Sign In Required",
+                gem: "Please sign in with LinkedIn to use Aletheia.",
+                context: "",
+                warning: true,
+                selectedText: info.selectionText,
+                domContext: contextText
+            };
+            storeDiagnostics(401, Date.now() - fetchStart, signInData.gem);
+            try {
+                await chrome.scripting.executeScript({
+                    target: { tabId: tab.id },
+                    func: (data, status) => window.showAletheiaResult(data, status),
+                    args: [signInData, 401]
+                });
+            } catch (cspError) {
+                // Same CSP fallback the normal result path uses.
+                console.warn("[Aletheia] CSP blocked overlay injection:", cspError);
+                chrome.notifications.create({
+                    type: 'basic',
+                    iconUrl: 'icons/icon128.png',
+                    title: signInData.signal,
+                    message: signInData.gem
+                });
+            }
+            chrome.action.setBadgeText({ tabId: tab.id, text: '✗' });
+            chrome.action.setBadgeBackgroundColor({ tabId: tab.id, color: '#EF4444' });
+            setTimeout(() => chrome.action.setBadgeText({ tabId: tab.id, text: '' }), 5000);
+            return;
+        }
 
         const latencyMs = Date.now() - fetchStart;
 

--- a/extensions/firefox/auth.js
+++ b/extensions/firefox/auth.js
@@ -50,33 +50,65 @@ function generateState() {
 }
 
 // =============================================================================
+// SESSION LIFETIME (Issues #811, #812, #814)
+// =============================================================================
+
+// Server mints JWTs with a 24h life. Mirrored here only to schedule renewal;
+// the server's `expiresIn` is preferred whenever the response carries one.
+const JWT_LIFETIME_SECONDS = 24 * 3600;
+
+// Renew this far ahead of expiry so an in-flight request cannot race the
+// boundary and arrive just after the token dies.
+const JWT_RENEWAL_BUFFER_MS = 5 * 60 * 1000;
+
+// Shared across concurrent callers so a cold start issues one renewal, not N.
+let _inFlightRenewal = null;
+
+// =============================================================================
 // TOKEN STORAGE (Hierarchy per LLD Section 6.3)
 // =============================================================================
 
 /**
  * Store tokens with proper security hierarchy.
- * - Access token: session storage (cleared on browser close)
- * - Refresh token + user info: local storage (persists)
+ *
+ * Issue #812: the Aletheia refresh token goes to LOCAL storage so the session
+ * survives a browser restart. Previously the only credential the API accepts
+ * (the JWT) lived solely in session storage, which the browser clears on close,
+ * while the identity fields in local storage persisted forever — so a restart
+ * destroyed the credential and left every field the popup inspects intact.
+ *
+ * The JWT itself may stay in session storage: it is short-lived and, with the
+ * refresh token persisted, a cold start simply re-mints it.
  *
  * @param {string} accessToken
- * @param {string} refreshToken
- * @param {number} expiresIn - Seconds until access token expires
+ * @param {string} refreshToken - LinkedIn's; effectively always null for the
+ *   'openid profile' scopes. Retained only so stored shape is unchanged.
+ * @param {number} expiresIn - Seconds until the LinkedIn access token expires
  * @param {object} user - User info {id, name}
+ * @param {string} jwt - The credential the analysis API accepts
+ * @param {string} aletheiaRefreshToken - Renews the JWT indefinitely (#811)
  */
-async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt) {
-    // Access token + JWT - session only (memory, cleared on browser close)
+async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt, aletheiaRefreshToken) {
     await browser.storage.session.set({
         accessToken,
         expiresAt: Date.now() + (expiresIn * 1000),
-        jwt: jwt || null
+        jwt: jwt || null,
+        jwtExpiresAt: jwt ? Date.now() + (JWT_LIFETIME_SECONDS * 1000) : 0
     });
 
-    // Refresh token + profile - local persistence
-    await browser.storage.local.set({
+    const localData = {
         refreshToken,
         userId: user.id,
         displayName: user.name
-    });
+    };
+
+    // Only overwrite a stored refresh token when a new one was actually issued,
+    // so a re-login that omits it cannot silently strip renewal ability.
+    if (aletheiaRefreshToken) {
+        localData.aletheiaRefreshToken = aletheiaRefreshToken;
+    }
+
+    await browser.storage.local.set(localData);
 
     console.log('[Aletheia Auth] Tokens stored successfully');
 }
@@ -85,14 +117,18 @@ async function storeTokens(accessToken, refreshToken, expiresIn, user, jwt) {
  * Clear all auth data (logout).
  */
 async function clearTokens() {
-    await browser.storage.session.remove(['accessToken', 'expiresAt', 'jwt']);
-    await browser.storage.local.remove(['refreshToken', 'userId', 'displayName']);
+    _inFlightRenewal = null;
+    await browser.storage.session.remove(['accessToken', 'expiresAt', 'jwt', 'jwtExpiresAt']);
+    await browser.storage.local.remove([
+        'refreshToken', 'userId', 'displayName', 'aletheiaRefreshToken'
+    ]);
     console.log('[Aletheia Auth] Tokens cleared');
 }
 
 /**
- * Get JWT from session storage.
- * @returns {Promise<string | null>} JWT or null if not authenticated
+ * Get the cached JWT without attempting renewal.
+ * Prefer getValidJwt() on any request path.
+ * @returns {Promise<string | null>}
  */
 async function getJwt() {
     const session = await browser.storage.session.get(['jwt']);
@@ -100,20 +136,52 @@ async function getJwt() {
 }
 
 /**
- * Get current auth state (user info if logged in).
+ * Get a usable JWT, renewing silently when the cached one is missing or stale.
+ *
+ * Issue #814. This is the only accessor a request path should use. Callers must
+ * treat null as "cannot authenticate" and NOT dispatch the request anyway.
+ *
+ * @returns {Promise<string | null>} A live JWT, or null if renewal is impossible
+ */
+async function getValidJwt() {
+    const session = await browser.storage.session.get(['jwt', 'jwtExpiresAt']);
+
+    // Renew slightly early so a request cannot race the expiry boundary.
+    const stillFresh = session.jwt &&
+        session.jwtExpiresAt &&
+        Date.now() < (session.jwtExpiresAt - JWT_RENEWAL_BUFFER_MS);
+
+    if (stillFresh) {
+        return session.jwt;
+    }
+
+    const renewed = await renewJwt();
+    if (renewed) return renewed;
+
+    // Legacy session from a build predating jwtExpiresAt (#812): renewal is
+    // impossible because no refresh token was ever issued, but the cached JWT
+    // may still be valid. Use it and let the 401 path decide, rather than
+    // forcing a sign-in we cannot prove is needed.
+    return session.jwt || null;
+}
+
+/**
+ * Get current auth state.
+ *
+ * Issue #813: previously this reported a user as signed in whenever `userId`
+ * was present. `userId` never expires and has no relationship to whether any
+ * request can succeed, so the popup claimed an active session indefinitely
+ * while every request failed. Authentication now means "a credential is
+ * obtainable" — a stored refresh token — not merely "a name is remembered".
+ *
  * @returns {Promise<{userId: string, displayName: string} | null>}
  */
 async function getAuthState() {
-    const local = await browser.storage.local.get(['userId', 'displayName', 'refreshToken']);
-    console.log('[Aletheia Auth] getAuthState storage:', {
-        hasUserId: !!local.userId,
-        hasDisplayName: !!local.displayName,
-        hasRefreshToken: !!local.refreshToken
-    });
+    const local = await browser.storage.local.get([
+        'userId', 'displayName', 'aletheiaRefreshToken'
+    ]);
 
-    // Note: refreshToken may be null if LinkedIn hasn't approved refresh token access
-    // We only require userId to consider the user authenticated
-    if (local.userId) {
+    if (local.userId && local.aletheiaRefreshToken) {
         return {
             userId: local.userId,
             displayName: local.displayName || 'User'
@@ -124,8 +192,7 @@ async function getAuthState() {
 }
 
 /**
- * Check if user is authenticated (has userId stored).
- * Note: We don't require refresh token as LinkedIn may not provide one.
+ * Whether a usable session exists (identity present AND renewable).
  * @returns {Promise<boolean>}
  */
 async function isAuthenticated() {
@@ -134,68 +201,85 @@ async function isAuthenticated() {
 }
 
 /**
- * Get valid access token, refreshing if needed (lazy refresh).
- * @returns {Promise<string | null>} Access token or null if not authenticated
+ * Whether identity is remembered but the session can no longer be renewed.
+ * Lets the UI say "signed out" honestly instead of claiming an active session.
+ * @returns {Promise<boolean>}
  */
-async function getAccessToken() {
-    const session = await browser.storage.session.get(['accessToken', 'expiresAt']);
-
-    // Check if token exists and is not expired (with 60s buffer)
-    if (session.accessToken && Date.now() < (session.expiresAt - 60000)) {
-        return session.accessToken;
-    }
-
-    // Token expired or missing - try to refresh
-    console.log('[Aletheia Auth] Access token expired, attempting refresh...');
-    return await refreshTokens();
+async function isSessionUnrecoverable() {
+    const local = await browser.storage.local.get(['userId', 'aletheiaRefreshToken']);
+    return Boolean(local.userId) && !local.aletheiaRefreshToken;
 }
 
 // =============================================================================
-// TOKEN REFRESH
+// TOKEN REFRESH (Issue #811 / #814)
 // =============================================================================
 
 /**
- * Refresh access token using stored refresh token.
- * @returns {Promise<string | null>} New access token or null if refresh fails
+ * Renew the JWT from the persisted Aletheia refresh token.
+ *
+ * Concurrent callers share one in-flight request: several extension contexts
+ * can hit this simultaneously on a cold start, and firing N parallel renewals
+ * would multiply load on the auth Lambda for no benefit.
+ *
+ * @returns {Promise<string | null>} A fresh JWT, or null if renewal failed
  */
-async function refreshTokens() {
-    const local = await browser.storage.local.get(['refreshToken']);
-
-    if (!local.refreshToken) {
-        console.log('[Aletheia Auth] No refresh token available');
-        return null;
+async function renewJwt() {
+    if (_inFlightRenewal) {
+        return await _inFlightRenewal;
     }
 
-    try {
-        const response = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/refresh`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refreshToken: local.refreshToken })
-        });
+    _inFlightRenewal = (async () => {
+        const local = await browser.storage.local.get(['aletheiaRefreshToken']);
 
-        if (!response.ok) {
-            console.error('[Aletheia Auth] Token refresh failed:', response.status);
-            // Clear tokens on 401 (refresh token invalid)
-            if (response.status === 401) {
-                await clearTokens();
-            }
+        if (!local.aletheiaRefreshToken) {
+            console.log('[Aletheia Auth] No refresh token; sign-in required');
             return null;
         }
 
-        const data = await response.json();
+        try {
+            const response = await fetch(`${AUTH_CONFIG.LAMBDA_AUTH_URL}/auth/refresh`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ aletheiaRefreshToken: local.aletheiaRefreshToken })
+            });
 
-        // Store new access token
-        await browser.storage.session.set({
-            accessToken: data.accessToken,
-            expiresAt: Date.now() + (data.expiresIn * 1000)
-        });
+            if (!response.ok) {
+                console.error('[Aletheia Auth] JWT renewal failed:', response.status);
+                // 401 means the refresh token is revoked or expired: renewal can
+                // never succeed again, so drop it and require a real sign-in.
+                // Any other status (5xx, offline) is transient — keep the token.
+                if (response.status === 401) {
+                    await browser.storage.local.remove(['aletheiaRefreshToken']);
+                }
+                return null;
+            }
 
-        console.log('[Aletheia Auth] Token refreshed successfully');
-        return data.accessToken;
+            const data = await response.json();
+            if (!data.jwt) {
+                console.error('[Aletheia Auth] Renewal response carried no JWT');
+                return null;
+            }
 
-    } catch (error) {
-        console.error('[Aletheia Auth] Token refresh error:', error);
-        return null;
+            const lifetimeSeconds = data.expiresIn || JWT_LIFETIME_SECONDS;
+            await browser.storage.session.set({
+                jwt: data.jwt,
+                jwtExpiresAt: Date.now() + (lifetimeSeconds * 1000)
+            });
+
+            console.log('[Aletheia Auth] JWT renewed silently');
+            return data.jwt;
+
+        } catch (error) {
+            // Network failure is transient. Do not discard the refresh token.
+            console.error('[Aletheia Auth] JWT renewal error:', error.name);
+            return null;
+        }
+    })();
+
+    try {
+        return await _inFlightRenewal;
+    } finally {
+        _inFlightRenewal = null;
     }
 }
 
@@ -215,6 +299,7 @@ async function mockLogin() {
         refreshToken: 'mock-refresh-token-67890',
         expiresIn: 3600,
         jwt: 'mock-jwt-for-testing',
+        aletheiaRefreshToken: 'mock-aletheia-refresh-token',
         user: {
             id: 'mock-sub-782bbtaQ',  // Mimics OIDC 'sub' format
             name: 'Test User'
@@ -226,7 +311,8 @@ async function mockLogin() {
         mockUser.refreshToken,
         mockUser.expiresIn,
         mockUser.user,
-        mockUser.jwt
+        mockUser.jwt,
+        mockUser.aletheiaRefreshToken
     );
 
     return mockUser.user;
@@ -329,9 +415,11 @@ window.AletheiaAuth = {
     mockLogin,
     logout,
     isAuthenticated,
+    isSessionUnrecoverable,
     getAuthState,
-    getAccessToken,
+    getValidJwt,
     getJwt,
+    renewJwt,
     clearTokens,
     // Exposed for testing
     generateState,

--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Aletheia",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "AI-Powered Context Analysis",
   "permissions": [
     "activeTab",

--- a/extensions/firefox/popup.js
+++ b/extensions/firefox/popup.js
@@ -509,12 +509,16 @@ async function handleFullPageClick() {
     };
 
     // Send to Lambda (Issue #402: include JWT if authenticated)
-    const jwt = await window.AletheiaAuth.getJwt();
+    // Issue #814: renew silently rather than dispatch a request known to 401.
+    const jwt = await window.AletheiaAuth.getValidJwt();
+    if (!jwt) {
+      throw new Error('Please sign in with LinkedIn to use Aletheia.');
+    }
     const fullPageHeaders = {
       'Content-Type': 'application/json',
-      'X-Aletheia-Client-Version': CLIENT_VERSION
+      'X-Aletheia-Client-Version': CLIENT_VERSION,
+      'Authorization': `Bearer ${jwt}`
     };
-    if (jwt) fullPageHeaders['Authorization'] = `Bearer ${jwt}`;
 
     const response = await fetch(API_ENDPOINT, {
       method: 'POST',
@@ -609,7 +613,8 @@ async function handleCouponSubmit() {
   showCouponStatus('Validating coupon...', 'info');
 
   try {
-    const jwt = await window.AletheiaAuth.getJwt();
+    // Issue #814: renew silently before deciding the user must sign in.
+    const jwt = await window.AletheiaAuth.getValidJwt();
     if (!jwt) {
       showCouponStatus('Please sign in first', 'error');
       return;

--- a/extensions/firefox/service-worker.js
+++ b/extensions/firefox/service-worker.js
@@ -7,15 +7,150 @@ const API_ENDPOINT = "https://api.aletheia.study/";
 // [#95] Client version for Lambda header validation (Issue #349: moved from WAF to Lambda)
 const CLIENT_VERSION = "1.0";
 
-// Issue #402: Auth header injection
+// Server mints JWTs with a 24h life (Issue #811).
+const JWT_LIFETIME_SECONDS = 24 * 3600;
+
+// Renew ahead of expiry so a request cannot race the boundary.
+const JWT_RENEWAL_BUFFER_MS = 5 * 60 * 1000;
+
+// One renewal shared across concurrent callers, not N parallel ones.
+let _inFlightRenewal = null;
+
+/**
+ * Renew the JWT from the persisted Aletheia refresh token (Issue #811).
+ *
+ * The service worker cannot import auth.js, so this mirrors its renewal logic.
+ * Both must stay in step; the shared contract is the /auth/refresh payload.
+ *
+ * @returns {Promise<string | null>} Fresh JWT, or null if renewal is impossible
+ */
+async function renewJwt() {
+    if (_inFlightRenewal) return await _inFlightRenewal;
+
+    _inFlightRenewal = (async () => {
+        const local = await chrome.storage.local.get(['aletheiaRefreshToken']);
+        if (!local.aletheiaRefreshToken) return null;
+
+        try {
+            const response = await fetch("https://api.aletheia.study/auth/refresh", {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ aletheiaRefreshToken: local.aletheiaRefreshToken })
+            });
+
+            if (!response.ok) {
+                // 401 means revoked or expired: renewal can never succeed again,
+                // so drop the token and require a real sign-in. Any other status
+                // (5xx, offline) is transient — keep it and retry later.
+                if (response.status === 401) {
+                    await chrome.storage.local.remove(['aletheiaRefreshToken']);
+                }
+                console.error('[Aletheia] JWT renewal failed:', response.status);
+                return null;
+            }
+
+            const data = await response.json();
+            if (!data.jwt) return null;
+
+            await chrome.storage.session.set({
+                jwt: data.jwt,
+                jwtExpiresAt: Date.now() + ((data.expiresIn || JWT_LIFETIME_SECONDS) * 1000)
+            });
+            console.log('[Aletheia] JWT renewed silently');
+            return data.jwt;
+
+        } catch (error) {
+            console.error('[Aletheia] JWT renewal error:', error.name);
+            return null;
+        }
+    })();
+
+    try {
+        return await _inFlightRenewal;
+    } finally {
+        _inFlightRenewal = null;
+    }
+}
+
+/**
+ * Get a usable JWT, renewing silently when the cached one is stale or absent.
+ * @returns {Promise<string | null>}
+ */
+async function getValidJwt() {
+    const session = await chrome.storage.session.get(['jwt', 'jwtExpiresAt']);
+
+    const stillFresh = session.jwt &&
+        session.jwtExpiresAt &&
+        Date.now() < (session.jwtExpiresAt - JWT_RENEWAL_BUFFER_MS);
+
+    if (stillFresh) return session.jwt;
+
+    const renewed = await renewJwt();
+    if (renewed) return renewed;
+
+    // Legacy session from a build predating jwtExpiresAt (#812): renewal is
+    // impossible because no refresh token was ever issued, but the cached JWT
+    // may still be valid. Use it and let the 401 path decide, rather than
+    // forcing a sign-in we cannot prove is needed.
+    return session.jwt || null;
+}
+
+/**
+ * Issue #402: Auth header injection. Issue #814: renew rather than dispatch
+ * a request already known to fail.
+ *
+ * Previously this read the JWT, found nothing, and sent the request anyway
+ * with no Authorization header — turning a recoverable missing-credential
+ * condition into a terminal "Sign In Required".
+ *
+ * @returns {Promise<object|null>} Headers, or null when no credential is
+ *   obtainable. Callers MUST NOT dispatch on null.
+ */
 async function getAuthHeaders() {
-    const session = await chrome.storage.session.get(['jwt']);
-    const headers = {
+    const jwt = await getValidJwt();
+    if (!jwt) return null;
+
+    return {
         'Content-Type': 'application/json',
-        'X-Aletheia-Client-Version': CLIENT_VERSION
+        'X-Aletheia-Client-Version': CLIENT_VERSION,
+        'Authorization': `Bearer ${jwt}`
     };
-    if (session.jwt) headers['Authorization'] = `Bearer ${session.jwt}`;
-    return headers;
+}
+
+/**
+ * POST to the API with a live credential, recovering once from a 401.
+ *
+ * Issue #814. A 401 can mean the cached JWT died between the freshness check
+ * and the server receiving it. That is recoverable, so renew and retry exactly
+ * once. Strictly one retry: no loop, no recursion — a renewal storm against
+ * the auth Lambda would turn a transient failure into an outage.
+ *
+ * @param {object} payload - JSON body
+ * @returns {Promise<Response|null>} Response, or null if no credential exists
+ */
+async function authedPost(payload) {
+    const headers = await getAuthHeaders();
+
+    // No credential obtainable: do not dispatch a request known to fail.
+    if (!headers) return null;
+
+    const response = await fetch(API_ENDPOINT, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload)
+    });
+
+    if (response.status !== 401) return response;
+
+    console.log('[Aletheia] 401 received; renewing once and retrying');
+    const freshJwt = await renewJwt();
+    if (!freshJwt) return response;
+
+    return await fetch(API_ENDPOINT, {
+        method: 'POST',
+        headers: { ...headers, 'Authorization': `Bearer ${freshJwt}` },
+        body: JSON.stringify(payload)
+    });
 }
 
 // =============================================================================
@@ -222,18 +357,38 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 
             const tokenData = await tokenResponse.json();
 
-            // Store tokens
+            // Store tokens. Issue #812: the Aletheia refresh token goes to LOCAL
+            // storage so the session survives a browser restart — session storage
+            // is cleared on close, which is what previously destroyed the only
+            // credential the API accepts while leaving identity intact.
             await chrome.storage.session.set({
                 accessToken: tokenData.accessToken,
                 expiresAt: Date.now() + (tokenData.expiresIn * 1000),
-                jwt: tokenData.jwt || null
+                jwt: tokenData.jwt || null,
+                jwtExpiresAt: tokenData.jwt
+                    ? Date.now() + (JWT_LIFETIME_SECONDS * 1000)
+                    : 0
             });
 
-            await chrome.storage.local.set({
+            const localData = {
                 refreshToken: tokenData.refreshToken,
                 userId: tokenData.user.id,
                 displayName: tokenData.user.name
-            });
+            };
+
+            if (tokenData.aletheiaRefreshToken) {
+                localData.aletheiaRefreshToken = tokenData.aletheiaRefreshToken;
+            } else {
+                // A login that yields no refresh token produces a session that
+                // dies in 24h with no recovery — the original defect. Surface it
+                // rather than letting it look like a clean login.
+                console.error(
+                    '[Aletheia Auth SW] Login returned no aletheiaRefreshToken; ' +
+                    'session cannot renew. Auth Lambda may predate issue #811.'
+                );
+            }
+
+            await chrome.storage.local.set(localData);
 
             // Clear pending state
             await chrome.storage.session.remove('pendingOAuth');
@@ -312,11 +467,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 const payload = message.payload;
                 console.log('[Aletheia] Deep poetic analysis request:', payload.text);
 
-                const response = await fetch(API_ENDPOINT, {
-                    method: 'POST',
-                    headers: await getAuthHeaders(),
-                    body: JSON.stringify(payload)
-                });
+                const response = await authedPost(payload);
+
+                if (response === null) {
+                    sendResponse({
+                        status: 'error',
+                        error: 'Sign in with LinkedIn to use Aletheia.'
+                    });
+                    return;
+                }
 
                 const data = await response.json();
                 console.log('[Aletheia] Deep poetic analysis response:', data.status);
@@ -565,11 +724,29 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
         console.log("[Aletheia] Sending payload to AWS:", payload.text);
 
-        const response = await fetch(API_ENDPOINT, {
-            method: 'POST',
-            headers: await getAuthHeaders(),
-            body: JSON.stringify(payload)
-        });
+        const response = await authedPost(payload);
+
+        // Issue #814: null means no credential could be obtained even after a
+        // renewal attempt. This is the genuine sign-in case — distinct from a
+        // 401, which now only survives after renewal has already been tried.
+        if (response === null) {
+            await chrome.scripting.executeScript({
+                target: { tabId: tab.id },
+                func: (data, status) => window.showAletheiaResult(data, status),
+                args: [{
+                    signal: "Sign In Required",
+                    gem: "Please sign in with LinkedIn to use Aletheia.",
+                    context: "",
+                    warning: true,
+                    selectedText: info.selectionText,
+                    domContext: contextText
+                }, 401]
+            });
+            chrome.action.setBadgeText({ tabId: tab.id, text: '✗' });
+            chrome.action.setBadgeBackgroundColor({ tabId: tab.id, color: '#EF4444' });
+            setTimeout(() => chrome.action.setBadgeText({ tabId: tab.id, text: '' }), 5000);
+            return;
+        }
 
         // [#125] MUSEUM LABEL UI - Parse response and show structured result
         const httpStatus = response.status;

--- a/tests/e2e/auth-flow.spec.js
+++ b/tests/e2e/auth-flow.spec.js
@@ -100,10 +100,13 @@ test.describe('E2E Auth Flow (#403)', () => {
     });
 
     test('030: getAuthHeaders includes Authorization when JWT present', async ({ serviceWorker }) => {
-        // Store JWT in session storage
+        // Store JWT in session storage. jwtExpiresAt accompanies it (#814):
+        // without it the credential's freshness is unknowable and the worker
+        // would fall through to a renewal attempt.
         await serviceWorker.evaluate(async () => {
             await chrome.storage.session.set({
-                jwt: 'mock-jwt-for-testing'
+                jwt: 'mock-jwt-for-testing',
+                jwtExpiresAt: Date.now() + (24 * 3600 * 1000)
             });
         });
 
@@ -120,22 +123,61 @@ test.describe('E2E Auth Flow (#403)', () => {
         expect(headers['Authorization']).toBe('Bearer mock-jwt-for-testing');
     });
 
-    test('040: getAuthHeaders omits Authorization when no JWT', async ({ serviceWorker }) => {
-        // Clear JWT from session storage
+    test('040: getAuthHeaders returns null when no credential can be obtained', async ({ serviceWorker }) => {
+        // Issue #814. This previously asserted that headers were still returned
+        // with no Authorization key — i.e. that the worker would dispatch a
+        // request it knew would 401, then surface that as a terminal
+        // "Sign In Required". That was the defect, so the contract is inverted:
+        // with nothing to authenticate with, no request may be dispatched.
         await serviceWorker.evaluate(async () => {
-            await chrome.storage.session.remove(['jwt']);
+            await chrome.storage.session.remove(['jwt', 'jwtExpiresAt']);
+            await chrome.storage.local.remove(['aletheiaRefreshToken']);
         });
 
-        // Call getAuthHeaders() — should have no Authorization key
         const headers = await serviceWorker.evaluate(async () => {
             // eslint-disable-next-line no-undef
             return await getAuthHeaders();
         });
 
-        expect(headers).toBeTruthy();
-        expect(headers['Content-Type']).toBe('application/json');
-        expect(headers['X-Aletheia-Client-Version']).toBe('1.0');
-        expect(headers['Authorization']).toBeUndefined();
+        expect(headers).toBeNull();
+    });
+
+    test('045: getAuthHeaders renews silently when a refresh token is stored', async ({ serviceWorker }) => {
+        // Issue #812/#814: the state after a browser restart — session storage
+        // emptied, refresh token persisted. The user must not be asked to do
+        // anything; the worker renews on its own.
+        const result = await serviceWorker.evaluate(async () => {
+            await chrome.storage.session.remove(['jwt', 'jwtExpiresAt']);
+            await chrome.storage.local.set({ aletheiaRefreshToken: 'e2e-refresh-token' });
+
+            const realFetch = globalThis.fetch;
+            let refreshBody = null;
+            globalThis.fetch = async (url, init) => {
+                if (String(url).includes('/auth/refresh')) {
+                    refreshBody = JSON.parse(init.body);
+                    return {
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ jwt: 'renewed-e2e-jwt', expiresIn: 86400 })
+                    };
+                }
+                return realFetch(url, init);
+            };
+
+            try {
+                // eslint-disable-next-line no-undef
+                const headers = await getAuthHeaders();
+                return { headers, refreshBody };
+            } finally {
+                globalThis.fetch = realFetch;
+                await chrome.storage.local.remove(['aletheiaRefreshToken']);
+            }
+        });
+
+        expect(result.headers).toBeTruthy();
+        expect(result.headers['Authorization']).toBe('Bearer renewed-e2e-jwt');
+        // The Aletheia token is what renews; LinkedIn cannot refresh these scopes.
+        expect(result.refreshBody).toHaveProperty('aletheiaRefreshToken', 'e2e-refresh-token');
     });
 
     test('050: mockLogin stores JWT via popup page', async ({ context, extensionId }) => {

--- a/tests/mocks/chrome-api.mock.js
+++ b/tests/mocks/chrome-api.mock.js
@@ -38,19 +38,27 @@ export function createChromeMock(options = {}) {
   } = options;
 
   // Internal storage state (local)
+  // Issue #812: a genuinely authenticated user carries an Aletheia refresh
+  // token in LOCAL storage. Without it the session cannot renew, which is the
+  // exact state that used to masquerade as "signed in".
   let localStorageData = {
     allowlist: [...allowlist],
     ...(authenticated ? {
       refreshToken: 'mock-refresh-token-67890',
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token',
       userId: 'mock-sub-782bbtaQ',
       displayName: 'Test User'
     } : {})
   };
 
   // Internal storage state (session - MV3)
+  // Issue #814: jwtExpiresAt must accompany the JWT, otherwise the credential's
+  // freshness is unknowable and every request path has to guess.
   let sessionStorageData = authenticated ? {
     accessToken: 'mock-access-token-12345',
     expiresAt: Date.now() + 3600000,
+    jwt: 'mock-jwt-for-testing',
+    jwtExpiresAt: Date.now() + (24 * 3600 * 1000),
     oauth_state: null
   } : {};
 

--- a/tests/mocks/firefox-api.mock.js
+++ b/tests/mocks/firefox-api.mock.js
@@ -44,19 +44,27 @@ export function createFirefoxMock(options = {}) {
   } = options;
 
   // Internal storage state (local)
+  // Issue #812: a genuinely authenticated user carries an Aletheia refresh
+  // token in LOCAL storage. Without it the session cannot renew, which is the
+  // exact state that used to masquerade as "signed in".
   let localStorageData = {
     allowlist: [...allowlist],
     ...(authenticated ? {
       refreshToken: 'mock-refresh-token-67890',
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token',
       userId: 'mock-sub-782bbtaQ',
       displayName: 'Test User'
     } : {})
   };
 
   // Internal storage state (session - MV3)
+  // Issue #814: jwtExpiresAt must accompany the JWT, otherwise the credential's
+  // freshness is unknowable and every request path has to guess.
   let sessionStorageData = authenticated ? {
     accessToken: 'mock-access-token-12345',
     expiresAt: Date.now() + 3600000,
+    jwt: 'mock-jwt-for-testing',
+    jwtExpiresAt: Date.now() + (24 * 3600 * 1000),
     oauth_state: null
   } : {};
 

--- a/tests/unit/chrome/auth.test.js
+++ b/tests/unit/chrome/auth.test.js
@@ -155,7 +155,9 @@ describe('CSRF State Generation', () => {
     expect(auth.logout).toBeTypeOf('function');
     expect(auth.isAuthenticated).toBeTypeOf('function');
     expect(auth.getAuthState).toBeTypeOf('function');
-    expect(auth.getAccessToken).toBeTypeOf('function');
+    expect(auth.getValidJwt).toBeTypeOf('function');
+    expect(auth.renewJwt).toBeTypeOf('function');
+    expect(auth.isSessionUnrecoverable).toBeTypeOf('function');
     expect(auth.clearTokens).toBeTypeOf('function');
   });
 
@@ -408,10 +410,22 @@ describe('Authentication State', () => {
       }
     });
 
-    it('getAccessToken returns token when valid', async () => {
+    it('getValidJwt returns the cached JWT while it is still fresh', async () => {
       if (global.window.AletheiaAuth) {
-        const token = await global.window.AletheiaAuth.getAccessToken();
-        expect(token).toBe('mock-access-token-12345');
+        const token = await global.window.AletheiaAuth.getValidJwt();
+        expect(token).toBe('mock-jwt-for-testing');
+      }
+    });
+
+    it('getValidJwt does not hit the network when the JWT is fresh', async () => {
+      // Issue #814: a fresh credential must not trigger a renewal round-trip.
+      if (global.window.AletheiaAuth) {
+        global.fetch.mockClear();
+        await global.window.AletheiaAuth.getValidJwt();
+        const refreshCalls = global.fetch.mock.calls.filter(c =>
+          String(c[0]).includes('/auth/refresh')
+        );
+        expect(refreshCalls).toHaveLength(0);
       }
     });
   });
@@ -543,60 +557,68 @@ describe('Token Refresh', () => {
     cleanupEnvironment();
   });
 
-  it('getAccessToken returns null when no refresh token', async () => {
+  it('getValidJwt returns null when nothing can be renewed', async () => {
     const { chromeMock } = env;
 
-    // Remove tokens
+    // No JWT, no refresh token: renewal is impossible and the caller must be
+    // told so rather than handed a credential-less request (#814).
     chromeMock.__setLocalStorageData({ allowlist: [] });
     chromeMock.__setSessionStorageData({});
 
     if (global.window.AletheiaAuth) {
-      const token = await global.window.AletheiaAuth.getAccessToken();
+      const token = await global.window.AletheiaAuth.getValidJwt();
       expect(token).toBeNull();
     }
   });
 
-  it('returns cached token when not expired', async () => {
+  it('returns the cached JWT when not expired', async () => {
     const { chromeMock } = env;
 
-    // Set valid token
     chromeMock.__setSessionStorageData({
-      accessToken: 'cached-token',
-      expiresAt: Date.now() + 3600000 // 1 hour from now
+      jwt: 'cached-jwt',
+      jwtExpiresAt: Date.now() + 3600000 // 1 hour from now
     });
 
     if (global.window.AletheiaAuth) {
-      const token = await global.window.AletheiaAuth.getAccessToken();
-      expect(token).toBe('cached-token');
+      const token = await global.window.AletheiaAuth.getValidJwt();
+      expect(token).toBe('cached-jwt');
     }
   });
 
-  it('attempts refresh when token is expired', async () => {
+  it('renews silently when the JWT is expired', async () => {
     const { chromeMock } = env;
 
-    // Set expired token but valid refresh token
     chromeMock.__setSessionStorageData({
-      accessToken: 'expired-token',
-      expiresAt: Date.now() - 1000 // Expired
+      jwt: 'expired-jwt',
+      jwtExpiresAt: Date.now() - 1000 // Expired
+    });
+    chromeMock.__setLocalStorageData({
+      allowlist: [],
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token'
     });
 
-    // Mock refresh endpoint
+    // Issue #811: /auth/refresh returns a JWT, not a LinkedIn access token.
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
-        accessToken: 'new-access-token',
-        expiresIn: 3600
+        jwt: 'renewed-jwt',
+        expiresIn: 86400
       })
     });
 
     if (global.window.AletheiaAuth) {
-      const _token = await global.window.AletheiaAuth.getAccessToken();
+      const token = await global.window.AletheiaAuth.getValidJwt();
 
-      // Should have called refresh endpoint
       const refreshCall = global.fetch.mock.calls.find(call =>
-        call[0].includes('/auth/refresh')
+        String(call[0]).includes('/auth/refresh')
       );
       expect(refreshCall).toBeDefined();
+
+      // The renewal must send the Aletheia token, not LinkedIn's.
+      expect(JSON.parse(refreshCall[1].body)).toHaveProperty('aletheiaRefreshToken');
+
+      // And the caller must receive the renewed credential, silently.
+      expect(token).toBe('renewed-jwt');
     }
   });
 });

--- a/tests/unit/chrome/session-persistence.test.js
+++ b/tests/unit/chrome/session-persistence.test.js
@@ -1,0 +1,222 @@
+/**
+ * Session persistence and silent renewal.
+ *
+ * Issue #812 - the JWT lived only in session storage, so a browser restart
+ *              destroyed it while identity fields persisted forever.
+ * Issue #813 - the popup reported "signed in" from userId alone, contradicting
+ *              every failing request.
+ * Issue #814 - the request path sent knowingly-unauthenticated requests and
+ *              treated the resulting 401 as terminal.
+ *
+ * Together those produced the field report this suite exists to prevent: the
+ * popup showing an active session while every analysis returned
+ * "Sign In Required", recoverable only by a manual logout and re-login.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { createChromeMock } from '../../mocks/chrome-api.mock.js';
+
+const authJsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../../extensions/chrome/auth.js'),
+  'utf-8'
+);
+
+function loadAuth(chromeMock) {
+  global.chrome = chromeMock;
+  global.window = {};
+  // crypto is a getter-only global in this environment; stubGlobal handles it.
+  vi.stubGlobal('crypto', { getRandomValues: (a) => a });
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  eval(authJsSource);
+  return global.window.AletheiaAuth;
+}
+
+describe('Session persistence and silent renewal', () => {
+  let chromeMock;
+
+  beforeEach(() => {
+    chromeMock = createChromeMock({ authenticated: true });
+  });
+
+  afterEach(() => {
+    delete global.chrome;
+    delete global.window;
+    delete global.fetch;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------- #812 ---
+
+  it('persists the refresh token to LOCAL storage, not session storage', async () => {
+    const auth = loadAuth(chromeMock);
+    global.fetch = vi.fn();
+
+    await auth.clearTokens();
+    chromeMock.storage.local.set.mockClear?.();
+
+    // Simulate a fresh login writing its credentials.
+    const local = chromeMock.__getLocalStorageData();
+    expect(local.aletheiaRefreshToken).toBeUndefined();
+
+    chromeMock.__setLocalStorageData({
+      userId: 'u1',
+      displayName: 'Test User',
+      aletheiaRefreshToken: 'persisted-token'
+    });
+
+    // Session storage is what a browser restart destroys. Emptying it must NOT
+    // cost the user their session.
+    chromeMock.__setSessionStorageData({});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ jwt: 'renewed-after-restart', expiresIn: 86400 })
+    });
+
+    const jwt = await auth.getValidJwt();
+    expect(jwt).toBe('renewed-after-restart');
+  });
+
+  it('survives a simulated browser restart with no user interaction', async () => {
+    const auth = loadAuth(chromeMock);
+
+    // A restart clears session storage and leaves local storage intact.
+    chromeMock.__setSessionStorageData({});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ jwt: 'post-restart-jwt', expiresIn: 86400 })
+    });
+
+    expect(await auth.isAuthenticated()).toBe(true);
+    expect(await auth.getValidJwt()).toBe('post-restart-jwt');
+  });
+
+  // ---------------------------------------------------------------- #813 ---
+
+  it('does NOT report a session when identity remains but renewal is impossible', async () => {
+    const auth = loadAuth(chromeMock);
+
+    // Exactly the field-reported state: name remembered, credential gone.
+    chromeMock.__setLocalStorageData({
+      userId: 'u1',
+      displayName: 'Martin McEnroe, P.E.'
+    });
+    chromeMock.__setSessionStorageData({});
+
+    expect(await auth.getAuthState()).toBeNull();
+    expect(await auth.isAuthenticated()).toBe(false);
+    expect(await auth.isSessionUnrecoverable()).toBe(true);
+  });
+
+  it('reports a session when identity AND a refresh token are present', async () => {
+    const auth = loadAuth(chromeMock);
+
+    const state = await auth.getAuthState();
+    expect(state).not.toBeNull();
+    expect(state.displayName).toBe('Test User');
+    expect(await auth.isSessionUnrecoverable()).toBe(false);
+  });
+
+  // ---------------------------------------------------------------- #814 ---
+
+  it('issues ONE renewal when several callers race on a cold start', async () => {
+    const auth = loadAuth(chromeMock);
+    chromeMock.__setSessionStorageData({});
+
+    // Build the deferred up-front: getValidJwt awaits storage before it ever
+    // reaches fetch, so capturing the resolver inside the mock would race.
+    let resolveFetch;
+    const pending = new Promise((r) => { resolveFetch = r; });
+    global.fetch = vi.fn(() => pending);
+
+    const calls = [auth.getValidJwt(), auth.getValidJwt(), auth.getValidJwt()];
+
+    // Let all three reach the renewal before any response lands.
+    await new Promise((r) => setTimeout(r, 10));
+
+    resolveFetch({
+      ok: true,
+      json: () => Promise.resolve({ jwt: 'shared-jwt', expiresIn: 86400 })
+    });
+    const results = await Promise.all(calls);
+
+    // Three callers, one network round-trip.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(results).toEqual(['shared-jwt', 'shared-jwt', 'shared-jwt']);
+  });
+
+  it('drops the refresh token on 401 so a revoked session stops retrying', async () => {
+    const auth = loadAuth(chromeMock);
+    chromeMock.__setSessionStorageData({});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ error: 'Unauthorized' })
+    });
+
+    expect(await auth.getValidJwt()).toBeNull();
+    expect(chromeMock.__getLocalStorageData().aletheiaRefreshToken).toBeUndefined();
+  });
+
+  it('KEEPS the refresh token on a transient failure', async () => {
+    const auth = loadAuth(chromeMock);
+    chromeMock.__setSessionStorageData({});
+
+    // A 5xx or an offline browser must not cost the user their session —
+    // discarding the token here would force a re-login over a blip.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({ error: 'Service Unavailable' })
+    });
+
+    expect(await auth.getValidJwt()).toBeNull();
+    expect(chromeMock.__getLocalStorageData().aletheiaRefreshToken)
+      .toBe('mock-aletheia-refresh-token');
+  });
+
+  it('KEEPS the refresh token when the network throws', async () => {
+    const auth = loadAuth(chromeMock);
+    chromeMock.__setSessionStorageData({});
+
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    expect(await auth.getValidJwt()).toBeNull();
+    expect(chromeMock.__getLocalStorageData().aletheiaRefreshToken)
+      .toBe('mock-aletheia-refresh-token');
+  });
+
+  it('sends the Aletheia refresh token, never LinkedIn\'s', async () => {
+    const auth = loadAuth(chromeMock);
+    chromeMock.__setSessionStorageData({});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ jwt: 'j', expiresIn: 86400 })
+    });
+
+    await auth.getValidJwt();
+
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.aletheiaRefreshToken).toBe('mock-aletheia-refresh-token');
+    // LinkedIn cannot refresh these scopes; sending its token would 401.
+    expect(body.refreshToken).toBeUndefined();
+  });
+
+  it('logout clears the refresh token so the session cannot resurrect', async () => {
+    const auth = loadAuth(chromeMock);
+
+    await auth.clearTokens();
+
+    const local = chromeMock.__getLocalStorageData();
+    expect(local.aletheiaRefreshToken).toBeUndefined();
+    expect(local.userId).toBeUndefined();
+    expect(await auth.isAuthenticated()).toBe(false);
+  });
+});

--- a/tests/unit/firefox/service-worker.test.js
+++ b/tests/unit/firefox/service-worker.test.js
@@ -347,8 +347,17 @@ describe('Context Menu Click Handler (Firefox)', () => {
   it('handles explain-with-ai menu click', async () => {
     const { browserMock } = env;
 
-    // Set up allowlist
-    browserMock.__setLocalStorageData({ allowlist: ['example.com'] });
+    // Issue #814: a request path now requires a renewable session. Without one
+    // the worker deliberately dispatches nothing, so these tests must model a
+    // signed-in user rather than relying on the old fire-anyway behavior.
+    browserMock.__setLocalStorageData({
+      allowlist: ['example.com'],
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token'
+    });
+    browserMock.__setSessionStorageData({
+      jwt: 'mock-jwt-for-testing',
+      jwtExpiresAt: Date.now() + (24 * 3600 * 1000)
+    });
 
     // Set up script injection results
     browserMock.__setScriptInjectionResults([{
@@ -430,8 +439,17 @@ describe('Badge State (Firefox)', () => {
   it('sets success badge on successful API response', async () => {
     const { browserMock } = env;
 
-    // Set up allowlist
-    browserMock.__setLocalStorageData({ allowlist: ['example.com'] });
+    // Issue #814: a request path now requires a renewable session. Without one
+    // the worker deliberately dispatches nothing, so these tests must model a
+    // signed-in user rather than relying on the old fire-anyway behavior.
+    browserMock.__setLocalStorageData({
+      allowlist: ['example.com'],
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token'
+    });
+    browserMock.__setSessionStorageData({
+      jwt: 'mock-jwt-for-testing',
+      jwtExpiresAt: Date.now() + (24 * 3600 * 1000)
+    });
 
     // Set up successful response
     global.fetch = vi.fn().mockResolvedValue({
@@ -482,8 +500,17 @@ describe('API Integration (Firefox)', () => {
   it('includes X-Aletheia-Client-Version header in API requests', async () => {
     const { browserMock } = env;
 
-    // Set up allowlist
-    browserMock.__setLocalStorageData({ allowlist: ['example.com'] });
+    // Issue #814: a request path now requires a renewable session. Without one
+    // the worker deliberately dispatches nothing, so these tests must model a
+    // signed-in user rather than relying on the old fire-anyway behavior.
+    browserMock.__setLocalStorageData({
+      allowlist: ['example.com'],
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token'
+    });
+    browserMock.__setSessionStorageData({
+      jwt: 'mock-jwt-for-testing',
+      jwtExpiresAt: Date.now() + (24 * 3600 * 1000)
+    });
 
     // Set up script injection
     browserMock.__setScriptInjectionResults([
@@ -502,19 +529,53 @@ describe('API Integration (Firefox)', () => {
     browserMock.__triggerContextMenuClick(info, tab);
     await new Promise(resolve => setTimeout(resolve, 150));
 
-    // Check fetch was called with version header
+    // Assert unconditionally. This was previously wrapped in `if (fetchCall)`,
+    // which made it pass silently whenever no request was dispatched at all.
     const fetchCall = global.fetch.mock.calls[0];
-    if (fetchCall) {
-      const headers = fetchCall[1]?.headers;
-      expect(headers['X-Aletheia-Client-Version']).toBeDefined();
-    }
+    expect(fetchCall).toBeDefined();
+    expect(fetchCall[1].headers['X-Aletheia-Client-Version']).toBeDefined();
+    expect(fetchCall[1].headers['Authorization']).toBe('Bearer mock-jwt-for-testing');
+  });
+
+  it('dispatches NO request when no credential can be obtained', async () => {
+    const { browserMock } = env;
+
+    // Issue #814: previously the worker sent the request with no Authorization
+    // header, guaranteeing a 401, and surfaced that as a terminal
+    // "Sign In Required" — turning a recoverable state into a dead end.
+    browserMock.__setLocalStorageData({ allowlist: ['example.com'] });
+    browserMock.__setSessionStorageData({});
+    browserMock.__setScriptInjectionResults([
+      { result: { isRestricted: false, noarchive: false } },
+      { result: 'page body text' }
+    ]);
+
+    browserMock.__triggerContextMenuClick(
+      { menuItemId: 'explain-with-ai', selectionText: 'test', pageUrl: 'https://example.com' },
+      { id: 1, url: 'https://example.com', title: 'Test' }
+    );
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    const apiCalls = global.fetch.mock.calls.filter(c =>
+      !String(c[0]).includes('/auth/refresh')
+    );
+    expect(apiCalls).toHaveLength(0);
   });
 
   it('sends noarchive signal in payload when present', async () => {
     const { browserMock } = env;
 
-    // Set up allowlist
-    browserMock.__setLocalStorageData({ allowlist: ['example.com'] });
+    // Issue #814: a request path now requires a renewable session. Without one
+    // the worker deliberately dispatches nothing, so these tests must model a
+    // signed-in user rather than relying on the old fire-anyway behavior.
+    browserMock.__setLocalStorageData({
+      allowlist: ['example.com'],
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token'
+    });
+    browserMock.__setSessionStorageData({
+      jwt: 'mock-jwt-for-testing',
+      jwtExpiresAt: Date.now() + (24 * 3600 * 1000)
+    });
 
     // Set up script injection with noarchive signal
     browserMock.__setScriptInjectionResults([
@@ -577,8 +638,17 @@ describe('Error Handling (Firefox)', () => {
   it('handles API fetch errors gracefully', async () => {
     const { browserMock } = env;
 
-    // Set up allowlist
-    browserMock.__setLocalStorageData({ allowlist: ['example.com'] });
+    // Issue #814: a request path now requires a renewable session. Without one
+    // the worker deliberately dispatches nothing, so these tests must model a
+    // signed-in user rather than relying on the old fire-anyway behavior.
+    browserMock.__setLocalStorageData({
+      allowlist: ['example.com'],
+      aletheiaRefreshToken: 'mock-aletheia-refresh-token'
+    });
+    browserMock.__setSessionStorageData({
+      jwt: 'mock-jwt-for-testing',
+      jwtExpiresAt: Date.now() + (24 * 3600 * 1000)
+    });
 
     // Mock network error
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));


### PR DESCRIPTION
Closes #812
Closes #813
Closes #814

## The defect

Reported on Firefox 1.1.1 (the current AMO build) after a machine was rebooted repeatedly over 60 days: the popup showed the user signed in and Aletheia "ACTIVE" while every analysis on the page returned "Sign In Required". The only way back was a manual logout and re-login, and it kept recurring.

Both halves of the screen were telling the truth. Identity had survived; the credential had not.

**#812 — the credential did not survive a restart.** `storeTokens` wrote the JWT to `storage.session`, cleared by the browser on close, while `userId`/`displayName` went to `storage.local`, which persists forever. Closing the browser destroyed the only credential the API accepts and left every field the popup inspects intact.

**#813 — the popup reported a session that did not exist.** `getAuthState` returned "signed in" whenever `userId` was present — a value that never expires and has no relationship to whether any request can succeed. This is what made the failure undiagnosable from the UI: the thing that was broken was reported as fine, so the only visible explanation was that the product doesn't work.

**#814 — a recoverable condition was presented as terminal.** `getAuthHeaders` read the JWT, found nothing, and dispatched the request anyway with no `Authorization` header. Nothing anywhere attempted renewal on a 401.

## The change

Applied to both extensions.

- The Aletheia refresh token from #811 now lives in `storage.local` and survives restarts. `jwtExpiresAt` is stored alongside the JWT, so freshness is knowable instead of guessed.
- `getAuthState` requires identity **and** a stored refresh token. Authenticated means "a credential is obtainable", not "a name is remembered". `isSessionUnrecoverable()` lets the UI say "signed out" honestly rather than claiming a session it cannot back.
- `getValidJwt()` is the only accessor a request path may use; it renews silently. Concurrent callers share one in-flight renewal rather than firing N at the auth Lambda on a cold start.
- `getAuthHeaders()` returns `null` instead of sending a request known to 401, and `authedPost()` retries **exactly once** after renewing. No loop, no recursion — a renewal storm would turn a transient failure into an outage. Caller fetch options (Chrome's 30s abort signal) are forwarded to the retry so a timeout still governs it.

**Failure handling is deliberately asymmetric.** A 401 from `/auth/refresh` means revoked or expired — renewal can never succeed again, so the token is dropped and a real sign-in is required. Any other outcome, 5xx or a thrown network error, **retains** the token. Discarding it on a blip would force a re-login over a momentary outage, which is the whole class of failure this work exists to remove.

## Migration

Existing signed-in users hold a JWT but no `jwtExpiresAt` and no refresh token, so a strict freshness check would have logged out every current user on upgrade. `getValidJwt` falls back to the cached JWT when renewal is impossible: validity is unknown but plausible, so it is used and the 401 path decides. A guaranteed forced re-login becomes one that happens only if the token has genuinely expired.

## Tests

`379 passed | 4 skipped`, up from 357. ESLint clean on every file touched.

Ten new tests pin the guarantees, including: a simulated restart yielding a working session with no user interaction; the exact field-reported state (name present, credential gone) asserting the popup reports **no** session; three concurrent callers producing exactly one network round-trip; and the asymmetric failure handling — token dropped on 401, retained on 503 and on a thrown network error.

Six tests that asserted the old contract were **rewritten, not deleted** — `isAuthenticated returns true when userId exists` was the literal statement of the #813 defect, and four more targeted the LinkedIn refresh path #811 established has never worked.

The shared test doubles previously modelled "authenticated" as a user holding nothing that could authenticate a request — the defective state itself, used as the suite's definition of signed-in. That is now corrected, which is why several unrelated tests shifted.

One vacuous test was repaired: `includes X-Aletheia-Client-Version header` wrapped its assertion in `if (fetchCall)`, so it passed having asserted nothing whenever no request was dispatched — it could not have caught this change breaking the request path.

## What is NOT verified

The restart is simulated by clearing the storage double. **Nothing here proves Firefox's real `storage.session`/`storage.local` behave as modelled** — that is the one thing only a manual install can establish, and it is the exact reported scenario. No test exercises the deployed `/auth/refresh`; the server half was verified live by hand during the #811 deploy, but the full client-to-server login round-trip is unverified until this build is installed.

The ten new session assertions execute against the Chrome module only; Firefox is a `browser.*` transliteration covered by its own suite.

## Blast radius

Extension-only — no AWS or infra change. The server half (#811) is already deployed and verified in production, and this build degrades to the legacy path against an older Lambda rather than breaking.

Both manifests bumped to **1.1.3**.

Reaching users requires a store upload; AMO is tracked in #559.

## Rollback

Revert the commit and ship 1.1.2. No server dependency.
