### PR TITLE
security: stop interpolating exception text into log messages (Closes #835)

### DIFF
--- a/docs/reports/835/implementation-report.md
+++ b/docs/reports/835/implementation-report.md
@@ -1,0 +1,116 @@
+# Implementation Report — Issue #835
+
+## What was found
+
+A fresh scan of `src/` found **50** `logger.*` calls interpolating exception
+text into log messages:
+
+- **34** in files umbrella #637 never scoped — `src/auth/*.py`,
+  `src/guardrails/denylist.py`, `src/observability.py`.
+- **16** in files #637 *did* cover. That audit fixed 14 enumerated line
+  numbers; the pattern persisted elsewhere in the same files.
+
+This is the second time #637's inventory has proven incomplete. #824
+(`fetch_linkedin_profile` logging `response.text`) was a live leak absent from
+its table, found only by following a sibling issue's pre-removal gate.
+
+## Why it matters
+
+`docs/observability.html` is a public, absolute commitment:
+
+> NEVER log prompt text, user input, completion text, URLs, or user IDs.
+
+Exception messages are unbounded third-party text.
+`botocore.exceptions.ClientError` can echo request field values back, and
+several of these sites wrap DynamoDB operations keyed on `user_id`.
+
+## Change
+
+49 sites rewritten to `e.__class__.__name__`, the pattern established by
+#636/#619. The diff is 49 insertions and 49 deletions — strictly one-for-one
+line rewrites, no control flow touched.
+
+Both call styles were handled:
+
+```python
+logger.error(f"...: {e}")                 →  logger.error(f"...: {e.__class__.__name__}")
+logger.error("...: %s", str(e))           →  logger.error("...: %s", e.__class__.__name__)
+```
+
+## Deliberately unchanged
+
+**One site kept**, at `src/lambda_function.py:237`:
+
+```python
+logger.error(f"DynamoDB error: {e.response['Error']['Code']}")
+```
+
+This extracts a single audited attribute rather than the whole message, which is
+the documented way to retain more signal than a bare class name. Rewriting it
+would have lost real diagnostic value for no privacy gain.
+
+**Response payloads untouched.** Issue #668 reverted an earlier over-scrub that
+reached returned fields — `gem`, `reason`, `message`, `error`,
+`metadata.error`, `metadata.opus_verifier_error`. The operator caught that
+regression in production and ordered an emergency fix. The recorded reasoning
+is that the response goes back to the user who made the request, who already
+knows their own input, and that the scrubbing produced tautologies like
+`{"error": "ValueError: ValueError"}` for zero benefit. Nothing here touches a
+returned field.
+
+**Identifier logging left in place.** Three sites log an identifier directly
+alongside the exception:
+
+```
+src/lambda_auth_function.py:422   f"Failed to get user tier for {user_id}: ..."
+src/lambda_auth_function.py:997   f"GDPR deletion error for user {user_id}: ..."
+src/lambda_auth_function.py:755   f"...Stripe cancellation failed for {sub_id}: ..."
+```
+
+Two sit on the GDPR erasure path — the one place a user has explicitly asked to
+stop being identifiable. This is a direct violation of the same commitment and
+arguably worse than the exception-text class, since no inference is required.
+
+It is **not** fixed here because #711 already owns identifier handling in audit
+log lines, and whether these become hashed or dropped is that issue's decision.
+Settling it unilaterally inside a log-scrubbing PR would pre-empt it. A fourth
+site, `lambda_auth_function.py:386` (`f"Created new user: {user_id}"`), was
+noticed during this work and belongs to the same decision.
+
+## The regression test
+
+`tests/compliance/test_log_privacy.py` scans `src/` and fails on any logger call
+interpolating exception text.
+
+This is the substantive part. #637 demonstrated that fixing enumerated line
+numbers does not hold — the same files regrew the pattern, and 34 more surfaces
+sat outside the audited set entirely. A source scan makes the defect class
+unrepresentable rather than merely absent today.
+
+It carries an explicit out-of-scope assertion so it can never be extended into
+response payloads and re-cause the #668 regression.
+
+## Blast radius
+
+Log text only. No control flow, no response payload, no auth decision.
+
+Diagnostic detail is reduced: an exception's message is lost, leaving its class
+plus any safe attribute extraction. That is the tradeoff the observability
+commitment already accepts and which #668 explicitly preserved for logs.
+
+## Deploy
+
+Server-side; merging does not deploy. **Not deployed** — landed overnight for
+review. A code-only deploy is sufficient:
+
+```
+aws lambda update-function-code --function-name AletheiaAgent --zip-file fileb://<new>.zip
+aws lambda update-function-code --function-name AletheiaAuth  --zip-file fileb://<new>.zip
+```
+
+Avoid a full `provision.sh` run — it re-applies the whole environment and can
+blank `CLOUDFLARE_ORIGIN_SECRET` on a transient SSM failure (#779).
+
+## Rollback
+
+`git revert <sha>` plus the same code-only deploy.

--- a/docs/reports/835/test-report.md
+++ b/docs/reports/835/test-report.md
@@ -1,0 +1,79 @@
+# Test Report — Issue #835
+
+## Result
+
+```
+poetry run pytest -q            →  934 passed, 3 skipped, 4 deselected   exit 0
+poetry run ruff check src/ tests/  →  All checks passed
+```
+
+Up from 930. The four added tests are the whole increase — **no existing test
+changed**, which is the important signal: 49 log messages were rewritten and
+nothing in the suite depended on their text.
+
+## Scan results
+
+| | Before | After |
+|---|---|---|
+| Files never scoped by #637 | 34 | 0 |
+| Files #637 did cover | 16 | 1 |
+
+The single remaining site is `src/lambda_function.py:237`
+(`e.response['Error']['Code']`), deliberately preserved as a sanctioned
+audited-attribute extraction.
+
+## New — `tests/compliance/test_log_privacy.py` (4 tests)
+
+- `test_no_logger_call_interpolates_exception_text` — scans every `src/**/*.py`
+  and fails on `{e}`, `str(e)`, `repr(e)`, or `e.args` inside a logger call,
+  listing file, line and source so the failure is actionable rather than a bare
+  count.
+- `test_the_scan_actually_inspects_source` — asserts at least 10 files were read
+  and that `logger.` appears among them. A scan that silently walks an empty
+  tree reports success forever; that is precisely the failure mode this issue is
+  about, so it is asserted rather than assumed.
+- `test_sanctioned_patterns_are_not_flagged` — the class-name and
+  audited-attribute forms must remain usable, otherwise the fix becomes
+  unadoptable and future authors work around the test.
+- `test_response_payload_assignments_are_out_of_scope` — asserts payload lines
+  such as `"gem": str(e)` do not match the logger pattern. This exists so the
+  scan can never be widened into returned fields and re-cause the #668
+  regression the operator caught in production.
+
+## Mutation testing
+
+The guard was verified by reintroducing the defect, not assumed to work:
+
+```
+# appended to src/observability.py
+logger.error(f"PROBE: {e}")
+```
+
+Result:
+
+```
+FAILED ...::test_no_logger_call_interpolates_exception_text
+assert not [('src/observability.py', 407, 'logger.error(f"PROBE: {e}")')]
+1 failed, 3 passed
+```
+
+It bites, and it reports the exact location. The probe was then reverted.
+
+**A mistake made and caught during that revert:** `git checkout
+src/observability.py` removed the probe *and* the nine legitimate scrubs in the
+same file. The rescan caught it — 10 surfaces reappeared where there had been 1
+— and the rewrite was re-applied. Had the rescan not been re-run, the PR would
+have shipped one file silently unfixed while the test still passed, because the
+test and the file would have regressed together. The lesson is that the rescan,
+not the test run, is what proves the source state.
+
+## Not covered
+
+- **Nothing verifies behavior in CloudWatch.** These are static source
+  assertions; no test observes a real log line. That gap is structural — proving
+  it end to end would mean invoking the Lambdas and reading their log groups.
+- **Identifier logging is still present and untested**, deliberately: three
+  sites log `user_id`/`sub_id` directly, two on the GDPR erasure path. Owned by
+  #711. This report is where that overlap is recorded so it is not lost.
+- **Not deployed.** The suite proves the source is clean; production still runs
+  the previous code until a code-only deploy is made.

--- a/src/auth/auth_middleware.py
+++ b/src/auth/auth_middleware.py
@@ -355,7 +355,7 @@ def require_auth(handler: Callable) -> Callable:
             if isinstance(body, dict) and body.get("action") == "deep_poetic_analysis":
                 weight = 5  # Opus is much more expensive
         except Exception as e:
-            logger.debug(f"Failed to parse body for rate limit weighting: {e}")
+            logger.debug(f"Failed to parse body for rate limit weighting: {e.__class__.__name__}")
 
         # Issue #369: Emit RequestCount metric and log anonymized user (fail-open)
         try:
@@ -363,7 +363,7 @@ def require_auth(handler: Callable) -> Callable:
             emit_request_metric(tier.value)
             log_anonymized_user(user_id)
         except Exception as e:
-            logger.warning(f"Metric emission failed (non-fatal): {e}")
+            logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
         allowed, error_response = check_rate_limit(
             user_id, tier, billing_anchor_day, weight
@@ -374,7 +374,7 @@ def require_auth(handler: Callable) -> Callable:
                 from ..observability import emit_cap_denied_metric
                 emit_cap_denied_metric(tier.value)
             except Exception as e:
-                logger.warning(f"CapDenied metric failed (non-fatal): {e}")
+                logger.warning(f"CapDenied metric failed (non-fatal): {e.__class__.__name__}")
             return _build_429_response(error_response)
 
         # Step 6: Inject user_id into event for downstream use

--- a/src/auth/coupon_handler.py
+++ b/src/auth/coupon_handler.py
@@ -166,7 +166,7 @@ def redeem_coupon(
             Key={"code": {"S": code}},
         )
     except ClientError as e:
-        logger.error(f"DynamoDB get_item error: {e}")
+        logger.error(f"DynamoDB get_item error: {e.__class__.__name__}")
         return {"success": False, "error": "internal_error"}
 
     item = result.get("Item")
@@ -216,7 +216,7 @@ def redeem_coupon(
     except ClientError as e:
         if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
             return {"success": False, "error": "code_exhausted"}
-        logger.error(f"DynamoDB update_item error: {e}")
+        logger.error(f"DynamoDB update_item error: {e.__class__.__name__}")
         return {"success": False, "error": "internal_error"}
 
     # Upgrade user tier
@@ -235,7 +235,7 @@ def redeem_coupon(
             ExpressionAttributeValues=expr_values,
         )
     except ClientError as e:
-        logger.error(f"Failed to upgrade user tier: {e}")
+        logger.error(f"Failed to upgrade user tier: {e.__class__.__name__}")
         # Coupon was consumed but tier upgrade failed — log for manual resolution
         return {"success": False, "error": "internal_error"}
 

--- a/src/auth/jwt_service.py
+++ b/src/auth/jwt_service.py
@@ -157,7 +157,7 @@ def get_jwt_secret() -> str:
         _cached_secret_time = now
         return secret
     except Exception as e:
-        logger.error("Failed to retrieve JWT secret from Secrets Manager: %s", str(e))
+        logger.error("Failed to retrieve JWT secret from Secrets Manager: %s", e.__class__.__name__)
         raise RuntimeError(f"Failed to retrieve JWT secret: {e}") from e
 
 

--- a/src/auth/metrics_handler.py
+++ b/src/auth/metrics_handler.py
@@ -189,7 +189,7 @@ def fetch_adoption_metrics(
         ]
         return adoption[-days:]  # Last N days
     except Exception as e:
-        logger.warning(f"Failed to fetch adoption metrics: {e}")
+        logger.warning(f"Failed to fetch adoption metrics: {e.__class__.__name__}")
         return []
 
 
@@ -211,7 +211,7 @@ def fetch_tier_distribution(dynamodb_client: Any) -> dict[str, int]:
                 tiers["free"] += 1  # Unknown tiers default to free
         return tiers
     except Exception as e:
-        logger.warning(f"Failed to fetch tier distribution: {e}")
+        logger.warning(f"Failed to fetch tier distribution: {e.__class__.__name__}")
         return {"free": 0, "subscriber": 0, "admin": 0}
 
 
@@ -266,7 +266,7 @@ def fetch_coupon_metrics(dynamodb_client: Any) -> dict[str, Any]:
     except dynamodb_client.exceptions.ResourceNotFoundException:
         return {"total_redeemed": 0, "by_code": {}}
     except Exception as e:
-        logger.warning(f"Failed to fetch coupon metrics: {e}")
+        logger.warning(f"Failed to fetch coupon metrics: {e.__class__.__name__}")
         return {"total_redeemed": 0, "by_code": {}}
 
 
@@ -312,7 +312,7 @@ def fetch_retention_metrics(
             "window_days": window_days,
         }
     except Exception as e:
-        logger.warning(f"Failed to fetch retention metrics: {e}")
+        logger.warning(f"Failed to fetch retention metrics: {e.__class__.__name__}")
         return {
             "returning_users": 0,
             "single_session_users": 0,

--- a/src/auth/stripe_handler.py
+++ b/src/auth/stripe_handler.py
@@ -177,7 +177,7 @@ def handle_create_checkout(event: dict, context: Any = None) -> dict:
         })
 
     except stripe.StripeError as e:
-        logger.error(f"Stripe checkout error: {e}")
+        logger.error(f"Stripe checkout error: {e.__class__.__name__}")
         return _build_response(500, {"error": "Failed to create checkout session"})
 
 
@@ -207,7 +207,7 @@ def handle_webhook(event: dict, context: Any = None) -> dict:
     try:
         webhook_secret = get_webhook_secret()
     except Exception as e:
-        logger.error(f"Failed to get webhook secret: {e}")
+        logger.error(f"Failed to get webhook secret: {e.__class__.__name__}")
         return _build_response(500, {"error": "Internal error"})
 
     # Validate signature
@@ -267,7 +267,7 @@ def handle_webhook(event: dict, context: Any = None) -> dict:
             }))
             return _build_response(200, {"status": "processed"})
         except Exception as e:
-            logger.error(f"Error processing {event_type}: {e}")
+            logger.error(f"Error processing {event_type}: {e.__class__.__name__}")
             return _build_response(500, {"error": "Processing failed"})
     else:
         # Unknown event type — acknowledge to prevent retries
@@ -302,7 +302,7 @@ def handle_subscription_status(event: dict, context: Any = None) -> dict:
             ProjectionExpression="tier, grace_period_end, stripe_customer_id",
         )
     except ClientError as e:
-        logger.error(f"DynamoDB error: {e}")
+        logger.error(f"DynamoDB error: {e.__class__.__name__}")
         return _build_response(500, {"error": "Internal error"})
 
     item = result.get("Item", {})
@@ -349,7 +349,7 @@ def _lookup_user_by_stripe_customer(customer_id: str) -> str | None:
         if items:
             return items[0]["user_id"]["S"]
     except ClientError as e:
-        logger.error(f"Customer lookup error: {e}")
+        logger.error(f"Customer lookup error: {e.__class__.__name__}")
     return None
 
 

--- a/src/auth/tier_config_service.py
+++ b/src/auth/tier_config_service.py
@@ -134,7 +134,7 @@ class TierConfigService:
             )
 
         except (ClientError, KeyError, ValueError) as e:
-            logger.warning("Failed to load tier config from DynamoDB: %s", str(e))
+            logger.warning("Failed to load tier config from DynamoDB: %s", e.__class__.__name__)
             return None
 
     def set_tier_config(
@@ -181,7 +181,7 @@ class TierConfigService:
             return True
 
         except ClientError as e:
-            logger.error("Failed to save tier config: %s", str(e))
+            logger.error("Failed to save tier config: %s", e.__class__.__name__)
             raise
 
     def invalidate_cache(self, tier: UserTier | str | None = None) -> None:

--- a/src/auth/token_cap_service.py
+++ b/src/auth/token_cap_service.py
@@ -91,7 +91,7 @@ def get_current_cap(table_name: str) -> int:
         return DEFAULT_DAILY_CAP
 
     except ClientError as e:
-        logger.error("Failed to get current cap: %s", str(e))
+        logger.error("Failed to get current cap: %s", e.__class__.__name__)
         # Fail closed - return 0 to deny all tokens if we can't read config
         raise
 
@@ -168,7 +168,7 @@ def check_and_increment_cap(table_name: str) -> tuple[bool, int]:
 
     except ClientError as e:
         if e.response["Error"]["Code"] != "ConditionalCheckFailedException":
-            logger.error("DynamoDB error during cap check: %s", str(e))
+            logger.error("DynamoDB error during cap check: %s", e.__class__.__name__)
         # Fail closed - deny token if DynamoDB is unavailable
         raise
 
@@ -254,7 +254,7 @@ def set_daily_cap(table_name: str, new_cap: int, admin_id: str) -> bool:
         return True
 
     except ClientError as e:
-        logger.error("Failed to update daily cap: %s", str(e))
+        logger.error("Failed to update daily cap: %s", e.__class__.__name__)
         raise
 
 
@@ -434,7 +434,7 @@ class MultiWindowCounter:
 
         except Exception as e:
             # Any other error (timeout, connection, etc.): hybrid fail mode
-            logger.error("Unexpected error in rate limit check: %s", str(e))
+            logger.error("Unexpected error in rate limit check: %s", e.__class__.__name__)
             return self._handle_dynamo_error(e, tier_config, user_id)
 
     def _find_exceeded_window(
@@ -634,7 +634,7 @@ class MultiWindowCounter:
                 else:
                     counts[name] = 0
         except (ClientError, Exception) as e:
-            logger.warning("Failed to read counter state: %s", str(e))
+            logger.warning("Failed to read counter state: %s", e.__class__.__name__)
             counts = {"hourly": 0, "daily": 0, "monthly": 0}
 
         return CounterState(

--- a/src/guardrails/denylist.py
+++ b/src/guardrails/denylist.py
@@ -57,11 +57,11 @@ def load_denylist(path: str | None = None) -> set[str]:
         _denylist = set()
         return _denylist
     except json.JSONDecodeError as e:
-        logger.warning(f"Malformed denylist JSON: {e}. Failing open.")
+        logger.warning(f"Malformed denylist JSON: {e.__class__.__name__}. Failing open.")
         _denylist = set()
         return _denylist
     except Exception as e:
-        logger.warning(f"Error loading denylist: {e}. Failing open.")
+        logger.warning(f"Error loading denylist: {e.__class__.__name__}. Failing open.")
         _denylist = set()
         return _denylist
 

--- a/src/lambda_auth_function.py
+++ b/src/lambda_auth_function.py
@@ -103,7 +103,7 @@ def get_linkedin_credentials() -> dict:
             response = client.get_secret_value(SecretId=secret_name)
             _linkedin_credentials = json.loads(response["SecretString"])
         except ClientError as e:
-            logger.error(f"Failed to retrieve LinkedIn credentials: {e}")
+            logger.error(f"Failed to retrieve LinkedIn credentials: {e.__class__.__name__}")
             raise
     return _linkedin_credentials
 
@@ -361,7 +361,7 @@ def get_or_create_user(user_info: dict) -> dict:
                 "last_login": now,
             }
     except ClientError as e:
-        logger.error(f"DynamoDB get_item error: {e}")
+        logger.error(f"DynamoDB get_item error: {e.__class__.__name__}")
         raise
 
     # Create new user (Issue #498: store profile fields)
@@ -391,7 +391,7 @@ def get_or_create_user(user_info: dict) -> dict:
             "last_login": now,
         }
     except ClientError as e:
-        logger.error(f"DynamoDB put_item error: {e}")
+        logger.error(f"DynamoDB put_item error: {e.__class__.__name__}")
         raise
 
 
@@ -419,7 +419,7 @@ def get_user_tier(user_id: str) -> tuple[str, int]:
         billing_anchor_day = int(item.get("billing_anchor_day", {}).get("N", "1"))
         return tier, billing_anchor_day
     except (ClientError, KeyError, ValueError) as e:
-        logger.warning(f"Failed to get user tier for {user_id}: {e}")
+        logger.warning(f"Failed to get user tier for {user_id}: {e.__class__.__name__}")
         return "free", 1
 
 
@@ -517,7 +517,7 @@ def handle_token_exchange(body: dict) -> dict:
                 tier=tier, billing_anchor_day=billing_anchor_day,
             )
         except Exception as e:
-            logger.error(f"JWT generation failed: {e}")
+            logger.error(f"JWT generation failed: {e.__class__.__name__}")
             return {
                 "statusCode": 500,
                 "headers": {"Content-Type": "application/json"},
@@ -752,7 +752,7 @@ def _cancel_stripe_subscription(user_record: dict) -> bool:
         logger.info(f"GDPR erasure: cancelled Stripe subscription {sub_id}")
         return True
     except Exception as e:
-        logger.warning(f"GDPR erasure: Stripe cancellation failed for {sub_id}: {e}")
+        logger.warning(f"GDPR erasure: Stripe cancellation failed for {sub_id}: {e.__class__.__name__}")
         return False
 
 
@@ -801,7 +801,7 @@ def _remove_from_coupon_redeemed_by(client, user_id: str) -> int:
             )
             updated += 1
     except ClientError as e:
-        logger.warning(f"GDPR erasure: coupon cleanup failed: {e}")
+        logger.warning(f"GDPR erasure: coupon cleanup failed: {e.__class__.__name__}")
 
     return updated
 
@@ -836,7 +836,7 @@ def _delete_rate_limit_records(client, user_id: str) -> int:
             )
             deleted += 1
     except ClientError as e:
-        logger.warning(f"GDPR erasure: rate limit cleanup failed: {e}")
+        logger.warning(f"GDPR erasure: rate limit cleanup failed: {e.__class__.__name__}")
 
     return deleted
 
@@ -994,7 +994,7 @@ def handle_delete_my_data(headers: dict) -> dict:
         }
 
     except ClientError as e:
-        logger.error(f"GDPR deletion error for user {user_id}: {e}")
+        logger.error(f"GDPR deletion error for user {user_id}: {e.__class__.__name__}")
         return {
             "statusCode": 500,
             "body": json.dumps({"error": "Deletion failed - please try again"}),

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -606,7 +606,7 @@ def _analysis_handler(
             estimated_cost = tokens * 0.00000075
             emit_bedrock_cost_metric(estimated_cost)
     except Exception as e:
-        logger.warning(f"Response metric emission failed (non-fatal): {e}")
+        logger.warning(f"Response metric emission failed (non-fatal): {e.__class__.__name__}")
 
     return {
         "statusCode": 200,
@@ -641,7 +641,7 @@ def _metrics_handler(event: dict, context: Any) -> dict:
                 users_by_tier[tier] = users_by_tier.get(tier, 0) + 1
                 total_users += 1
         except Exception as e:
-            logger.warning(f"Failed to scan users table: {e}")
+            logger.warning(f"Failed to scan users table: {e.__class__.__name__}")
 
         # Count denials today
         denials_today = 0
@@ -659,7 +659,7 @@ def _metrics_handler(event: dict, context: Any) -> dict:
             )
             denials_today = scan_result.get("Count", 0)
         except Exception as e:
-            logger.warning(f"Failed to count denials: {e}")
+            logger.warning(f"Failed to count denials: {e.__class__.__name__}")
 
         return {
             "statusCode": 200,
@@ -671,7 +671,7 @@ def _metrics_handler(event: dict, context: Any) -> dict:
             }),
         }
     except Exception as e:
-        logger.error(f"Metrics handler error: {e}")
+        logger.error(f"Metrics handler error: {e.__class__.__name__}")
         return {"statusCode": 500, "body": json.dumps({"error": "Metrics unavailable"})}
 
 

--- a/src/observability.py
+++ b/src/observability.py
@@ -121,7 +121,7 @@ def trace_bedrock_call(
 
     except Exception as e:
         # Tracing should never break the main flow
-        logger.debug(f"X-Ray annotation failed (non-fatal): {e}")
+        logger.debug(f"X-Ray annotation failed (non-fatal): {e.__class__.__name__}")
 
 
 def create_subsegment(name: str) -> Any:
@@ -200,7 +200,7 @@ def log_bedrock_metrics(
 
     except Exception as e:
         # Metrics logging should never break the main flow
-        logger.warning(f"Failed to log CloudWatch metrics (non-fatal): {e}")
+        logger.warning(f"Failed to log CloudWatch metrics (non-fatal): {e.__class__.__name__}")
 
 
 # --------------------------------------------------------------------------- #
@@ -275,7 +275,7 @@ def emit_request_metric(tier: str) -> None:
         )
         _emit_emf_log(payload)
     except Exception as e:
-        logger.warning(f"Metric emission failed (non-fatal): {e}")
+        logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
 
 def emit_cap_utilization_metric(
@@ -302,7 +302,7 @@ def emit_cap_utilization_metric(
         )
         _emit_emf_log(payload)
     except Exception as e:
-        logger.warning(f"Metric emission failed (non-fatal): {e}")
+        logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
 
 def emit_cap_denied_metric(tier: str) -> None:
@@ -321,7 +321,7 @@ def emit_cap_denied_metric(tier: str) -> None:
         )
         _emit_emf_log(payload)
     except Exception as e:
-        logger.warning(f"Metric emission failed (non-fatal): {e}")
+        logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
 
 def emit_bedrock_cost_metric(estimated_cost_usd: float) -> None:
@@ -340,7 +340,7 @@ def emit_bedrock_cost_metric(estimated_cost_usd: float) -> None:
         )
         _emit_emf_log(payload)
     except Exception as e:
-        logger.warning(f"Metric emission failed (non-fatal): {e}")
+        logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
 
 def emit_error_rate_metric(status_code: int) -> None:
@@ -359,7 +359,7 @@ def emit_error_rate_metric(status_code: int) -> None:
         )
         _emit_emf_log(payload)
     except Exception as e:
-        logger.warning(f"Metric emission failed (non-fatal): {e}")
+        logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
 
 def emit_latency_metric(latency_ms: float) -> None:
@@ -378,7 +378,7 @@ def emit_latency_metric(latency_ms: float) -> None:
         )
         _emit_emf_log(payload)
     except Exception as e:
-        logger.warning(f"Metric emission failed (non-fatal): {e}")
+        logger.warning(f"Metric emission failed (non-fatal): {e.__class__.__name__}")
 
 
 def log_anonymized_user(user_id: str) -> None:
@@ -396,7 +396,7 @@ def log_anonymized_user(user_id: str) -> None:
         anon_id = anonymize_user_id(user_id)
         logger.info(_json.dumps({"action": "request", "anon_user": anon_id}))
     except Exception as e:
-        logger.warning(f"Anonymized user logging failed (non-fatal): {e}")
+        logger.warning(f"Anonymized user logging failed (non-fatal): {e.__class__.__name__}")
 
 
 # Initialize X-Ray on module import (Lambda cold start)

--- a/src/poetic_analyzer.py
+++ b/src/poetic_analyzer.py
@@ -182,7 +182,7 @@ def _extract_json_from_response(raw_text: str) -> dict | None:
     try:
         return json.loads(json_str)
     except json.JSONDecodeError as e:
-        logger.warning(f"JSON decode failed for Opus response: {e}")
+        logger.warning(f"JSON decode failed for Opus response: {e.__class__.__name__}")
         logger.warning(f"JSON string (first 300 chars): {json_str[:300]}")
         return None
 

--- a/src/signal_inspector/fetcher.py
+++ b/src/signal_inspector/fetcher.py
@@ -88,7 +88,7 @@ def fetch_robots_txt(
         logger.warning(f"Timeout fetching robots.txt from {robots_url}")
         return None
     except requests.exceptions.RequestException as e:
-        logger.warning(f"Error fetching robots.txt: {e}")
+        logger.warning(f"Error fetching robots.txt: {e.__class__.__name__}")
         return None
 
 

--- a/tests/compliance/test_log_privacy.py
+++ b/tests/compliance/test_log_privacy.py
@@ -1,0 +1,134 @@
+"""Verify no logger call interpolates exception text.
+
+Issue #835. Umbrella #637 fixed 14 enumerated line numbers; the same pattern
+later reappeared in the very files it had covered, and 34 further surfaces sat
+in files it never scoped at all. Enumerating locations does not hold. This scans
+the source so the defect class cannot return unnoticed.
+
+Protects the public commitment in `docs/observability.html`:
+
+    "NEVER log prompt text, user input, completion text, URLs, or user IDs."
+
+Exception messages are unbounded third-party text. `botocore.exceptions.
+ClientError` in particular can echo request field values back, and several call
+sites wrap DynamoDB operations keyed on user_id.
+
+SCOPE — logs only.
+    Response payloads deliberately keep `str(e)`. Issue #668 reverted an
+    over-scrub that reached returned fields; the operator caught the regression
+    in production, and the reasoning is that the response goes back to the user
+    who made the request and who already knows their own input. This module must
+    never be extended to flag a returned field.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SRC_DIR = Path(__file__).parent.parent.parent / "src"
+
+_LOG_CALL = re.compile(
+    r"logger\.(?:debug|info|warning|error|critical|exception)\s*\("
+)
+
+# Exception text reaching the message: f-string `{e}` or an interpolated str(e).
+_LEAK = re.compile(
+    r"\{(?:e|err|ex|exc)\}"
+    r"|str\((?:e|err|ex|exc)\)"
+    r"|repr\((?:e|err|ex|exc)\)"
+    r"|(?:e|err|ex|exc)\.args"
+)
+
+# Sanctioned alternatives.
+#   - class name only: the established pattern from #636/#619
+#   - a specific, audited attribute (e.g. e.response['Error']['Code']), which is
+#     the documented way to keep more signal than a bare class name
+_SANCTIONED = re.compile(
+    r"__class__\.__name__"
+    r"|type\((?:e|err|ex|exc)\)\.__name__"
+    r"|(?:e|err|ex|exc)\.response\["
+)
+
+
+def _python_sources() -> list[Path]:
+    return [
+        f
+        for f in sorted(SRC_DIR.rglob("*.py"))
+        if "__pycache__" not in str(f)
+    ]
+
+
+def _find_leaks() -> list[tuple[str, int, str]]:
+    leaks: list[tuple[str, int, str]] = []
+    for path in _python_sources():
+        rel = path.relative_to(SRC_DIR.parent).as_posix()
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if line.strip().startswith("#"):
+                continue
+            if not _LOG_CALL.search(line):
+                continue
+            if _SANCTIONED.search(line):
+                continue
+            if _LEAK.search(line):
+                leaks.append((rel, lineno, line.strip()))
+    return leaks
+
+
+class TestLogPrivacy:
+    """No exception text may reach a log message."""
+
+    def test_no_logger_call_interpolates_exception_text(self) -> None:
+        leaks = _find_leaks()
+
+        assert not leaks, (
+            "EXCEPTION TEXT IN LOGS — violates docs/observability.html:\n"
+            + "\n".join(f"  {f}:{n}  {line}" for f, n, line in leaks)
+            + "\n\nUse `e.__class__.__name__`, or extract one specific audited "
+            "attribute (e.g. e.response['Error']['Code']).\n"
+            "Do NOT change response-payload fields — those keep str(e) per #668."
+        )
+
+    def test_the_scan_actually_inspects_source(self) -> None:
+        """Guard against the check passing because it found nothing to read.
+
+        A scan that silently walks an empty tree reports success forever. That
+        is the failure mode this whole issue is about.
+        """
+        sources = _python_sources()
+        assert len(sources) >= 10, (
+            f"Only {len(sources)} source files scanned; the scan is not "
+            "reaching src/ and its green result is meaningless."
+        )
+
+        joined = "\n".join(p.read_text(encoding="utf-8") for p in sources)
+        assert "logger." in joined, "No logger calls found — scan is not working."
+
+    def test_sanctioned_patterns_are_not_flagged(self) -> None:
+        """The class-name and audited-attribute forms must remain usable."""
+        for safe in (
+            'logger.error(f"OP_FAILED: {e.__class__.__name__}")',
+            'logger.error(f"OP_FAILED: {type(e).__name__}")',
+            "logger.error(f\"DynamoDB error: {e.response['Error']['Code']}\")",
+            'logger.error("Failed: %s", e.__class__.__name__)',
+        ):
+            assert _LOG_CALL.search(safe)
+            assert _SANCTIONED.search(safe), f"wrongly flagged: {safe}"
+
+    def test_response_payload_assignments_are_out_of_scope(self) -> None:
+        """#668: returned fields keep str(e) and must never be flagged here.
+
+        Re-scrubbing them reintroduces a regression the operator caught in
+        production, so this is asserted rather than left to convention.
+        """
+        for payload_line in (
+            '            "gem": str(e),',
+            '                "error": str(e),',
+            '        original_result["metadata"]["opus_verifier_error"] = str(e)',
+            '                "message": str(e),',
+        ):
+            assert not _LOG_CALL.search(payload_line), (
+                f"response-payload line matched the log-call pattern: {payload_line}"
+            )


### PR DESCRIPTION
Closes #835

## What a fresh scan found

**50** `logger.*` calls interpolating exception text into log messages:

- **34** in files umbrella #637 never scoped — `src/auth/*.py`, `src/guardrails/denylist.py`, `src/observability.py`
- **16** in files it *did* cover, because that audit fixed 14 enumerated line numbers rather than the defect class

This is the second time #637's inventory has proven incomplete. #824 (`fetch_linkedin_profile` logging `response.text`) was a live leak absent from the same table.

`docs/observability.html` commits absolutely: *"NEVER log prompt text, user input, completion text, URLs, or user IDs."* Exception messages are unbounded third-party text, and `botocore.exceptions.ClientError` can echo request field values back — several of these sites wrap DynamoDB operations keyed on `user_id`.

## The change

49 sites rewritten to `e.__class__.__name__`, handling both call styles:

```python
logger.error(f"...: {e}")          →  logger.error(f"...: {e.__class__.__name__}")
logger.error("...: %s", str(e))    →  logger.error("...: %s", e.__class__.__name__)
```

**49 insertions, 49 deletions** — one-for-one line rewrites, no control flow touched. `934 passed` (up from 930, entirely the new tests), ruff clean, and **no existing test changed** — nothing in the suite depended on those message strings.

## Three things deliberately left alone

**`lambda_function.py:237`** keeps `e.response['Error']['Code']`. Extracting one audited attribute is the documented way to retain more signal than a bare class name; rewriting it would lose real diagnostics for no privacy gain.

**Response payloads.** #668 reverted an earlier over-scrub that reached returned fields — you caught that regression in production and ordered an emergency fix. The reasoning recorded there is that the response goes back to the user who made the request and already knows their own input, and that scrubbing produced tautologies like `{"error": "ValueError: ValueError"}`. Nothing here touches a returned field, and there's a test asserting the scan can never be widened into them.

**Identifier logging.** Three sites log an identifier directly:

```
lambda_auth_function.py:422   f"Failed to get user tier for {user_id}: ..."
lambda_auth_function.py:997   f"GDPR deletion error for user {user_id}: ..."
lambda_auth_function.py:755   f"...Stripe cancellation failed for {sub_id}: ..."
```

Two are on the **GDPR erasure path** — the one place a user has explicitly asked to stop being identifiable — and this is arguably worse than the exception-text class, since no inference is needed. Not fixed here because **#711** already owns identifier handling and whether these get hashed or dropped is that issue's call; settling it inside a log-scrubbing PR would pre-empt it. A fourth site (`:386`, `f"Created new user: {user_id}"`) was noticed and recorded there too.

## The regression test is the substantive part

`tests/compliance/test_log_privacy.py` scans `src/` rather than pinning locations. #637 proved that enumerating line numbers doesn't hold — the same files regrew the pattern and 34 more surfaces sat outside the audited set.

Verified by **mutation**, not assumed. Appending `logger.error(f"PROBE: {e}")` to `src/observability.py` produces:

```
FAILED ...::test_no_logger_call_interpolates_exception_text
assert not [('src/observability.py', 407, 'logger.error(f"PROBE: {e}")')]
```

It also asserts the scan actually read files — a scan that walks an empty tree reports success forever, which is exactly this issue's failure mode.

**A mistake worth recording:** reverting that probe with `git checkout src/observability.py` also reverted the nine legitimate scrubs in that file. The rescan caught it — 10 surfaces where there had been 1 — and the rewrite was re-applied. Without re-running the scan, this PR would have shipped one file silently unfixed *while the test still passed*, because test and file regressed together. The rescan, not the test run, is what proves the source state.

## Blast radius

Log text only. No control flow, no response payload, no auth decision. Diagnostic detail is reduced to the exception class plus any safe attribute — the tradeoff the observability commitment already accepts and which #668 explicitly preserved for logs.

## Deploy

**Not deployed** — landed for your review. Server-side, so merging ships nothing. A code-only deploy suffices on `AletheiaAgent` and `AletheiaAuth`; avoid a full `provision.sh` run, per #779.

## Rollback

`git revert <sha>` plus the same code-only deploy.
