### PR TITLE
test: make live website tests opt-in so a local run is a clean signal again (Closes #817)

### DIFF
--- a/docs/reports/817/implementation-report.md
+++ b/docs/reports/817/implementation-report.md
@@ -1,0 +1,87 @@
+# Implementation Report — Issue #817
+
+## Problem
+
+`tests/unit/test_signal_inspector.py::TestLiveWebsites` fetches real websites
+and asserts against their **current** robots.txt. One case
+(`test_noarchive_net_blocked_without_force`) fails on a clean checkout of
+`main` because the third-party site's policy appears to have changed:
+
+```
+AssertionError: assert <FetchStatus.SUCCESS> == <FetchStatus.ROBOTS_BLOCKED>
+```
+
+A suite that is red for reasons outside this repository stops being a signal.
+Every developer must first work out which failures are theirs — the same tax a
+permanently-red suite always imposes, and one that was paid twice while landing
+the session-renewal work.
+
+## What was already true
+
+The class was **already** marked `@pytest.mark.live` (line 399), the `live`
+marker was **already** declared in `pyproject.toml`, and the class docstring
+**already** said:
+
+> Run with: `poetry run pytest -v -m live`
+
+Nothing enforced any of that. A declared marker does not exclude anything by
+itself, so the live tests ran on every default invocation despite the stated
+intent that they be opt-in.
+
+The original issue proposed replacing the live calls with recorded fixtures.
+That turned out to be unnecessary: the intended design was already in the tree
+and simply had no mechanism behind it. Adding fixtures would have discarded a
+genuine end-to-end check that still has value when run deliberately.
+
+## Change
+
+One line in `[tool.pytest.ini_options]`:
+
+```toml
+addopts = "-m 'not live'"
+```
+
+Live tests are now opt-in via `poetry run pytest -m live`, exactly as the class
+docstring always said.
+
+## Why CI is deliberately unaffected
+
+CI runs `pytest tests/ -v -m "not audit"`. A `-m` given on the command line
+overrides one supplied through `addopts` (later occurrence wins), so **CI still
+runs the live tests**. That is intentional:
+
+- The failure is environment-specific — these pass in GitHub Actions and fail
+  from the operator's network, so CI genuinely does exercise the real-world
+  check.
+- Excluding them from CI as well would need an edit to `.github/workflows/`,
+  which the fine-grained PAT cannot push (it deliberately lacks `workflow`
+  scope). That would require the gpg-gated classic-PAT path and a human
+  passphrase.
+
+So the split is: the local suite is a clean signal again, and CI keeps the
+real-world coverage. If the live checks later become flaky in CI too, that is a
+separate decision and a separate change.
+
+## Verification performed
+
+| Command | Result |
+|---|---|
+| `pytest tests/unit -q` | `879 passed, 4 deselected` — green |
+| `pytest tests/unit -q -m "not audit"` (CI's form) | live tests still run; the known failure appears |
+| `pytest tests/unit -q -m live` | `1 failed, 3 passed, 879 deselected` — opt-in works |
+| `ruff check src/ tests/` | clean |
+
+The middle row is the important one: it proves CI behavior is unchanged rather
+than assumed.
+
+## Blast radius
+
+Test configuration only. No production code path.
+
+The real risk is that a default run now covers slightly less than before. That
+is the intended trade, and it is bounded: the same four tests still execute in
+CI on every push.
+
+## Rollback
+
+`git revert <sha>`. No deploy dependency.

--- a/docs/reports/817/test-report.md
+++ b/docs/reports/817/test-report.md
@@ -1,0 +1,56 @@
+# Test Report — Issue #817
+
+## Result
+
+```
+pytest tests/unit -q                    →  879 passed, 4 deselected   (green)
+pytest tests/unit -q -m "not audit"     →  live tests still run       (CI form)
+pytest tests/unit -q -m live            →  1 failed, 3 passed, 879 deselected
+ruff check src/ tests/                  →  All checks passed
+```
+
+No test code changed. No assertion was added, removed, or weakened.
+
+## What was verified
+
+This change alters test *selection*, so the verification is about which tests
+run under which invocation — not about new assertions.
+
+**1. The default run is green again.** `879 passed, 4 deselected`. The four
+deselected are exactly `TestLiveWebsites`. This is the reported problem fixed.
+
+**2. CI behavior is unchanged — proven, not assumed.** Running CI's actual
+command form (`-m "not audit"`) still executes the live tests, and the known
+environment-specific failure still appears locally. This confirms a
+command-line `-m` overrides `addopts`, which is the mechanism the whole change
+depends on. Had this not held, the change would have silently removed live
+coverage from CI.
+
+**3. The documented opt-in works.** `-m live` selects exactly the four live
+tests and deselects the other 879, matching what the class docstring has always
+instructed.
+
+## What is NOT fixed by this change
+
+**The underlying assertion is still wrong.** `noarchive.net` no longer appears
+to be robots-blocked for the operator's network, and this change does not
+correct that expectation — it stops the failure from contaminating unrelated
+local work. The test still fails when run deliberately with `-m live`, and it
+still fails on the operator's machine in CI's command form.
+
+That is the honest state: the signal was restored, the underlying disagreement
+with reality was not resolved. Whether `noarchive.net` genuinely changed policy,
+or whether the operator's network (ISP, DNS, or a proxy) returns a different
+robots.txt than GitHub's runners do, is unestablished — and the difference
+matters, because one means the assertion is stale and the other means the tool
+behaves differently on different networks.
+
+**No fixture was recorded.** The issue proposed pinning behavior with recorded
+responses. That was not done, because the tests were already designed as opt-in
+live checks and converting them would have discarded real end-to-end coverage
+to solve a selection problem. If the live checks later prove flaky in CI as
+well, recording fixtures becomes the right answer and should be revisited then.
+
+**CI still runs the live tests.** Excluding them there needs a
+`.github/workflows/` edit, which the fine-grained PAT cannot push. Left
+deliberately, and explained in the implementation report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,17 @@ markers = [
     "tools: tests for CLI tools",
     "benchmark: performance benchmark tests (Issue #161)",
 ]
+# Issue #817: live tests assert against third parties' CURRENT robots.txt, so
+# they fail for reasons outside this repository — and a suite that is red for
+# external reasons stops being a signal. TestLiveWebsites was already marked
+# `live`, and its docstring already said to run it with `-m live`; nothing
+# enforced that, so it fired on every default run. Opt in explicitly:
+#
+#     poetry run pytest -m live
+#
+# A CLI `-m` overrides this (later occurrence wins), so CI's existing
+# `-m "not audit"` is unaffected and still exercises the live checks.
+addopts = "-m 'not live'"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
Closes #817

## The problem

`TestLiveWebsites` asserts against third parties' **current** robots.txt, so it fails for reasons outside this repository. `noarchive.net` no longer reads as robots-blocked from your network, turning every local run red — and a suite that is red for external reasons stops being a signal. That tax got paid twice while landing the session-renewal work.

## What was already true

The intended design was already in the tree with nothing behind it:

- the class was already marked `@pytest.mark.live`
- the `live` marker was already declared in `pyproject.toml`
- the class docstring already said *"Run with: `poetry run pytest -v -m live`"*

A declared marker excludes nothing on its own, so the live tests fired on every default invocation despite the stated intent.

## The change

One line:

```toml
addopts = "-m 'not live'"
```

The issue proposed recording fixtures instead. That turned out to be the wrong fix — these were *designed* as opt-in live checks, and converting them would have discarded genuine end-to-end coverage to solve what is really a test-selection problem.

## CI is deliberately unaffected

CI runs `-m "not audit"`, and a command-line `-m` overrides `addopts` (later occurrence wins), so **CI still runs the live tests**.

That split is wanted: these pass on GitHub's runners and fail only from your network, so CI keeps real-world coverage while the local suite becomes trustworthy again. Excluding them in CI too would need a `.github/workflows/` edit, which the fine-grained PAT deliberately cannot push.

I verified this by running CI's exact command form rather than assuming it — had the override not held, this change would have silently stripped live coverage from CI.

## Verification

| Command | Result |
|---|---|
| `pytest tests/unit -q` | `879 passed, 4 deselected` — green |
| `pytest tests/unit -q -m "not audit"` (CI's form) | live tests still run |
| `pytest tests/unit -q -m live` | `1 failed, 3 passed, 879 deselected` |
| `ruff check src/ tests/` | clean |

No test code changed. No assertion added, removed, or weakened.

## What this does NOT fix

**The underlying assertion is still wrong.** This stops the failure contaminating unrelated work; it does not correct the expectation. The test still fails when run deliberately with `-m live`.

Whether `noarchive.net` genuinely changed policy, or whether your network (ISP, DNS, proxy) returns a different robots.txt than GitHub's runners do, is **unestablished** — and the difference matters: one means the assertion is stale, the other means the compliance tool behaves differently depending on the network it runs from. The second would be a finding about the tool, not the test.

## Separately, while investigating the sibling lint issue

#820 reported 9 `no-unused-vars` errors in `tests/e2e/`. Following them up found something worse, filed as **#827**: three security/safety e2e tests compute a value and then **assert nothing at all** — overlay memory-leak cleanup, XSS event-handler propagation, and a tautological `expect(page).toBeTruthy()`. They pass whatever the extension does.

Silencing those lint errors with an underscore prefix — the obvious fix — would have permanently hidden that. Not touched here; #827 needs real assertions written, and adding them may legitimately turn something red.

## Blast radius

Test configuration only, no production path. A default run now covers slightly less; that is the intended trade, and it is bounded because the same four tests still execute in CI on every push.

## Rollback

`git revert <sha>`. No deploy dependency.
