### PR TITLE
fix: unify index discovery and extraction patterns so the compliance suite passes on main (Closes #829)

### DIFF
--- a/docs/reports/829/implementation-report.md
+++ b/docs/reports/829/implementation-report.md
@@ -1,0 +1,103 @@
+# Implementation Report — Issue #829
+
+## What actually blocked the dependabot gate
+
+Not the dependency bumps. `tests/compliance/test_index_consistency.py::test_audit_index_complete`
+failed on **main**, and it would have failed for any PR riding the same suite.
+
+Measured, not inferred:
+
+| Ref | Result |
+|---|---|
+| `main` @ `cb07b43` | `1 failed, 927 passed, 3 skipped, 4 deselected` — exit 1 |
+| PR #805 @ `8f0bda5` | `1 failed, 927 passed, 3 skipped, 4 deselected` — exit 1 |
+
+Identical dispositions, same single failure. A types-only stub bump
+(`types-requests`) introduces nothing at runtime, which is exactly what the
+numbers show.
+
+## Root cause
+
+The test discovered audit files with a **shell glob** and matched index entries
+with a **regex**, and the two disagreed about what an audit file is:
+
+```python
+AUDITS_DIR.glob("108*-audit-*.md")       # discovery  — permissive
+r"108\d{2}-audit-[^)]+\.md"              # extraction — strict
+```
+
+The glob's `*` spans any characters, so it matched files whose `-audit-` sits
+mid-name:
+
+- `10833-wiki-audit-and-refresh-plan.md`
+- `10834-wiki-audit-report-2026-06.md`
+
+The regex requires `-audit-` immediately after the two-digit serial, so it can
+never match those names inside the index.
+
+The consequence is a test that **cannot be satisfied by editing the index**: it
+demands entries for two files and would then refuse to recognise them. The
+failure message says *"Add these to docs/audits/10800-audit-index.md section
+10.1"* — following that instruction would not have fixed it. Any attempt to
+clear this by adding index rows would have failed and looked inexplicable.
+
+## Why those two files should not be indexed anyway
+
+`10833` states its own status:
+
+> **Supersedes:** Nothing. Complements `docs/audits/10817-audit-wiki-alignment.md`
+> (the recurring checklist). This document is the project-specific, **one-time**
+> refresh plan that 10817 cannot generate from first principles.
+
+`10834` is that plan's output — a report of a single June 2026 run.
+
+The index's stated purpose, per the test's own docstring, is *"audits that
+won't be scheduled or run"*. A one-time plan and a historical report are
+neither. The recurring wiki audit, `10817-audit-wiki-alignment.md`, is already
+indexed. So the glob was not merely inconsistent — it was wrong about the
+domain.
+
+## Change
+
+One pattern per document type, used by **both** discovery and extraction, so
+they cannot drift:
+
+```python
+ADR_PATTERN      = r"102\d{2}-ADR-[^)]+\.md"
+AUDIT_PATTERN    = r"108\d{2}-audit-[^)]+\.md"
+SKILL_PATTERN    = r"106\d{2}-skill-[^)]+\.md"
+TEMPLATE_PATTERN = r"101\d{2}-TEMPLATE-[^`]+\.md"
+```
+
+plus `discover_documents()`, which is regex-based rather than glob-based
+precisely so it can share those patterns.
+
+All four index tests (ADR, audit, template, skill) carried the same
+glob/regex divergence. Only audits had a filename that exercised it; the other
+three were latent. All four are fixed, not just the one that was failing.
+
+No documentation was edited. No file was renamed. No assertion was weakened.
+
+## Deliberately not done
+
+- **Adding the two files to the index** — impossible, as shown above, and
+  wrong on the merits.
+- **Renaming them to `108NN-audit-*.md`** — they are referenced by issues #739,
+  #741 and #743 and cross-linked from each other; renaming breaks those links
+  to make two non-audits look like audits.
+- **Touching #809** — the `cryptography` 48→50 bump fails on a fleet-wide
+  install/wheel problem tracked in AssemblyZero#2153. Nothing local affects it.
+- **Merging or approving any dependabot PR** — per the work order, the 6 AM
+  fleet pipeline does that once the blocker falls.
+
+## Blast radius
+
+Test-only; no production code path, no deploy.
+
+The real risk is the tightened pattern silently under-discovering, which would
+stop enforcing the audit index without failing anything. That is guarded by an
+explicit lower-bound test (see the test report).
+
+## Rollback
+
+`git revert <sha>`. No deploy dependency.

--- a/docs/reports/829/test-report.md
+++ b/docs/reports/829/test-report.md
@@ -1,0 +1,92 @@
+# Test Report — Issue #829
+
+## Result
+
+```
+poetry run pytest -q          →  930 passed, 3 skipped, 4 deselected   exit 0
+poetry run ruff check src/ tests/  →  All checks passed
+```
+
+Baseline on `main` @ `cb07b43` was `1 failed, 927 passed` (exit 1). The gate is
+unblocked.
+
+The count rises by 3: the previously-failing test now passes, plus two new
+tests.
+
+## Baseline comparison performed
+
+The work order asked whether #805's failures also occur on main. They do,
+identically:
+
+| Ref | Failures | Disposition |
+|---|---|---|
+| `main` @ `cb07b43` | `test_audit_index_complete` | `1 failed, 927 passed, 3 skipped, 4 deselected` |
+| PR #805 @ `8f0bda5` | `test_audit_index_complete` | `1 failed, 927 passed, 3 skipped, 4 deselected` |
+
+Run in a separate worktree with its own `poetry install --no-root --with dev`,
+using the gate's own command shape (`pytest -q --tb=short`), so the comparison
+reflects what the tool sees rather than what a narrower invocation would.
+
+## New tests
+
+`TestAuditDiscoveryScope` pins discovery scope from **both** directions,
+because either extreme is a silent failure:
+
+- `test_infix_artifacts_are_not_treated_as_indexable_audits` — asserts
+  `10833-wiki-audit-and-refresh-plan.md` and `10834-wiki-audit-report-2026-06.md`
+  are not discovered as indexable audits. Too-permissive discovery re-admits
+  them and the original bug returns.
+- `test_conventionally_named_audits_are_still_discovered` — asserts at least 20
+  audits are found and names two specific ones. Too-strict discovery would make
+  the suite green while quietly enforcing nothing, which is the more dangerous
+  direction because nothing complains.
+
+## Mutation testing — and a test I threw away
+
+Both new tests were verified by deliberately reintroducing the defect rather
+than assumed to work.
+
+**Mutation:** loosen `AUDIT_PATTERN` to `r"108.*-audit-[^)]+\.md"` (the glob's
+semantics). Result:
+
+```
+FAILED ...::test_audit_index_complete
+FAILED ...::test_infix_artifacts_are_not_treated_as_indexable_audits
+2 failed, 5 passed
+```
+
+The guard bites, and the mutation reproduces the original failure exactly —
+confirming the diagnosis rather than merely being consistent with it.
+
+**A third test was written, then deleted.** It synthesised an index entry for
+every discovered file and asserted extraction could match it back. Under
+mutation it **passed**, which exposed it as tautological: it took a single
+pattern and checked that a file matching that pattern could be matched by that
+same pattern — true for any input, incapable of failing.
+
+That is the same defect logged in #827 for three e2e tests. Shipping it would
+have added a test that looked like a regression guard and guarded nothing, so
+it was removed rather than kept for appearance. The two surviving tests were
+kept only because mutation proved they fail.
+
+## Scope verified beyond the failing test
+
+All four index tests shared the glob/regex divergence; only audits had a
+filename that triggered it. After the change, the full
+`test_index_consistency.py` module passes (7 tests), so the ADR, template and
+skill paths still enforce their indexes under the tightened discovery.
+
+An intermediate version of the round-trip test failed on templates, which
+correctly revealed that the template guide uses a table row
+(`| \`name.md\` | … | Active |`) rather than a markdown link. That difference is
+real and is preserved.
+
+## Not covered
+
+- **Whether the fleet gate now exonerates #805** is unverified here. It depends
+  on the tool re-running against a green main; the disposition can only be
+  confirmed on the next scheduled run.
+- **#809 is untouched and still expected to fail.** Its blocker is the
+  fleet-wide `cryptography` 50.0.0 install/wheel problem (AssemblyZero#2153),
+  which no local change affects.
+- **No dependabot PR was merged or approved**, per the work order.

--- a/tests/compliance/test_index_consistency.py
+++ b/tests/compliance/test_index_consistency.py
@@ -24,6 +24,52 @@ TEMPLATES_DIR = DOCS_DIR / "templates"
 SKILLS_DIR = DOCS_DIR / "skills"
 
 
+# Issue #829: ONE pattern per document type, used by BOTH discovery and index
+# extraction.
+#
+# These previously diverged: discovery used a shell glob (`108*-audit-*.md`)
+# while extraction used a regex (`108\d{2}-audit-...`). The glob is far more
+# permissive — it matched `10833-wiki-audit-and-refresh-plan.md`, whose
+# `-audit-` sits mid-name — but the regex requires `-audit-` immediately after
+# the two-digit serial, so that file could never be matched in the index.
+#
+# The result was a test demanding an index entry it would then refuse to
+# recognise: unfixable by editing the index, and it failed on main. Because the
+# fleet dependabot gate exonerates a PR only when its failure set equals base's,
+# an unstable red main deferred every open dependency bump (#804, #805, #809).
+#
+# Keeping discovery and extraction on a single pattern makes that divergence
+# unrepresentable.
+ADR_PATTERN = r"102\d{2}-ADR-[^)]+\.md"
+AUDIT_PATTERN = r"108\d{2}-audit-[^)]+\.md"
+SKILL_PATTERN = r"106\d{2}-skill-[^)]+\.md"
+TEMPLATE_PATTERN = r"101\d{2}-TEMPLATE-[^`]+\.md"
+
+
+def discover_documents(
+    directory: Path, name_pattern: str, index_filename: str
+) -> set[str]:
+    """Find files whose full name matches `name_pattern`.
+
+    Deliberately regex-based rather than glob-based so it can share the exact
+    pattern used to extract entries from the index.
+
+    Args:
+        directory: Directory to scan.
+        name_pattern: Regex the whole filename must match.
+        index_filename: The index itself, excluded from results.
+
+    Returns:
+        Set of matching filenames.
+    """
+    regex = re.compile(name_pattern)
+    return {
+        f.name
+        for f in directory.iterdir()
+        if f.is_file() and regex.fullmatch(f.name) and f.name != index_filename
+    }
+
+
 def extract_links_from_markdown(content: str, pattern: str) -> set[str]:
     """Extract markdown links matching a pattern from content.
 
@@ -53,15 +99,11 @@ class TestIndexConsistency:
         assert index_file.exists(), "ADR index not found at docs/adrs/10200-ADR-index.md"
 
         # Find actual ADR files (excluding the index itself)
-        actual_adrs = {
-            f.name
-            for f in ADRS_DIR.glob("102*-ADR-*.md")
-            if f.name != "10200-ADR-index.md"
-        }
+        actual_adrs = discover_documents(ADRS_DIR, ADR_PATTERN, "10200-ADR-index.md")
 
         # Extract ADRs referenced in index
         content = index_file.read_text(encoding="utf-8")
-        indexed_adrs = extract_links_from_markdown(content, r"102\d{2}-ADR-[^)]+\.md")
+        indexed_adrs = extract_links_from_markdown(content, ADR_PATTERN)
 
         # Check for missing entries
         missing = actual_adrs - indexed_adrs
@@ -88,17 +130,13 @@ class TestIndexConsistency:
         assert index_file.exists(), "Audit index not found at docs/audits/10800-audit-index.md"
 
         # Find actual audit files (excluding the index itself)
-        actual_audits = {
-            f.name
-            for f in AUDITS_DIR.glob("108*-audit-*.md")
-            if f.name != "10800-audit-index.md"
-        }
+        actual_audits = discover_documents(
+            AUDITS_DIR, AUDIT_PATTERN, "10800-audit-index.md"
+        )
 
         # Extract audits referenced in index (section 10.1 has the links)
         content = index_file.read_text(encoding="utf-8")
-        indexed_audits = extract_links_from_markdown(
-            content, r"108\d{2}-audit-[^)]+\.md"
-        )
+        indexed_audits = extract_links_from_markdown(content, AUDIT_PATTERN)
 
         # Check for missing entries
         missing = actual_audits - indexed_audits
@@ -126,11 +164,9 @@ class TestIndexConsistency:
         assert index_file.exists(), "Template guide not found at docs/templates/10100-TEMPLATE-GUIDE.md"
 
         # Find actual template files (pattern: 101xx-TEMPLATE-*.md)
-        actual_templates = {
-            f.name
-            for f in TEMPLATES_DIR.glob("101*-TEMPLATE-*.md")
-            if f.name != "10100-TEMPLATE-GUIDE.md"
-        }
+        actual_templates = discover_documents(
+            TEMPLATES_DIR, TEMPLATE_PATTERN, "10100-TEMPLATE-GUIDE.md"
+        )
 
         # Extract templates referenced in index
         content = index_file.read_text(encoding="utf-8")
@@ -138,7 +174,7 @@ class TestIndexConsistency:
         # Templates are listed as `filename.md` in table cells
         # Match patterns like: | `10101-TEMPLATE-issue.md` |
         # Only match templates marked as "Active" (exclude "Future" planned templates)
-        template_pattern = r"\| `(101\d{2}-TEMPLATE-[^`]+\.md)` \|[^|]+\| Active \|"
+        template_pattern = rf"\| `({TEMPLATE_PATTERN})` \|[^|]+\| Active \|"
         indexed_templates = set(re.findall(template_pattern, content))
 
         # Check for missing entries (actual files not in "Active" index entries)
@@ -165,17 +201,13 @@ class TestIndexConsistency:
             return  # Index not yet created
 
         # Find actual skill instruction files
-        actual_skills = {
-            f.name
-            for f in SKILLS_DIR.glob("106*-skill-*.md")
-            if f.name != "10600-skill-instructions-index.md"
-        }
+        actual_skills = discover_documents(
+            SKILLS_DIR, SKILL_PATTERN, "10600-skill-instructions-index.md"
+        )
 
         # Extract skills referenced in index (exclude the index file itself)
         content = index_file.read_text(encoding="utf-8")
-        indexed_skills = extract_links_from_markdown(
-            content, r"106\d{2}-skill-[^)]+\.md"
-        )
+        indexed_skills = extract_links_from_markdown(content, SKILL_PATTERN)
         indexed_skills.discard("10600-skill-instructions-index.md")
 
         # Check for missing entries
@@ -193,6 +225,60 @@ class TestIndexConsistency:
             + "\n".join(f"  - {f}" for f in sorted(orphaned))
             + "\n\nRemove these from docs/skills/10600-skill-instructions-index.md"
         )
+
+
+class TestAuditDiscoveryScope:
+    """Issue #829: what counts as an indexable audit.
+
+    Discovery previously used a shell glob (``108*-audit-*.md``) while
+    extraction used a regex (``108\\d{2}-audit-...``). The glob swept in files
+    whose ``-audit-`` sits mid-name, which the regex could never match in the
+    index — so the suite demanded index entries it would then refuse to
+    recognise. That is unfixable by editing the index, and it failed on main.
+
+    Because the fleet dependabot gate exonerates a PR only when its failure set
+    equals base's, a red main deferred every open dependency bump.
+
+    These tests pin the *scope* of discovery from both directions: too
+    permissive re-admits the artifacts below, too strict silently stops
+    enforcing the index at all.
+    """
+
+    def test_infix_artifacts_are_not_treated_as_indexable_audits(self) -> None:
+        """Reports and plans about an audit are not themselves audits.
+
+        `10833-wiki-audit-and-refresh-plan.md` and
+        `10834-wiki-audit-report-2026-06.md` are a one-time plan and its report
+        — outputs of the recurring `10817-audit-wiki-alignment.md`, by 10833's
+        own statement. They are not schedulable audits, so the index (whose
+        purpose is "audits that will be scheduled or run") must not require
+        them.
+
+        The old shell glob swept them in because `-audit-` appears mid-name.
+        """
+        discovered = discover_documents(AUDITS_DIR, AUDIT_PATTERN, "10800-audit-index.md")
+
+        for artifact in (
+            "10833-wiki-audit-and-refresh-plan.md",
+            "10834-wiki-audit-report-2026-06.md",
+        ):
+            if (AUDITS_DIR / artifact).exists():
+                assert artifact not in discovered, (
+                    f"{artifact} was discovered as an indexable audit. "
+                    "It is an output artifact, not a recurring audit definition."
+                )
+
+    def test_conventionally_named_audits_are_still_discovered(self) -> None:
+        """The tightened pattern must not silently stop enforcing the index."""
+        discovered = discover_documents(AUDITS_DIR, AUDIT_PATTERN, "10800-audit-index.md")
+
+        # Guard against the fix "working" by discovering nothing at all.
+        assert len(discovered) >= 20, (
+            f"Only {len(discovered)} audits discovered; the pattern is too strict "
+            "and the index is no longer being enforced."
+        )
+        assert "10809-audit-security.md" in discovered
+        assert "10817-audit-wiki-alignment.md" in discovered
 
 
 class TestIndexCrossReferences:


### PR DESCRIPTION
Closes #829

## The gate was not blocked by any dependency bump

Measured on both refs with the gate's own command shape (`pytest -q --tb=short`), each in its own worktree with a fresh `poetry install --no-root --with dev`:

| Ref | Result |
|---|---|
| `main` @ `cb07b43` | `1 failed, 927 passed, 3 skipped, 4 deselected` — exit 1 |
| PR #805 @ `8f0bda5` | `1 failed, 927 passed, 3 skipped, 4 deselected` — exit 1 |

Identical dispositions, same single failure: `test_audit_index_complete`. A types-only stub bump introduces nothing at runtime, which is exactly what the numbers say. The suspicion in the work order was correct — it was the suite, not the dep.

## Root cause

The test discovered audit files with a **shell glob** and matched index entries with a **regex**, and the two disagreed about what an audit file is:

```python
AUDITS_DIR.glob("108*-audit-*.md")   # discovery  — permissive
r"108\d{2}-audit-[^)]+\.md"          # extraction — strict
```

The glob's `*` spans any characters, so it swept in files whose `-audit-` sits mid-name — `10833-wiki-audit-and-refresh-plan.md` and `10834-wiki-audit-report-2026-06.md`. The regex needs `-audit-` immediately after the two-digit serial and can never match those names inside the index.

**That made the test unsatisfiable by editing the index.** It demanded entries for two files and would then refuse to recognise them. Its own failure message says *"Add these to docs/audits/10800-audit-index.md section 10.1"* — following that instruction would not have worked, and would have looked inexplicable.

## Those two files should not be indexed regardless

`10833` states its own status: *"Complements `10817-audit-wiki-alignment.md` (the recurring checklist). This document is the project-specific, **one-time** refresh plan."* `10834` is that plan's June 2026 report.

The index exists for audits that get scheduled — the test's own docstring says so. A one-time plan and a historical report are neither, and the recurring wiki audit is already indexed. The glob wasn't just inconsistent; it was wrong about the domain.

## The change

One pattern per document type, used by **both** discovery and extraction, plus a regex-based `discover_documents()` so the pattern can actually be shared. Divergence becomes unrepresentable rather than merely fixed.

All four index tests (ADR, audit, template, skill) carried the same divergence — only audits had a filename that exercised it. All four are fixed, not just the one that was failing.

No docs edited, no files renamed, no assertion weakened.

## Tests — and one I deleted

`930 passed, exit 0`, ruff clean.

Two new guards, both verified by **mutation** rather than assumed. Loosening `AUDIT_PATTERN` back to glob semantics produces:

```
FAILED ...::test_audit_index_complete
FAILED ...::test_infix_artifacts_are_not_treated_as_indexable_audits
```

— the guard bites, and the mutation reproduces the original failure exactly, confirming the diagnosis rather than merely being consistent with it.

They pin scope from **both** directions: too permissive re-admits the artifacts, too strict makes the suite green while quietly enforcing nothing — the more dangerous direction, because nothing complains.

**A third test was written and deleted.** It synthesised an index entry per discovered file and asserted extraction matched it back. Under mutation it *passed*, exposing it as tautological — one pattern checked against itself, incapable of failing. That's the same defect logged in #827 for three e2e tests, so it was removed rather than kept for appearance.

## Dispositions of the three PRs

- **#804** (python-minor group) — already merged on re-audit; its blocker cleared independently.
- **#805** (types-requests) — unblocked by this change. Nothing wrong with the bump.
- **#809** (cryptography 48→50) — untouched and still expected to fail. Its blocker is the fleet-wide install/wheel problem in AssemblyZero#2153; no local change affects it, and it clears when upstream ships cp314 wheels or dependabot supersedes the PR.

No dependabot PR was merged or approved here — the 6 AM fleet pipeline does that now the blocker has fallen.

## Blast radius

Test-only, no production path, no deploy. The residual risk is the tightened pattern under-discovering and silently ceasing to enforce the index; that is guarded by an explicit lower-bound test.

## Rollback

`git revert <sha>`.
